### PR TITLE
Distribute Blob and Bucket IDs instead of creating them on-node

### DIFF
--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -222,6 +222,10 @@ void LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
                         const char *bucket_name, BucketID bucket_id);
 void LocalDestroyBlob(SharedMemoryContext *context, RpcContext *rpc,
                       const char *blob_name, BlobID blob_id);
+BucketID LocalGetNextFreeBucketId(SharedMemoryContext *context, RpcContext *rpc,
+                                  const std::string &name);
+u32 LocalAllocateBufferIdList(MetadataManager *mdm,
+                              const std::vector<BufferID> &buffer_ids);
 void LocalRenameBucket(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID id, const std::string &old_name,
                        const std::string &new_name);

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -127,6 +127,23 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       LocalDestroyBucket(context, rpc, name.c_str(), id);
     };
 
+  function<void(const request&, const string&)>
+    rpc_get_next_free_bucket_id = [context, rpc](const request &req,
+                                                 const string &name) {
+      BucketID result = LocalGetNextFreeBucketId(context, rpc, name);
+
+      req.respond(result);
+    };
+
+  function<void(const request&, const vector<BufferID>&)>
+    rpc_allocate_buffer_id_list =
+      [context](const request &req, const vector<BufferID> &buffer_ids) {
+        MetadataManager *mdm = GetMetadataManagerFromContext(context);
+        u32 result = LocalAllocateBufferIdList(mdm, buffer_ids);
+
+        req.respond(result);
+    };
+
   function<void(const request&, BucketID, const string&, const string&)>
     rpc_rename_bucket = [context, rpc](const request &req, BucketID id,
                                        const string &old_name,


### PR DESCRIPTION
Anthony requested this change during our last meeting. Instead of creating a Bucket or Blob on the calling rank's node, we hash the name and distribute it more uniformly.
@jya-kmu 