### PR TITLE
Cache dependencies to speed up build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  LOCAL: ~/local
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -26,45 +27,26 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
         uses: actions/checkout@v2
-        
-      - name: Install Dependencies
+
+      - name: Cache Spack packages
+        uses: actions/cache@v2
+        id: spack-cache
+        with:
+          path: ${{ env.LOCAL }}
+          key: ${{ runner.os }}-${{ hashFiles('ci/install_deps.sh') }}
+
+      - name: Install APT Dependencies
         run: |
-          npm install
           sudo apt update
-          sudo apt-get install build-essential
-          sudo apt-get install cmake
-          sudo apt-get install autoconf
-          sudo apt-get install automake
-          sudo apt-get install libboost-all-dev
+          sudo apt-get install -y autoconf
+          sudo apt-get install -y automake
           sudo apt-get install -y mpich
-          sudo apt-get -y install build-essential zlib1g-dev
-          sudo apt-get -y install libsdl2-dev
+          sudo apt-get install -y zlib1g-dev 
+          sudo apt-get install -y libsdl2-dev
           
-      - name: Install Spack Related Dependency Packages
-        run: |
-          git clone https://github.com/spack/spack ${{ runner.workspace }}/spack
-          . ${{ runner.workspace }}/spack/share/spack/setup-env.sh
-          cp ci/packages.yaml ${{ runner.workspace }}/spack/etc/spack/packages.yaml
-          spack install gotcha@develop
-          spack install glog@0.3.5
-          git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git
-          spack repo add sds-repo
-          spack install mochi-thallium~cereal
-          
-      - name: Install Other Dependency Packages
-        run: |
-          wget -P ${{ runner.workspace }} https://github.com/google/or-tools/releases/download/v7.7/or-tools_ubuntu-18.04_v7.7.7810.tar.gz
-          tar -xvf ${{ runner.workspace }}/or-tools_ubuntu-18.04_v7.7.7810.tar.gz -C ${{ runner.workspace }}
+      - name: Build And Install Dependencies
+        if: steps.spack-cache.outputs.cache-hit != 'true'
+        run: ci/install_deps.sh ${{ env.LOCAL }}
           
       - name: Build and Test
-        run: |
-          . ${{ runner.workspace }}/spack/share/spack/setup-env.sh
-          spack load gotcha@develop
-          spack load glog@0.3.5
-          spack load -r mochi-thallium~cereal
-          mkdir "${{ runner.workspace }}/build"
-          cd "${{ runner.workspace }}/build"
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=`which mpicxx` -DCMAKE_C_COMPILER=`which mpicc` -DBUILD_SHARED_LIBS=ON -DORTOOLS_DIR="${{ runner.workspace }}/or-tools_Ubuntu-18.04-64bit_v7.7.7810" -DHERMES_INTERCEPT_IO=ON -DHERMES_COMMUNICATION_MPI=ON -DBUILD_BUFFER_POOL_VISUALIZER=ON -DUSE_ADDRESS_SANITIZER=OFF -DUSE_THREAD_SANITIZER=ON -DHERMES_USE_TCP=ON -DHERMES_RPC_THALLIUM=ON -DHERMES_DEBUG_HEAP=OFF $GITHUB_WORKSPACE
-          cmake --build . -- -j4
-          ctest -C $BUILD_TYPE -VV
-        shell: bash
+        run: ci/install_hermes.sh ${{ env.LOCAL }}

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -x
+
+if [[ "$#" -ne 1 ]]; then
+   echo "$0 Expected the workspace directory as its first argument"
+   exit 1
+fi
+
+INSTALL_DIR=${1}
+SPACK_DIR=${INSTALL_DIR}/spack
+SDS_REPO_DIR=${INSTALL_DIR}/sds-repo
+THALLIUM_VERSION=0.8.3
+GOTCHA_VERSION=develop
+
+echo "Installing dependencies at ${INSTALL_DIR}"
+mkdir -p ${INSTALL_DIR}
+git clone https://github.com/spack/spack ${SPACK_DIR}
+
+set +x
+. ${SPACK_DIR}/share/spack/setup-env.sh
+set -x
+
+cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
+git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git ${SDS_REPO_DIR}
+
+set +x
+spack repo add ${SDS_REPO_DIR}
+
+GOTCHA_SPEC=gotcha@${GOTCHA_VERSION}
+spack install ${GOTCHA_SPEC}
+THALLIUM_SPEC="mochi-thallium~cereal@${THALLIUM_VERSION} ^mercury~boostsys"
+spack install ${THALLIUM_SPEC}
+
+SPACK_STAGING_DIR=~/spack_staging
+mkdir -p ${SPACK_STAGING_DIR}
+spack view --verbose symlink ${SPACK_STAGING_DIR} ${THALLIUM_SPEC} ${GOTCHA_SPEC}
+set -x
+
+ORTOOLS_VERSION=v7.7
+ORTOOLS_MINOR_VERSION=7810
+ORTOOLS_BASE_URL=https://github.com/google/or-tools/releases/download
+ORTOOLS_TARBALL_NAME=or-tools_ubuntu-18.04_${ORTOOLS_VERSION}.${ORTOOLS_MINOR_VERSION}.tar.gz
+wget ${ORTOOLS_BASE_URL}/${ORTOOLS_VERSION}/${ORTOOLS_TARBALL_NAME}
+tar -xvf ${ORTOOLS_TARBALL_NAME} -C ${INSTALL_DIR} --strip-components=1
+
+cp -LRnv ${SPACK_STAGING_DIR}/* ${INSTALL_DIR}
+

--- a/ci/install_hermes.sh
+++ b/ci/install_hermes.sh
@@ -1,24 +1,32 @@
 #!/bin/bash
 
-LOCAL=${HOME}/local
+set -x
+
+if [[ "$#" -ne 1 ]]; then
+   echo "$0 Expected the dependencies directory as its first argument"
+   exit 1
+fi
+
+LOCAL=${1}
 mkdir build
 pushd build
 
 export CXXFLAGS="${CXXFLAGS} -std=c++17"
 cmake                                                      \
     -DCMAKE_INSTALL_PREFIX=${LOCAL}                        \
+    -DCMAKE_PREFIX_PATH=${LOCAL}                           \
     -DCMAKE_BUILD_RPATH="${LOCAL}/lib"                     \
     -DCMAKE_INSTALL_RPATH="${LOCAL}/lib"                   \
     -DCMAKE_BUILD_TYPE=Release                             \
     -DCMAKE_CXX_COMPILER=`which mpicxx`                    \
     -DCMAKE_C_COMPILER=`which mpicc`                       \
     -DBUILD_SHARED_LIBS=ON                                 \
-    -DHERMES_INTERCEPT_IO=${HERMES_INTERCEPT_IO}           \
+    -DHERMES_INTERCEPT_IO=ON                               \
     -DHERMES_COMMUNICATION_MPI=ON                          \
-    -DBUILD_BUFFER_POOL_VISUALIZER=OFF                     \
+    -DBUILD_BUFFER_POOL_VISUALIZER=ON                      \
+    -DORTOOLS_DIR=${LOCAL}                                 \
     -DUSE_ADDRESS_SANITIZER=ON                             \
     -DUSE_THREAD_SANITIZER=OFF                             \
-    -DHERMES_USE_TCP=ON                                    \
     -DHERMES_RPC_THALLIUM=ON                               \
     -DHERMES_DEBUG_HEAP=OFF                                \
     ..

--- a/ci/packages.yaml
+++ b/ci/packages.yaml
@@ -1,31 +1,38 @@
 packages:
   all:
     target: [x86_64]
-  boost:
-    paths:
-      boost@1.72.0: /usr
-    buildable: False
   mpich:
-    paths:
-      mpich@3.3: /opt/mpich-3.3-intel
+    externals:
+    - spec: mpich@3.3
+      prefix: /opt/mpich-3.3-intel
     buildable: False
   cmake:
-    paths:
-      cmake@3.10.0: /usr/local/cmake-3.10.0
+    externals:
+    - spec: cmake@3.10.0
+      prefix: /usr/local/cmake-3.10.0
     buildable: False
   autoconf:
-    paths:
-      autoconf@2.69: /usr
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
     buildable: False
   automake:
-    paths:
-      automake@1.15: /usr
+    externals:
+    - spec: automake@1.15
+      prefix: /usr
     buildable: False
   libtool:
-    paths:
-      libtool@2.4.6: /usr
+    externals:
+    - spec: libtool@2.4.6
+      prefix: /usr
     buildable: False
   m4:
-    paths:
-      m4@4.17: /usr
+    externals:
+    - spec: m4@4.17
+      prefix: /usr
+    buildable: False
+  pkg-config:
+    externals:
+    - spec: pkg-config@0.29.1
+      prefix: /usr
     buildable: False


### PR DESCRIPTION
* Remove unnecessary APT packages.
* Convert `packages.yaml` to latest spack format to avoid deprecation warnings.
* Cache spack dependencies. This speeds up the CI build time significantly (up to 7x). Any update to `ci/install_deps.sh` will invalidate the cached dependencies and force a rebuild, which will then be cached for future use.