### PR TITLE
Remove some stray thallium includes

### DIFF
--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -4,15 +4,11 @@
 
 #include <string>
 
-#include <thallium/serialization/stl/string.hpp>
-
 #include "memory_management.h"
 #include "buffer_pool.h"
 #include "buffer_pool_internal.h"
 #include "rpc.h"
 #include "metadata_storage.h"
-
-namespace tl = thallium;
 
 namespace hermes {
 

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -9,6 +9,7 @@
 #include <thallium.hpp>
 #include <thallium/serialization/stl/vector.hpp>
 #include <thallium/serialization/stl/pair.hpp>
+#include <thallium/serialization/stl/string.hpp>
 
 namespace tl = thallium;
 

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -9,10 +9,6 @@
 
 #include <mpi.h>
 
-#include <thallium.hpp>
-#include <thallium/serialization/stl/vector.hpp>
-#include <thallium/serialization/stl/pair.hpp>
-
 #include "common.h"
 #include "buffer_pool.h"
 #include "buffer_pool_internal.h"


### PR DESCRIPTION
I'm trying to keep all Thallium-related code in `rpc_thallium.h` or `rpc_thallium.cc`.