### PR TITLE
Support OpenMPI

### DIFF
--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -43,11 +43,11 @@ bool Hermes::IsApplicationCore() {
 }
 
 void Hermes::AppBarrier() {
-  hermes::AppBarrier(&comm_);
+  hermes::SubBarrier(&comm_);
 }
 
 int Hermes::GetProcessRank() {
-  int result = comm_.app_proc_id;
+  int result = comm_.sub_proc_id;
 
   return result;
 }

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -54,18 +54,6 @@
 
 namespace hermes {
 
-void WorldBarrier(CommunicationContext *comm) {
-  comm->world_barrier(comm->state);
-}
-
-void AppBarrier(CommunicationContext *comm) {
-  comm->app_barrier(comm->state);
-}
-
-void HermesBarrier(CommunicationContext *comm) {
-  comm->hermes_barrier(comm->state);
-}
-
 void Finalize(SharedMemoryContext *context, CommunicationContext *comm,
               const char *shmem_name, Arena *trans_arena,
               bool is_application_core) {


### PR DESCRIPTION
The previous implementation relied on the fact that `MPI_Comm` was just an `int` in MPICH, which meant we could put the communicators in shared memory and each process could share them. However, in OpenMPI, `MPI_Comm` is a pointer, and since this pointer is different in each process's address space, we cannot share it. The upside is that not trying to share communicators makes a lot of things easier, and I was able to remove a lot of code. Besides, we were only saving 12 bytes per rank by sharing. Once we have CI up and running, it would probably be good to test with both MPICH and OpenMPI.

* Replaced `CommunicationContext::hermes_comm` and `CommunicationContext::app_comm` with a single `sub_comm`. The grouping depends on `ProcessKind`.
* Removed several unused fields from `CommunicationContext`.
* Removed complex `CommunicationContext` initialization required when we were trying to share communicators.

@jya-kmu 