### PR TITLE
Rename Tier to Device and TieredSchema to PlacementSchema

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -28,7 +28,7 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
 
   if (IsValid()) {
     std::vector<size_t> sizes(1, size);
-    std::vector<TieredSchema> schemas; 
+    std::vector<PlacementSchema> schemas;
     ret = CalculatePlacement(&hermes_->context_, &hermes_->rpc_, sizes, schemas,
                              ctx);
 

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -63,7 +63,7 @@ class Bucket {
    *
    */
   template<typename T>
-  Status PlaceBlobs(std::vector<TieredSchema> &schemas,
+  Status PlaceBlobs(std::vector<PlacementSchema> &schemas,
                     const std::vector<std::vector<T>> &blobs,
                     const std::vector<std::string> &names);
 
@@ -124,13 +124,13 @@ Status Bucket::Put(const std::string &name, const std::vector<T> &data,
 }
 
 template<typename T>
-Status Bucket::PlaceBlobs(std::vector<TieredSchema> &schemas,
+Status Bucket::PlaceBlobs(std::vector<PlacementSchema> &schemas,
                           const std::vector<std::vector<T>> &blobs,
                           const std::vector<std::string> &names) {
   Status result = 0;
 
   for (size_t i = 0; i < schemas.size(); ++i) {
-    TieredSchema &schema = schemas[i];
+    PlacementSchema &schema = schemas[i];
     if (schema.size()) {
       std::vector<BufferID> buffer_ids = GetBuffers(&hermes_->context_, schema);
       if (buffer_ids.size()) {
@@ -169,7 +169,7 @@ Status Bucket::Put(std::vector<std::string> &names,
     for (size_t i = 0; i < num_blobs; ++i) {
       sizes[i] = blobs[i].size();
     }
-    std::vector<TieredSchema> schemas;
+    std::vector<PlacementSchema> schemas;
     ret = CalculatePlacement(&hermes_->context_, &hermes_->rpc_, sizes,
                              schemas, ctx);
 

--- a/src/buffer_pool_internal.h
+++ b/src/buffer_pool_internal.h
@@ -57,7 +57,7 @@ size_t RoundDownToMultiple(size_t val, size_t multiple);
  * Divides the shared memory segment pointed to by hermes_memory into
  * 1) An array of RAM buffers.
  * 2) An array of BufferHeaders.
- * 3) An array of Tiers.
+ * 3) An array of Devices.
  * 4) The BufferPool struct, which contains pointers (really offsets) to the
  *    data above.
  *
@@ -65,7 +65,7 @@ size_t RoundDownToMultiple(size_t val, size_t multiple);
  * Each BufferHeader is initialized to point to a specfic offset. In the case of
  * a RAM buffer, this offset is from the beginning of the shared memory. In the
  * case of a file buffer, the offset is from the beginning of a file. Free lists
- * for each slab in each Tier are also constructed.
+ * for each slab in each Device are also constructed.
  *
  * @param hermes_memory The base pointer to a shared memory segment.
  * @param buffer_pool_arena An Arena backed by the shared memory segment pointed
@@ -95,19 +95,19 @@ ptrdiff_t InitBufferPool(u8 *hermes_memory, Arena *buffer_pool_arena,
 BufferPool *GetBufferPoolFromContext(SharedMemoryContext *context);
 
 /**
- * Returns a pointer to the Tier with index tier_id in the shared memory
+ * Returns a pointer to the Device with index device_id in the shared memory
  * context.
  *
  * This pointer should never be freed, since it lives in shared memory and is
  * managed by the Hermes core.
  *
- * @param context The shared memory context where the Tiers are stored.
- * @param tier_id An identifier for the desired Tier. This is an index into an
- * array of Tiers.
+ * @param context The shared memory context where the Devices are stored.
+ * @param device_id An identifier for the desired Device. This is an index into an
+ * array of Devices.
  *
- * @return A pointer to the Tier with ID tier_id.
+ * @return A pointer to the Device with ID device_id.
  */
-Tier *GetTierById(SharedMemoryContext *context, TierID tier_id);
+Device *GetDeviceById(SharedMemoryContext *context, DeviceID device_id);
 
 /**
  * Returns a pointer to the first BufferHeader in the array of BufferHeaders
@@ -120,7 +120,7 @@ Tier *GetTierById(SharedMemoryContext *context, TierID tier_id);
  * Example:
  * ```cpp
  * BufferHeader *headers = GetHeadersBase(context);
- * for (u32 i = 0; i < pool->num_headers[tier_id]; ++i) {
+ * for (u32 i = 0; i < pool->num_headers[device_id]; ++i) {
  *   BufferHeader *header = headers + i;
  *   // ...
  * }
@@ -178,7 +178,7 @@ void MergeRamBufferFreeList(SharedMemoryContext *context, int slab_index);
 /**
  *
  */
-BufferID PeekFirstFreeBufferId(SharedMemoryContext *context, TierID tier_id,
+BufferID PeekFirstFreeBufferId(SharedMemoryContext *context, DeviceID device_id,
                                int slab_index);
 
 /**
@@ -194,7 +194,7 @@ void LocalReleaseBuffers(SharedMemoryContext *context,
 /**
  *
  */
-i32 GetSlabUnitSize(SharedMemoryContext *context, TierID tier_id,
+i32 GetSlabUnitSize(SharedMemoryContext *context, DeviceID device_id,
                     int slab_index);
 
 /**
@@ -204,7 +204,7 @@ u32 LocalGetBufferSize(SharedMemoryContext *context, BufferID id);
 /**
  *
  */
-i32 GetSlabBufferSize(SharedMemoryContext *context, TierID tier_id,
+i32 GetSlabBufferSize(SharedMemoryContext *context, DeviceID device_id,
                       int slab_index);
 
 /**

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -39,7 +39,7 @@ enum class TokenType {
 
 enum ConfigVariable {
   ConfigVariable_Unkown,
-  ConfigVariable_NumTiers,
+  ConfigVariable_NumDevices,
   ConfigVariable_Capacities,
   ConfigVariable_BlockSizes,
   ConfigVariable_NumSlabs,
@@ -70,7 +70,7 @@ enum ConfigVariable {
 // TODO(chogan): Make this work independent of declaration order
 static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "unknown",
-  "num_tiers",
+  "num_devices",
   "capacities_mb",
   "block_sizes_kb",
   "num_slabs",
@@ -596,9 +596,9 @@ Token *ParseCharArrayString(Token *tok, char *arr) {
   return tok;
 }
 
-void RequireNumTiers(Config *config) {
-  if (config->num_tiers == 0) {
-    LOG(FATAL) << "The configuration variable 'num_tiers' must be defined first"
+void RequireNumDevices(Config *config) {
+  if (config->num_devices == 0) {
+    LOG(FATAL) << "The configuration variable 'num_devices' must be defined first"
                << std::endl;
   }
 }
@@ -659,56 +659,56 @@ void ParseTokens(TokenList *tokens, Config *config) {
     tok = BeginStatement(tok);
 
     switch (var) {
-      case ConfigVariable_NumTiers: {
+      case ConfigVariable_NumDevices: {
         int val = ParseInt(&tok);
-        config->num_tiers = val;
+        config->num_devices = val;
         break;
       }
       case ConfigVariable_Capacities: {
-        RequireNumTiers(config);
-        tok = ParseSizetList(tok, config->capacities, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseSizetList(tok, config->capacities, config->num_devices);
         // NOTE(chogan): Convert from MB to bytes
-        for (int i = 0; i < config->num_tiers; ++i) {
+        for (int i = 0; i < config->num_devices; ++i) {
           config->capacities[i] *= 1024 * 1024;
         }
         break;
       }
       case ConfigVariable_BlockSizes: {
-        RequireNumTiers(config);
-        tok = ParseIntList(tok, config->block_sizes, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseIntList(tok, config->block_sizes, config->num_devices);
         // NOTE(chogan): Convert from KB to bytes
-        for (int i = 0; i < config->num_tiers; ++i) {
+        for (int i = 0; i < config->num_devices; ++i) {
           config->block_sizes[i] *= 1024;
         }
         break;
       }
       case ConfigVariable_NumSlabs: {
-        RequireNumTiers(config);
-        tok = ParseIntList(tok, config->num_slabs, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseIntList(tok, config->num_slabs, config->num_devices);
         break;
       }
       case ConfigVariable_SlabUnitSizes: {
-        RequireNumTiers(config);
+        RequireNumDevices(config);
         RequireNumSlabs(config);
-        tok = ParseIntListList(tok, config->slab_unit_sizes, config->num_tiers,
+        tok = ParseIntListList(tok, config->slab_unit_sizes, config->num_devices,
                                config->num_slabs);
         break;
       }
       case ConfigVariable_DesiredSlabPercentages: {
-        RequireNumTiers(config);
+        RequireNumDevices(config);
         RequireNumSlabs(config);
         tok = ParseFloatListList(tok, config->desired_slab_percentages,
-                                 config->num_tiers, config->num_slabs);
+                                 config->num_devices, config->num_slabs);
         break;
       }
       case ConfigVariable_BandwidthsMbps: {
-        RequireNumTiers(config);
-        tok = ParseFloatList(tok, config->bandwidths, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseFloatList(tok, config->bandwidths, config->num_devices);
         break;
       }
       case ConfigVariable_LatenciesUs: {
-        RequireNumTiers(config);
-        tok = ParseFloatList(tok, config->latencies, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseFloatList(tok, config->latencies, config->num_devices);
         break;
       }
       case ConfigVariable_BufferPoolArenaPercentage: {
@@ -732,8 +732,8 @@ void ParseTokens(TokenList *tokens, Config *config) {
         break;
       }
       case ConfigVariable_MountPoints: {
-        RequireNumTiers(config);
-        tok = ParseStringList(tok, config->mount_points, config->num_tiers);
+        RequireNumDevices(config);
+        tok = ParseStringList(tok, config->mount_points, config->num_devices);
         break;
       }
       case ConfigVariable_MaxBucketsPerNode: {

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -23,29 +23,29 @@ enum class PlacementPolicy {
 // TODO(chogan): Unfinished sketch
 Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
                         std::vector<size_t> blob_sizes,
-                        std::vector<TieredSchema> &output) {
+                        std::vector<PlacementSchema> &output) {
   HERMES_NOT_IMPLEMENTED_YET;
 
   Status result = 0;
-  std::vector<u64> global_state = GetGlobalTierCapacities(context, rpc);
+  std::vector<u64> global_state = GetGlobalDeviceCapacities(context, rpc);
 
   for (auto &blob_size : blob_sizes) {
-    TieredSchema schema;
+    PlacementSchema schema;
     size_t size_left = blob_size;
-    TierID current_tier = 0;
+    DeviceID current_device = 0;
 
-    while (size_left > 0 && current_tier < global_state.size()) {
+    while (size_left > 0 && current_device < global_state.size()) {
       size_t bytes_used = 0;
-      if (global_state[current_tier] > size_left) {
+      if (global_state[current_device] > size_left) {
         bytes_used = size_left;
       } else {
-        bytes_used = global_state[current_tier];
-        current_tier++;
+        bytes_used = global_state[current_device];
+        current_device++;
       }
 
       if (bytes_used) {
         size_left -= bytes_used;
-        schema.push_back(std::make_pair(current_tier, bytes_used));
+        schema.push_back(std::make_pair(current_device, bytes_used));
       }
     }
 
@@ -63,15 +63,15 @@ Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
 
 Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
                        std::vector<size_t> &blob_sizes,
-                       std::vector<TieredSchema> &output) {
-  std::vector<u64> global_state = GetGlobalTierCapacities(context, rpc);
+                       std::vector<PlacementSchema> &output) {
+  std::vector<u64> global_state = GetGlobalDeviceCapacities(context, rpc);
   Status result = 0;
   for (auto &blob_size : blob_sizes) {
-    TieredSchema schema;
-    TierID tier_id = rand() % global_state.size();
+    PlacementSchema schema;
+    DeviceID device_id = rand() % global_state.size();
 
-    if (global_state[tier_id] > blob_size) {
-      schema.push_back(std::make_pair(blob_size, tier_id));
+    if (global_state[device_id] > blob_size) {
+      schema.push_back(std::make_pair(blob_size, device_id));
     } else {
       HERMES_NOT_IMPLEMENTED_YET;
       // TODO(chogan): Trigger BufferOrganizer
@@ -85,14 +85,14 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
 
 Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
                             std::vector<size_t> &blob_sizes,
-                            std::vector<TieredSchema> &output) {
+                            std::vector<PlacementSchema> &output) {
   using operations_research::MPSolver;
   using operations_research::MPVariable;
   using operations_research::MPConstraint;
   using operations_research::MPObjective;
 
   Status result = 0;
-  std::vector<u64> global_state = GetGlobalTierCapacities(context, rpc);
+  std::vector<u64> global_state = GetGlobalDeviceCapacities(context, rpc);
   std::vector<f32> bandwidths = GetBandwidths(context);
   // TODO (KIMMY): size of constraints should be from context
   std::vector<MPConstraint*> blob_constrt(blob_sizes.size() +
@@ -187,17 +187,17 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
   }
 
   for (size_t i {0}; i < blob_sizes.size(); ++i) {
-    TieredSchema schema;
-    size_t tier_pos {0}; // to track the tier with most data
+    PlacementSchema schema;
+    size_t device_pos {0}; // to track the device with most data
     auto largest_bulk{blob_fraction[i][0]->solution_value()*blob_sizes[i]};
-    // NOTE: could be inefficient if there are hundreds of tiers
+    // NOTE: could be inefficient if there are hundreds of devices
     for (size_t j {1}; j < global_state.size(); ++j) {
       if (blob_fraction[i][j]->solution_value()*blob_sizes[i] > largest_bulk)
-        tier_pos = j;
+        device_pos = j;
     }
     size_t blob_partial_sum {0};
     for (size_t j {0}; j < global_state.size(); ++j) {
-      if (j == tier_pos)
+      if (j == device_pos)
         continue;
       double check_frac_size {blob_fraction[i][j]->solution_value()*
                               blob_sizes[i]}; // blob fraction size
@@ -208,8 +208,8 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
         blob_partial_sum += frac_size_cast;
       }
     }
-    // Push the rest data to tier tier_pos
-    schema.push_back(std::make_pair(blob_sizes[i]-blob_partial_sum, tier_pos));
+    // Push the rest data to device device_pos
+    schema.push_back(std::make_pair(blob_sizes[i]-blob_partial_sum, device_pos));
     output.push_back(schema);
   }
 
@@ -218,13 +218,13 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
 
 Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
                           std::vector<size_t> &blob_sizes,
-                          std::vector<TieredSchema> &output,
+                          std::vector<PlacementSchema> &output,
                           const api::Context &api_context) {
   (void)api_context;
   Status result = 0;
 
-  // TODO(chogan): Return a TieredSchema that minimizes a cost function F given
-  // a set of N Tiers and a blob, while satisfying a policy P.
+  // TODO(chogan): Return a PlacementSchema that minimizes a cost function F given
+  // a set of N Devices and a blob, while satisfying a policy P.
 
   // TODO(chogan): This should be part of the Context
   PlacementPolicy policy = PlacementPolicy::kMinimizeIoTime;

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -13,7 +13,7 @@ class DataPlacementEngine {
 
 Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
                           std::vector<size_t> &blob_size,
-                          std::vector<TieredSchema> &output,
+                          std::vector<PlacementSchema> &output,
                           const api::Context &api_context);
 
 }  // namespace hermes

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -26,24 +26,24 @@ typedef int64_t i64;
 typedef float f32;
 typedef double f64;
 
-typedef u16 TierID;
+typedef u16 DeviceID;
 
-// TODO(chogan): These constants impose limits on the number of slabs, tiers,
+// TODO(chogan): These constants impose limits on the number of slabs, devices,
 // file path lengths, and shared memory name lengths, but eventually we should
 // allow arbitrary sizes of each.
 static constexpr int kMaxBufferPoolSlabs = 8;
 constexpr int kMaxPathLength = 256;
 constexpr int kMaxBufferPoolShmemNameLength = 64;
-constexpr int kMaxTiers = 8;
+constexpr int kMaxDevices = 8;
 
 #define HERMES_NOT_IMPLEMENTED_YET \
   LOG(FATAL) << __func__ << " not implemented yet\n"
 
 /**
- * A TieredSchema is a vector of (size, tier) pairs where size is the number of
- * bytes to buffer and tier is the Tier ID where to buffer those bytes.
+ * A PlacementSchema is a vector of (size, device) pairs where size is the number of
+ * bytes to buffer and device is the Device ID where to buffer those bytes.
  */
-using TieredSchema = std::vector<std::pair<size_t, TierID>>;
+using PlacementSchema = std::vector<std::pair<size_t, DeviceID>>;
 
 /**
  * Distinguishes whether the process (or rank) is part of the application cores
@@ -69,37 +69,37 @@ enum ArenaType {
  * System and user configuration that is used to initialize Hermes.
  */
 struct Config {
-  /** The total capacity of each buffering Tier */
-  size_t capacities[kMaxTiers];
-  /** The block sizes of each Tier */
-  int block_sizes[kMaxTiers];
-  /** The number of slabs that each Tier has */
-  int num_slabs[kMaxTiers];
-  /** The unit of each slab, which is a multiplier of the Tier's block size */
-  int slab_unit_sizes[kMaxTiers][kMaxBufferPoolSlabs];
-  /** The percentage of space each slab should occupy per Tier. The values for
-   * each Tier should add up to 1.0.
+  /** The total capacity of each buffering Device */
+  size_t capacities[kMaxDevices];
+  /** The block sizes of each Device */
+  int block_sizes[kMaxDevices];
+  /** The number of slabs that each Device has */
+  int num_slabs[kMaxDevices];
+  /** The unit of each slab, which is a multiplier of the Device's block size */
+  int slab_unit_sizes[kMaxDevices][kMaxBufferPoolSlabs];
+  /** The percentage of space each slab should occupy per Device. The values for
+   * each Device should add up to 1.0.
    */
-  f32 desired_slab_percentages[kMaxTiers][kMaxBufferPoolSlabs];
-  /** The bandwidth of each Tier */
-  f32 bandwidths[kMaxTiers];
-  /** The latency of each Tier */
-  f32 latencies[kMaxTiers];
+  f32 desired_slab_percentages[kMaxDevices][kMaxBufferPoolSlabs];
+  /** The bandwidth of each Device */
+  f32 bandwidths[kMaxDevices];
+  /** The latency of each Device */
+  f32 latencies[kMaxDevices];
   /** The percentages of the total available Hermes memory allotted for each
    *  `ArenaType`
    */
   f32 arena_percentages[kArenaType_Count];
-  /** The number of Tiers */
-  int num_tiers;
+  /** The number of Devices */
+  int num_devices;
 
   u32 max_buckets_per_node;
   u32 max_vbuckets_per_node;
   u32 system_view_state_update_interval_ms;
 
-  /** The mount point or desired directory for each Tier. RAM Tier should be the
+  /** The mount point or desired directory for each Device. RAM Device should be the
    * empty string.
    */
-  std::string mount_points[kMaxTiers];
+  std::string mount_points[kMaxDevices];
   /** The hostname of the RPC server, minus any numbers that Hermes may
    * auto-generate when the rpc_hostNumber_range is specified. */
   std::string rpc_server_base_name;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -101,8 +101,8 @@ struct VBucketInfo {
 };
 
 struct SystemViewState {
-  std::atomic<u64> bytes_available[kMaxTiers];
-  int num_tiers;
+  std::atomic<u64> bytes_available[kMaxDevices];
+  int num_devices;
 };
 
 struct MetadataManager {
@@ -253,8 +253,8 @@ void LocalUpdateGlobalSystemViewState(SharedMemoryContext *context,
                                       std::vector<i64> adjustments);
 SystemViewState *GetLocalSystemViewState(SharedMemoryContext *context);
 SystemViewState *GetGlobalSystemViewState(SharedMemoryContext *context);
-std::vector<u64> LocalGetGlobalTierCapacities(SharedMemoryContext *context);
-std::vector<u64> GetGlobalTierCapacities(SharedMemoryContext *context,
+std::vector<u64> LocalGetGlobalDeviceCapacities(SharedMemoryContext *context);
+std::vector<u64> GetGlobalDeviceCapacities(SharedMemoryContext *context,
                                           RpcContext *rpc);
 void UpdateGlobalSystemViewState(SharedMemoryContext *context,
                                  RpcContext *rpc);

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -56,8 +56,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
 
   // BufferPool requests
 
-  function<void(const request&, const TieredSchema&)> rpc_get_buffers =
-    [context](const request &req, const TieredSchema &schema) {
+  function<void(const request&, const PlacementSchema&)> rpc_get_buffers =
+    [context](const request &req, const PlacementSchema &schema) {
       std::vector<BufferID> result = GetBuffers(context, schema);
       req.respond(result);
     };
@@ -272,9 +272,9 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       LocalDecrementRefcount(context, id);
     };
 
-  function<void(const request&)> rpc_get_global_tier_capacities =
+  function<void(const request&)> rpc_get_global_device_capacities =
     [context](const request &req) {
-      std::vector<u64> result = LocalGetGlobalTierCapacities(context);
+      std::vector<u64> result = LocalGetGlobalDeviceCapacities(context);
 
       req.respond(result);
     };
@@ -335,8 +335,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                     rpc_decrement_refcount).disable_response();
   rpc_server->define("RemoteUpdateGlobalSystemViewState",
                      rpc_update_global_system_view_state).disable_response();
-  rpc_server->define("RemoteGetGlobalTierCapacities",
-                     rpc_get_global_tier_capacities);
+  rpc_server->define("RemoteGetGlobalDeviceCapacities",
+                     rpc_get_global_device_capacities);
   rpc_server->define("RemoteFinalize", rpc_finalize).disable_response();
 }
 

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -34,7 +34,7 @@ struct TimingResult {
 
 TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
   TimingResult result = {};
-  TieredSchema schema{std::make_pair(4096, 0)};
+  PlacementSchema schema{std::make_pair(4096, 0)};
 
   Timer get_timer;
   Timer release_timer;
@@ -63,7 +63,7 @@ TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
 
 TimingResult TestGetBuffers(SharedMemoryContext *context, int iters) {
   TimingResult result = {};
-  TieredSchema schema{std::make_pair(4096, 0)};
+  PlacementSchema schema{std::make_pair(4096, 0)};
 
   Timer get_timer;
   Timer release_timer;
@@ -149,7 +149,7 @@ void TestFileBuffering(std::shared_ptr<hapi::Hermes> hermes, int rank,
                        const char *test_file) {
   SharedMemoryContext *context = &hermes->context_;
   RpcContext *rpc = &hermes->rpc_;
-  TierID tier_id = 1;
+  DeviceID device_id = 1;
 
   ScopedTemporaryMemory scratch(&hermes->trans_arena_);
 
@@ -157,7 +157,7 @@ void TestFileBuffering(std::shared_ptr<hapi::Hermes> hermes, int rank,
   Blob blob = mapper.blob;
 
   if (blob.data) {
-    TieredSchema schema{std::make_pair(blob.size, tier_id)};
+    PlacementSchema schema{std::make_pair(blob.size, device_id)};
     std::vector<BufferID> buffer_ids(0);
 
     while (buffer_ids.size() == 0) {

--- a/test/common.h
+++ b/test/common.h
@@ -36,23 +36,23 @@ const char buffer_pool_shmem_name[] = "/hermes_buffer_pool_";
 const char rpc_server_name[] = "sockets://localhost:8080";
 
 void InitTestConfig(Config *config) {
-  config->num_tiers = 4;
-  assert(config->num_tiers < kMaxTiers);
+  config->num_devices = 4;
+  assert(config->num_devices < kMaxDevices);
 
-  for (int tier = 0; tier < config->num_tiers; ++tier) {
-    config->capacities[tier] = MEGABYTES(50);
-    config->block_sizes[tier] = KILOBYTES(4);
-    config->num_slabs[tier] = 4;
+  for (int dev = 0; dev < config->num_devices; ++dev) {
+    config->capacities[dev] = MEGABYTES(50);
+    config->block_sizes[dev] = KILOBYTES(4);
+    config->num_slabs[dev] = 4;
 
-    config->slab_unit_sizes[tier][0] = 1;
-    config->slab_unit_sizes[tier][1] = 4;
-    config->slab_unit_sizes[tier][2] = 16;
-    config->slab_unit_sizes[tier][3] = 32;
+    config->slab_unit_sizes[dev][0] = 1;
+    config->slab_unit_sizes[dev][1] = 4;
+    config->slab_unit_sizes[dev][2] = 16;
+    config->slab_unit_sizes[dev][3] = 32;
 
-    config->desired_slab_percentages[tier][0] = 0.25f;
-    config->desired_slab_percentages[tier][1] = 0.25f;
-    config->desired_slab_percentages[tier][2] = 0.25f;
-    config->desired_slab_percentages[tier][3] = 0.25f;
+    config->desired_slab_percentages[dev][0] = 0.25f;
+    config->desired_slab_percentages[dev][1] = 0.25f;
+    config->desired_slab_percentages[dev][2] = 0.25f;
+    config->desired_slab_percentages[dev][3] = 0.25f;
   }
 
   config->bandwidths[0] = 6000.0f;
@@ -97,7 +97,7 @@ void InitTestConfig(Config *config) {
 
 ArenaInfo GetArenaInfo(Config *config) {
   size_t page_size = sysconf(_SC_PAGESIZE);
-  // NOTE(chogan): Assumes first Tier is RAM
+  // NOTE(chogan): Assumes first Device is RAM
   size_t total_hermes_memory = RoundDownToMultiple(config->capacities[0],
                                                    page_size);
   size_t total_pages = total_hermes_memory / page_size;
@@ -180,7 +180,7 @@ BootstrapSharedMemory(Arena *arenas, Config *config, CommunicationContext *comm,
   InitArena(&arenas[kArenaType_Transient], bootstrap_size, bootstrap_memory);
 
   ArenaInfo arena_info = GetArenaInfo(config);
-  // NOTE(chogan): The buffering capacity for the RAM Tier is the size of the
+  // NOTE(chogan): The buffering capacity for the RAM Device is the size of the
   // BufferPool Arena
   config->capacities[0] = arena_info.sizes[kArenaType_BufferPool];
 

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -23,8 +23,8 @@ int main(int argc, char **argv) {
 
   hermes::ParseConfig(&arena, argv[1], &config);
 
-  Assert(config.num_tiers == 4);
-  for (int i = 0; i < config.num_tiers; ++i) {
+  Assert(config.num_devices == 4);
+  for (int i = 0; i < config.num_devices; ++i) {
     Assert(config.capacities[i] == MEGABYTES(50));
     Assert(config.block_sizes[i] == KILOBYTES(4));
     Assert(config.num_slabs[i] == 4);

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -1,6 +1,6 @@
 # Test configuration for Ares cluster
 
-num_tiers = 4;
+num_devices = 4;
 
 capacities_mb = {50, 50, 50, 50};
 block_sizes_kb = {4, 4, 4, 4};

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -1,6 +1,6 @@
 # Test configuration
 
-num_tiers = 4;
+num_devices = 4;
 
 capacities_mb = {128, 512, 1024, 4096};
 block_sizes_kb = {4, 4, 4, 4};

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -1,6 +1,6 @@
 # Test configuration
 
-num_tiers = 4;
+num_devices = 4;
 
 capacities_mb = {50, 50, 50, 50};
 block_sizes_kb = {4, 4, 4, 4};


### PR DESCRIPTION
This removes the concept of a `Tier` from the codebase. I thought it would be easier to separate this step from the rest of the work for adding `BufferingTarget`s. The next step is to move the per-target data from `Device` to `BufferingTarget` (e.g., capacity, speed, latency, etc.).