### PR TITLE
Exit with failure on any failed CI command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  LOCAL: ~/local
+  LOCAL: local
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v2
         id: spack-cache
         with:
-          path: ${{ env.LOCAL }}
+          path: ~/${{ env.LOCAL }}
           key: ${{ runner.os }}-${{ hashFiles('ci/install_deps.sh') }}
 
       - name: Install APT Dependencies
@@ -46,7 +46,7 @@ jobs:
           
       - name: Build And Install Dependencies
         if: steps.spack-cache.outputs.cache-hit != 'true'
-        run: ci/install_deps.sh ${{ env.LOCAL }}
+        run: ci/install_deps.sh
           
       - name: Build and Test
-        run: ci/install_hermes.sh ${{ env.LOCAL }}
+        run: ci/install_hermes.sh

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
 set -x
+set -e
+set -o pipefail
 
-if [[ "$#" -ne 1 ]]; then
-   echo "$0 Expected the workspace directory as its first argument"
-   exit 1
-fi
-
-INSTALL_DIR=${1}
+INSTALL_DIR="${HOME}/${LOCAL}"
 SPACK_DIR=${INSTALL_DIR}/spack
 SDS_REPO_DIR=${INSTALL_DIR}/sds-repo
 THALLIUM_VERSION=0.8.3

--- a/ci/install_hermes.sh
+++ b/ci/install_hermes.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 
 set -x
+set -e
+set -o pipefail
 
-if [[ "$#" -ne 1 ]]; then
-   echo "$0 Expected the dependencies directory as its first argument"
-   exit 1
-fi
-
-LOCAL=${1}
 mkdir build
 pushd build
 
+INSTALL_PREFIX="${HOME}/${LOCAL}"
+
 export CXXFLAGS="${CXXFLAGS} -std=c++17"
 cmake                                                      \
-    -DCMAKE_INSTALL_PREFIX=${LOCAL}                        \
-    -DCMAKE_PREFIX_PATH=${LOCAL}                           \
-    -DCMAKE_BUILD_RPATH="${LOCAL}/lib"                     \
-    -DCMAKE_INSTALL_RPATH="${LOCAL}/lib"                   \
+    -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}               \
+    -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}                  \
+    -DCMAKE_BUILD_RPATH=${INSTALL_PREFIX}/lib              \
+    -DCMAKE_INSTALL_RPATH=${INSTALL_PREFIX}/lib            \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE}                       \
     -DCMAKE_CXX_COMPILER=`which mpicxx`                    \
     -DCMAKE_C_COMPILER=`which mpicc`                       \
@@ -24,7 +22,7 @@ cmake                                                      \
     -DHERMES_INTERCEPT_IO=ON                               \
     -DHERMES_COMMUNICATION_MPI=ON                          \
     -DBUILD_BUFFER_POOL_VISUALIZER=ON                      \
-    -DORTOOLS_DIR=${LOCAL}                                 \
+    -DORTOOLS_DIR=${INSTALL_PREFIX}                        \
     -DUSE_ADDRESS_SANITIZER=ON                             \
     -DUSE_THREAD_SANITIZER=OFF                             \
     -DHERMES_RPC_THALLIUM=ON                               \


### PR DESCRIPTION
Each step in a workflow is considered successful if the command returns with an exit status of 0. Since we're using scripts to run our steps, the script will return with the exit code of the last command in the script. Since our `install_hermes.sh` script ends with `popd`, the script always returns 0, so the step is always considered successful, even if there are build or test failures. Setting bash to exit on any command failure (`set -e`) ensures that the step fails if any command in the script fails.