### PR TITLE
Enable buffer pool visualizer in CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: GitHub Actions
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, chogan/** ]
   pull_request:
     branches: [ master ]
  
@@ -30,13 +30,15 @@ jobs:
       - name: Install Dependencies
         run: |
           npm install
+          sudo apt update
           sudo apt-get install build-essential
           sudo apt-get install cmake
           sudo apt-get install autoconf
           sudo apt-get install automake
           sudo apt-get install libboost-all-dev
           sudo apt-get install -y mpich
-          sudo apt-get -y install build-essential zlib1g-dev 
+          sudo apt-get -y install build-essential zlib1g-dev
+          sudo apt-get -y install libsdl2-dev
           
       - name: Install Spack Related Dependency Packages
         run: |
@@ -62,7 +64,7 @@ jobs:
           spack load -r mochi-thallium~cereal
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=`which mpicxx` -DCMAKE_C_COMPILER=`which mpicc` -DBUILD_SHARED_LIBS=ON -DORTOOLS_DIR="${{ runner.workspace }}/or-tools_Ubuntu-18.04-64bit_v7.7.7810" -DHERMES_INTERCEPT_IO=ON -DHERMES_COMMUNICATION_MPI=ON -DBUILD_BUFFER_POOL_VISUALIZER=OFF -DUSE_ADDRESS_SANITIZER=OFF -DUSE_THREAD_SANITIZER=ON -DHERMES_USE_TCP=ON -DHERMES_RPC_THALLIUM=ON -DHERMES_DEBUG_HEAP=OFF $GITHUB_WORKSPACE
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=`which mpicxx` -DCMAKE_C_COMPILER=`which mpicc` -DBUILD_SHARED_LIBS=ON -DORTOOLS_DIR="${{ runner.workspace }}/or-tools_Ubuntu-18.04-64bit_v7.7.7810" -DHERMES_INTERCEPT_IO=ON -DHERMES_COMMUNICATION_MPI=ON -DBUILD_BUFFER_POOL_VISUALIZER=ON -DUSE_ADDRESS_SANITIZER=OFF -DUSE_THREAD_SANITIZER=ON -DHERMES_USE_TCP=ON -DHERMES_RPC_THALLIUM=ON -DHERMES_DEBUG_HEAP=OFF $GITHUB_WORKSPACE
           cmake --build . -- -j4
           ctest -C $BUILD_TYPE -VV
         shell: bash


### PR DESCRIPTION
Also builds every push to my branches in CI. I like to see that everything is green before opening a PR.