### PR TITLE
Ignore warnings from ortools source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,10 @@ target_include_directories(hermes
           $<INSTALL_INTERFACE:${HERMES_INSTALL_INCLUDE_INTERFACE}>
 )
 
+target_include_directories(hermes
+  SYSTEM PUBLIC ${HERMES_EXT_INCLUDE_DEPENDENCIES}
+)
+
 target_link_libraries(hermes
   PUBLIC ${ORTOOLS_LIBRARIES}
   PRIVATE thallium

--- a/src/buffer_pool_visualizer/CMakeLists.txt
+++ b/src/buffer_pool_visualizer/CMakeLists.txt
@@ -8,9 +8,7 @@ if(TARGET SDL2::SDL2)
   target_link_libraries(bp_viz hermes SDL2::SDL2)
 else()
   # SDL2 built with autotools
-  target_include_directories(bp_viz
-    PRIVATE ${SDL2_INCLUDE_DIRS}
-    PRIVATE ${ORTOOLS_INCLUDE_DIRS}) # for GLOG
+  target_include_directories(bp_viz PRIVATE ${SDL2_INCLUDE_DIRS})
   target_link_libraries(bp_viz hermes ${SDL2_LIBRARIES})
 endif()
 

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -131,6 +131,7 @@ struct FileMapper {
 
   FileMapper(const char *path) {
     FILE *f = fopen(path, "r");
+    blob = {};
     if (f) {
       fseek(f, 0, SEEK_END);
       blob.size = ftell(f);


### PR DESCRIPTION
Adding external include dependencies as a SYSTEM include target will ignore warnings outside of Hermes. Also fixed a "maybe-uninitialized" warning in `FileMapper`.