### PR TITLE
Initial implementation of Targets

### DIFF
--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -711,7 +711,6 @@ Target *InitTargets(Arena *arena, Config *config, Device *devices,
     id.bits.index = i;
     Target *target = result + i;
     target->id = id;
-    // TODO(chogan): Distinguish between per-node capacity and shared capacity
     target->capacity = config->capacities[i];
     target->remaining_space.store(config->capacities[i]);
     target->speed.store(devices[i].bandwidth_mbps);

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -119,6 +119,12 @@ Target *GetTarget(SharedMemoryContext *context, int index) {
   return result;
 }
 
+Target *GetTargetFromId(SharedMemoryContext *context, TargetID id) {
+  Target *result = GetTarget(context, id.bits.index);
+
+  return result;
+}
+
 std::vector<f32> GetBandwidths(SharedMemoryContext *context) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   std::vector<f32> result(pool->num_devices, 0);

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1072,6 +1072,7 @@ ptrdiff_t InitBufferPool(u8 *shmem_base, Arena *buffer_pool_arena,
   BufferPool *pool = PushClearedStruct<BufferPool>(buffer_pool_arena);
   pool->headers_offset = header_begin - shmem_base;
   pool->devices_offset = (u8 *)devices - shmem_base;
+  pool->targets_offset = (u8 *)targets - shmem_base;
   pool->num_devices = config->num_devices;
   pool->total_headers = total_headers;
 

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -105,8 +105,16 @@ BufferPool *GetBufferPoolFromContext(SharedMemoryContext *context) {
 
 Device *GetDeviceFromHeader(SharedMemoryContext *context, BufferHeader *header) {
   BufferPool *pool = GetBufferPoolFromContext(context);
-  Device *devices_base = (Device *)(context->shm_base + pool->device_storage_offset);
+  Device *devices_base = (Device *)(context->shm_base + pool->devices_offset);
   Device *result = devices_base + header->device_id;
+
+  return result;
+}
+
+Target *GetTarget(SharedMemoryContext *context, int index) {
+  BufferPool *pool = GetBufferPoolFromContext(context);
+  Target *targets_base = (Target *)(context->shm_base + pool->targets_offset);
+  Target *result = targets_base + index;
 
   return result;
 }
@@ -125,7 +133,7 @@ std::vector<f32> GetBandwidths(SharedMemoryContext *context) {
 
 Device *GetDeviceById(SharedMemoryContext *context, DeviceID device_id) {
   BufferPool *pool = GetBufferPoolFromContext(context);
-  Device *devices_base = (Device *)(context->shm_base + pool->device_storage_offset);
+  Device *devices_base = (Device *)(context->shm_base + pool->devices_offset);
   Device *result = devices_base + device_id;
 
   return result;
@@ -134,7 +142,7 @@ Device *GetDeviceById(SharedMemoryContext *context, DeviceID device_id) {
 BufferHeader *GetHeadersBase(SharedMemoryContext *context) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   BufferHeader *result = (BufferHeader *)(context->shm_base +
-                                          pool->header_storage_offset);
+                                          pool->headers_offset);
 
   return result;
 }
@@ -606,7 +614,7 @@ BufferID MakeBufferHeaders(Arena *arena, int buffer_size, u32 start_index,
     previous = header;
 
     // NOTE(chogan): Store the address of the first header so we can later
-    // compute the `header_storage_offset`
+    // compute the `headers_offset`
     if (i == 0 && header_begin) {
       *header_begin = (u8 *)header;
     }
@@ -648,11 +656,10 @@ Device *InitDevices(Arena *arena, Config *config) {
   for (int i = 0; i < config->num_devices; ++i) {
     Device *device = result + i;
     device->bandwidth_mbps = config->bandwidths[i];
-    device->capacity = config->capacities[i];
     device->latency_ns = config->latencies[i];
     device->id = i;
     // TODO(chogan): @configuration Get this from cmake.
-    device->has_fallocate = true;
+    device->has_fallocate = false;
     size_t path_length = config->mount_points[i].size();
 
     if (path_length == 0) {
@@ -663,6 +670,30 @@ Device *InitDevices(Arena *arena, Config *config) {
       snprintf(device->mount_point, path_length + 1, "%s",
                config->mount_points[i].c_str());
     }
+  }
+
+  return result;
+}
+
+Target *InitTargets(Arena *arena, Config *config, Device *devices,
+                    int node_id) {
+  Target *result = PushArray<Target>(arena, config->num_targets);
+
+  if (config->num_targets != config->num_devices) {
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  for (int i = 0; i < config->num_targets; ++i) {
+    TargetID id = {};
+    id.bits.node_id = node_id;
+    id.bits.device_id = (u16)i;
+    id.bits.index = i;
+    Target *target = result + i;
+    target->id = id;
+    // TODO(chogan): Distinguish between per-node capacity and shared capacity
+    target->capacity = config->capacities[i];
+    target->remaining_space = config->capacities[i];
+    target->speed = devices[i].bandwidth_mbps;
   }
 
   return result;
@@ -985,9 +1016,11 @@ ptrdiff_t InitBufferPool(u8 *shmem_base, Arena *buffer_pool_arena,
                         buffer_counts[0][slab], config->block_sizes[slab]);
   }
 
-  // Build Devices
+  // Init Devices and Targets
 
   Device *devices = InitDevices(buffer_pool_arena, config);
+
+  Target *targets = InitTargets(buffer_pool_arena, config, devices, node_id);
 
   // Create Free Lists
 
@@ -1037,8 +1070,8 @@ ptrdiff_t InitBufferPool(u8 *shmem_base, Arena *buffer_pool_arena,
   // Build BufferPool
 
   BufferPool *pool = PushClearedStruct<BufferPool>(buffer_pool_arena);
-  pool->header_storage_offset = header_begin - shmem_base;
-  pool->device_storage_offset = (u8 *)devices - shmem_base;
+  pool->headers_offset = header_begin - shmem_base;
+  pool->devices_offset = (u8 *)devices - shmem_base;
   pool->num_devices = config->num_devices;
   pool->total_headers = total_headers;
 
@@ -1132,16 +1165,21 @@ void InitFilesForBuffering(SharedMemoryContext *context, bool make_space) {
       const char *buffering_fname =
         context->buffering_filenames[device_id][slab].c_str();
       FILE *buffering_file = fopen(buffering_fname, "w+");
-      if (make_space && device->has_fallocate) {
-        // TODO(chogan): Some Devices require file initialization on each node,
-        // and some are shared (burst buffers) and only require one rank to
-        // initialize them
+      if (make_space) {
+        if (device->has_fallocate) {
+          // TODO(chogan): Use posix_fallocate when it is available
+        } else {
+          // TODO(chogan): Some Devices require file initialization on each node,
+          // and some are shared (burst buffers) and only require one rank to
+          // initialize them
 
-        // TODO(chogan): Use posix_fallocate when it is available
-        [[maybe_unused]] int ftruncate_result =
-          ftruncate(fileno(buffering_file), device->capacity);
-        // TODO(chogan): @errorhandling
-        assert(ftruncate_result == 0);
+          // TEMP(chogan): Figure out correct capacity
+          Target *target = GetTarget(context, device_id);
+          [[maybe_unused]] int ftruncate_result =
+            ftruncate(fileno(buffering_file), target->capacity);
+          // TODO(chogan): @errorhandling
+          assert(ftruncate_result == 0);
+        }
       }
       context->open_streams[device_id][slab] = buffering_file;
     }

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -686,7 +686,7 @@ Target *InitTargets(Arena *arena, Config *config, Device *devices,
   for (int i = 0; i < config->num_targets; ++i) {
     TargetID id = {};
     id.bits.node_id = node_id;
-    id.bits.device_id = (u16)i;
+    id.bits.device_id = (DeviceID)i;
     id.bits.index = i;
     Target *target = result + i;
     target->id = id;

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -36,7 +36,7 @@ struct RpcContext;
 struct Device {
   /** The device's theoretical bandwidth in MiB/second. */
   f32 bandwidth_mbps;
-  /** The devices's theoretical latency in nanoseconds. */
+  /** The device's theoretical latency in nanoseconds. */
   f32 latency_ns;
   /** The Device's identifier. This is an index into the array of Devices stored in
    * the BufferPool.

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -183,7 +183,7 @@ struct BufferPool {
   ptrdiff_t slab_buffer_sizes_offsets[kMaxDevices];
   /** The offset from the base of shared memory where each Device's list of
    * available buffers per slab is stored. Each offset can be converted to a
-   * pointer to an arry of N (num_slabs[device_id]) u32.
+   * pointer to an arry of N (num_slabs[device_id]) std::atomic<u32>.
    */
   ptrdiff_t buffers_available_offsets[kMaxDevices];
   /** A ticket lock to syncrhonize access to free lists

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -56,6 +56,17 @@ struct Device {
   char mount_point[kMaxPathLength];
 };
 
+struct Device_ {
+  /** True if the Device is byte addressable */
+  bool is_byte_addressable;
+  /** True if the functionality of `posix_fallocate` is available on this
+   * Device
+   */
+  bool has_fallocate;
+  /** The directory where buffering files can be created. Zero terminated. */
+  char mount_point[kMaxPathLength];
+};
+
 /**
  * A unique identifier for any buffer in the system.
  *

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -68,8 +68,8 @@ struct Target {
   TargetID id;
   /** The total capacity of the Target. */
   u64 capacity;
-  u64 remaining_space;
-  u64 speed;
+  std::atomic<u64> remaining_space;
+  std::atomic<u64> speed;
 };
 
 /**

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -34,11 +34,9 @@ struct RpcContext;
  * initialized, and they remain throughout a Hermes run.
  */
 struct Device {
-  /** The total capacity of the Device. */
-  u64 capacity;
-  /** The theoretical (or perceived by Apollo?) bandwidth in MiB/second. */
+  /** The device's theoretical bandwidth in MiB/second. */
   f32 bandwidth_mbps;
-  /** The theoretical (or perceived by Apollo?) latency in nanoseconds. */
+  /** The devices's theoretical latency in nanoseconds. */
   f32 latency_ns;
   /** The Device's identifier. This is an index into the array of Devices stored in
    * the BufferPool.
@@ -56,15 +54,22 @@ struct Device {
   char mount_point[kMaxPathLength];
 };
 
-struct Device_ {
-  /** True if the Device is byte addressable */
-  bool is_byte_addressable;
-  /** True if the functionality of `posix_fallocate` is available on this
-   * Device
-   */
-  bool has_fallocate;
-  /** The directory where buffering files can be created. Zero terminated. */
-  char mount_point[kMaxPathLength];
+union TargetID {
+  struct {
+    u32 node_id;
+    u16 device_id;
+    u16 index;
+  } bits;
+
+  u64 as_int;
+};
+
+struct Target {
+  TargetID id;
+  /** The total capacity of the Target. */
+  u64 capacity;
+  u64 remaining_space;
+  u64 speed;
 };
 
 /**
@@ -153,10 +158,11 @@ struct BufferPool {
   /** The offset from the base of shared memory where the BufferHeader array
    * begins.
    */
-  ptrdiff_t header_storage_offset;
+  ptrdiff_t headers_offset;
   /** The offset from the base of shared memory where the Device array begins.
    */
-  ptrdiff_t device_storage_offset;
+  ptrdiff_t devices_offset;
+  ptrdiff_t targets_offset;
   /** The offset from the base of shared memory where each Device's free list is
    * stored. Converting the offset to a pointer results in a pointer to an array
    * of N BufferIDs where N is the number of slabs in that Device.
@@ -195,6 +201,7 @@ struct BufferPool {
   u32 num_headers[kMaxDevices];
   /** The total number of Devices. */
   i32 num_devices;
+  i32 num_targets;
   /** The total number of BufferHeaders in the header array. */
   u32 total_headers;
 };

--- a/src/buffer_pool_internal.h
+++ b/src/buffer_pool_internal.h
@@ -232,6 +232,11 @@ u8 *GetRamBufferPtr(SharedMemoryContext *context, BufferID buffer_id);
  */
 Target *GetTarget(SharedMemoryContext *context, int index);
 
+/**
+ *
+ */
+Target *GetTargetFromId(SharedMemoryContext *context, TargetID id);
+
 }  // namespace hermes
 
 #endif  // HERMES_BUFFER_POOL_INTERNAL_H_

--- a/src/buffer_pool_internal.h
+++ b/src/buffer_pool_internal.h
@@ -227,6 +227,11 @@ u8 *InitSharedMemory(const char *shmem_name, size_t total_size);
  */
 u8 *GetRamBufferPtr(SharedMemoryContext *context, BufferID buffer_id);
 
+/**
+ *
+ */
+Target *GetTarget(SharedMemoryContext *context, int index);
+
 }  // namespace hermes
 
 #endif  // HERMES_BUFFER_POOL_INTERNAL_H_

--- a/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
+++ b/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
@@ -47,6 +47,9 @@ static DeviceID global_active_device;
 static ActiveSegment global_active_segment;
 static ActiveHeap global_active_heap;
 static u32 global_color_counter;
+static DebugState *id_debug_state;
+static DebugState *map_debug_state;
+
 
 struct Range {
   int start;
@@ -571,8 +574,12 @@ static void HandleInput(SharedMemoryContext *context, bool *running,
             break;
           }
           case SDL_SCANCODE_M: {
-            global_active_segment =  ActiveSegment::Metadata;
-            SDL_Log("Viewing Metadata segment\n");
+            if (id_debug_state == 0 || map_debug_state == 0) {
+              SDL_Log("Must enable HERMES_DEBUG_HEAP to inspect metadata\n");
+            } else {
+              global_active_segment =  ActiveSegment::Metadata;
+              SDL_Log("Viewing Metadata segment\n");
+            }
             break;
           }
           case SDL_SCANCODE_R: {
@@ -847,9 +854,6 @@ int main() {
     GetSharedMemoryContext(global_debug_id_name);
   SharedMemoryContext map_debug_context =
     GetSharedMemoryContext(global_debug_map_name);
-
-  DebugState *id_debug_state = 0;
-  DebugState *map_debug_state = 0;
 
   if (id_debug_context.shm_base) {
     id_debug_state = (DebugState *)id_debug_context.shm_base;

--- a/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
+++ b/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
@@ -365,8 +365,7 @@ static void DrawEndOfRamBuffers(SharedMemoryContext *context,
   int pad = 2;
   f32 memory_offset_to_pixels = (f32)(block_width) / (f32)(block_size);
 
-  int pixel_offset = (int)(pool->header_storage_offset *
-                           memory_offset_to_pixels);
+  int pixel_offset = (int)(pool->headers_offset * memory_offset_to_pixels);
   int x = pixel_offset % window_width;
   int y = (pixel_offset / window_width) * h;
 

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -21,6 +21,7 @@
 // 4. Add a case to ParseTokens for the new variable.
 // 5. Add the new variable to the Config struct.
 // 6. Add an Assert to config_parser_test.cc to test the functionality.
+// 7. Set a default value in InitTestConfig
 
 namespace hermes {
 
@@ -40,6 +41,7 @@ enum class TokenType {
 enum ConfigVariable {
   ConfigVariable_Unkown,
   ConfigVariable_NumDevices,
+  ConfigVariable_NumTargets,
   ConfigVariable_Capacities,
   ConfigVariable_BlockSizes,
   ConfigVariable_NumSlabs,
@@ -71,6 +73,7 @@ enum ConfigVariable {
 static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "unknown",
   "num_devices",
+  "num_targets",
   "capacities_mb",
   "block_sizes_kb",
   "num_slabs",
@@ -662,6 +665,11 @@ void ParseTokens(TokenList *tokens, Config *config) {
       case ConfigVariable_NumDevices: {
         int val = ParseInt(&tok);
         config->num_devices = val;
+        break;
+      }
+      case ConfigVariable_NumTargets: {
+        int val = ParseInt(&tok);
+        config->num_targets = val;
         break;
       }
       case ConfigVariable_Capacities: {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -91,6 +91,8 @@ struct Config {
   f32 arena_percentages[kArenaType_Count];
   /** The number of Devices */
   int num_devices;
+  /** The number of Targets */
+  int num_targets;
 
   u32 max_buckets_per_node;
   u32 max_vbuckets_per_node;

--- a/src/memory_management.cc
+++ b/src/memory_management.cc
@@ -415,8 +415,7 @@ void *HeapRealloc(Heap *heap, void *ptr, size_t size) {
     // map uses STBDS_REALLOC for its malloc style allocations. We just give the
     // initial map a large enough size so that it never needs to realloc.
 
-    // TODO(chogan): @errorhandling
-    assert(!"Can't realloc in Heap\n");
+    HERMES_NOT_IMPLEMENTED_YET;
   }
 
   void *result = HeapPushSize(heap, size);

--- a/src/memory_management.h
+++ b/src/memory_management.h
@@ -303,6 +303,23 @@ inline T *PushArray(Arena *arena, int count, size_t alignment=8) {
   return result;
 }
 
+/**
+ * Reserves space for @p count `T` objects, clears them to zero, and returns a
+ * pointer to the first one.
+ *
+ * @param[in,out] arena The backing Arena from which to reserve space.
+ * @param[in] count The number of objects to allocate.
+ * @param[in] alignment Align the result to a desired multiple.
+ *
+ * @return A pointer to the first `T` instance in the array.
+ */
+template<typename T>
+inline T *PushClearedArray(Arena *arena, int count, size_t alignment=8) {
+  T *result = reinterpret_cast<T *>(PushSizeAndClear(arena, sizeof(T) * count,
+                                                     alignment));
+
+  return result;
+}
 u8 *HeapPushSize(Heap *heap, u32 size);
 
 template<typename T>

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -728,8 +728,6 @@ void InitMetadataManager(MetadataManager *mdm, Arena *arena, Config *config,
       info->next_free.bits.index = i + 1;
     }
   }
-
-  InitMetadataStorage(mdm, arena, config);
 }
 
 }  // namespace hermes

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -550,20 +550,18 @@ void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
 }
 
 u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id) {
-  Target *target = GetTarget(context, id.bits.index);
+  Target *target = GetTargetFromId(context, id);
   u64 result = target->remaining_space.load();
 
   return result;
 }
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context) {
-  std::vector<u64> targets = GetNodeTargets(context);
+  std::vector<TargetID> targets = GetNodeTargets(context);
   std::vector<u64> result(targets.size());
 
   for (size_t i = 0; i < targets.size(); ++i) {
-    TargetID id = {};
-    id.as_int = targets[i];
-    result[i] = LocalGetRemainingCapacity(context, id);
+    result[i] = LocalGetRemainingCapacity(context, targets[i]);
   }
 
   return result;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -556,6 +556,19 @@ u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id) {
   return result;
 }
 
+std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context) {
+  std::vector<u64> targets = GetNodeTargets(context);
+  std::vector<u64> result(targets.size());
+
+  for (size_t i = 0; i < targets.size(); ++i) {
+    TargetID id = {};
+    id.as_int = targets[i];
+    result[i] = LocalGetRemainingCapacity(context, id);
+  }
+
+  return result;
+}
+
 u64 GetRemainingCapacity(SharedMemoryContext *context, RpcContext *rpc,
                          TargetID id) {
   u32 target_node = id.bits.node_id;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -71,7 +71,7 @@ struct BlobIdList {
   u32 capacity;
 };
 
-struct BufferIdList {
+struct IdList {
   u32 head_offset;
   u32 length;
 };

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -46,22 +46,6 @@ union BlobID {
   u64 as_int;
 };
 
-union TargetID {
-  struct {
-    u32 node_id;
-    u16 device_id;
-    u16 index;
-  } bits;
-
-  u64 as_int;
-};
-
-struct Target {
-  u64 capacity;
-  u64 remaining_space;
-  u64 speed;
-};
-
 enum class TraitID : u8 {
   None,
   Placement,

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -265,6 +265,10 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
                                             RpcContext *rpc, Arena *arena,
                                             double slepp_ms);
 
+void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
+                         Arena *arena, Config *config);
+
+
 } // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -251,6 +251,7 @@ u64 LocalGet(MetadataManager *mdm, const char *key, MapType map_type);
 void LocalPut(MetadataManager *mdm, const char *key, u64 val, MapType map_type);
 void LocalDelete(MetadataManager *mdm, const char *key, MapType map_type);
 
+u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id);
 void LocalUpdateGlobalSystemViewState(SharedMemoryContext *context,
                                       std::vector<i64> adjustments);
 SystemViewState *GetLocalSystemViewState(SharedMemoryContext *context);

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -65,7 +65,7 @@ struct Stats {
 
 const int kIdListChunkSize = 10;
 
-struct BlobIdList {
+struct ChunkedIdList {
   u32 head_offset;
   u32 length;
   u32 capacity;
@@ -83,7 +83,7 @@ struct BufferIdArray {
 
 struct BucketInfo {
   BucketID next_free;
-  BlobIdList blobs;
+  ChunkedIdList blobs;
   std::atomic<int> ref_count;
   bool active;
   Stats stats;
@@ -93,7 +93,7 @@ static constexpr int kMaxTraitsPerVBucket = 8;
 
 struct VBucketInfo {
   VBucketID next_free;
-  BlobIdList blobs;
+  ChunkedIdList blobs;
   std::atomic<int> ref_count;
   TraitID traits[kMaxTraitsPerVBucket];
   bool active;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -258,7 +258,7 @@ SystemViewState *GetLocalSystemViewState(SharedMemoryContext *context);
 SystemViewState *GetGlobalSystemViewState(SharedMemoryContext *context);
 std::vector<u64> LocalGetGlobalDeviceCapacities(SharedMemoryContext *context);
 std::vector<u64> GetGlobalDeviceCapacities(SharedMemoryContext *context,
-                                          RpcContext *rpc);
+                                           RpcContext *rpc);
 void UpdateGlobalSystemViewState(SharedMemoryContext *context,
                                  RpcContext *rpc);
 
@@ -269,6 +269,7 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config);
 
+std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 
 } // namespace hermes
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -134,6 +134,8 @@ struct MetadataManager {
 
   size_t map_seed;
 
+  IdList node_targets;
+
   u32 system_view_state_update_interval_ms;
   u32 global_system_view_state_node_id;
   u32 num_buckets;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -46,6 +46,22 @@ union BlobID {
   u64 as_int;
 };
 
+union TargetID {
+  struct {
+    u32 node_id;
+    u16 device_id;
+    u16 index;
+  } bits;
+
+  u64 as_int;
+};
+
+struct Target {
+  u64 capacity;
+  u64 remaining_space;
+  u64 speed;
+};
+
 enum class TraitID : u8 {
   None,
   Placement,

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -42,7 +42,7 @@ size_t GetStoredMapSize(MetadataManager *mdm, MapType map_type);
 /**
  *
  */
-std::vector<u64> GetNodeTargets(SharedMemoryContext *context);
+std::vector<TargetID> GetNodeTargets(SharedMemoryContext *context);
 
 }  // namespace hermes
 

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -39,6 +39,11 @@ void SeedHashForStorage(size_t seed);
  */
 size_t GetStoredMapSize(MetadataManager *mdm, MapType map_type);
 
+/**
+ *
+ */
+std::vector<u64> GetNodeTargets(SharedMemoryContext *context);
+
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_STORAGE_H_

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -6,11 +6,6 @@ namespace hermes {
 /**
  *
  */
-void InitMetadataStorage(MetadataManager *mdm, Arena *arena, Config *config);
-
-/**
- *
- */
 void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
                 MapType map_type);
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -288,15 +288,17 @@ void LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
   EndTicketMutex(&mdm->bucket_mutex);
 }
 
-std::vector<u64> GetNodeTargets(SharedMemoryContext *context) {
+std::vector<TargetID> GetNodeTargets(SharedMemoryContext *context) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   Heap *id_heap = GetIdHeap(mdm);
   u64 *targets = (u64 *)HeapOffsetToPtr(id_heap, mdm->node_targets.head_offset);
   u32 length = mdm->node_targets.length;
-  std::vector<u64> result(length);
+  std::vector<TargetID> result(length);
 
   for (u32 i = 0; i < length; ++i) {
-    result[i] = targets[i];
+    TargetID id = {};
+    id.as_int = targets[i];
+    result[i] = id;
   }
 
   return result;

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -288,6 +288,20 @@ void LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
   EndTicketMutex(&mdm->bucket_mutex);
 }
 
+std::vector<u64> GetNodeTargets(SharedMemoryContext *context) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  Heap *id_heap = GetIdHeap(mdm);
+  u64 *targets = (u64 *)HeapOffsetToPtr(id_heap, mdm->node_targets.head_offset);
+  u32 length = mdm->node_targets.length;
+  std::vector<u64> result(length);
+
+  for (u32 i = 0; i < length; ++i) {
+    result[i] = targets[i];
+  }
+
+  return result;
+}
+
 void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
                   MapType map_type) {
   Heap *heap = GetMapHeap(mdm);

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -100,7 +100,7 @@ static char *GetKey(MetadataManager *mdm, IdMap *map, u32 index) {
   return result;
 }
 
-void AllocateOrGrowBlobIdList(MetadataManager *mdm, BlobIdList *blobs) {
+void AllocateOrGrowBlobIdList(MetadataManager *mdm, ChunkedIdList *blobs) {
   Heap *id_heap = GetIdHeap(mdm);
   BeginTicketMutex(&mdm->id_mutex);
   if (blobs->capacity == 0) {
@@ -133,7 +133,7 @@ void LocalAddBlobIdToBucket(MetadataManager *mdm, BucketID bucket_id,
   // TODO(chogan): Think about lock granularity
   BeginTicketMutex(&mdm->bucket_mutex);
   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  BlobIdList *blobs = &info->blobs;
+  ChunkedIdList *blobs = &info->blobs;
 
   if (blobs->length >= blobs->capacity) {
     AllocateOrGrowBlobIdList(mdm, blobs);
@@ -201,7 +201,7 @@ void LocalRemoveBlobFromBucketInfo(SharedMemoryContext *context,
                                    BucketID bucket_id, BlobID blob_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  BlobIdList *blobs = &info->blobs;
+  ChunkedIdList *blobs = &info->blobs;
   Heap *id_heap = GetIdHeap(mdm);
 
   BeginTicketMutex(&mdm->bucket_mutex);
@@ -219,7 +219,7 @@ bool LocalContainsBlob(SharedMemoryContext *context, BucketID bucket_id,
                        BlobID blob_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  BlobIdList *blobs = &info->blobs;
+  ChunkedIdList *blobs = &info->blobs;
   Heap *id_heap = GetIdHeap(mdm);
   BlobID *blob_id_arr = (BlobID *)HeapOffsetToPtr(id_heap, blobs->head_offset);
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -148,12 +148,12 @@ void LocalAddBlobIdToBucket(MetadataManager *mdm, BucketID bucket_id,
 
 u32 LocalAllocateBufferIdList(MetadataManager *mdm,
                               const std::vector<BufferID> &buffer_ids) {
-  static_assert(sizeof(BufferIdList) == sizeof(BufferID));
+  static_assert(sizeof(IdList) == sizeof(BufferID));
   Heap *id_heap = GetIdHeap(mdm);
   u32 length = (u32)buffer_ids.size();
   // NOTE(chogan): Add 1 extra for the embedded BufferIdList
   BufferID *id_list_memory = HeapPushArray<BufferID>(id_heap, length + 1);
-  BufferIdList *id_list = (BufferIdList *)id_list_memory;
+  IdList *id_list = (IdList *)id_list_memory;
   id_list->length = length;
   id_list->head_offset = GetHeapOffset(id_heap, (u8 *)(id_list + 1));
   CopyIds((u64 *)(id_list + 1), (u64 *)buffer_ids.data(), length);
@@ -168,8 +168,8 @@ u32 LocalAllocateBufferIdList(MetadataManager *mdm,
 std::vector<BufferID> LocalGetBufferIdList(MetadataManager *mdm,
                                            BlobID blob_id) {
   Heap *id_heap = GetIdHeap(mdm);
-  BufferIdList *id_list =
-    (BufferIdList *)HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
+  IdList *id_list =
+    (IdList *)HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
   BufferID *ids = (BufferID *)HeapOffsetToPtr(id_heap, id_list->head_offset);
   std::vector<BufferID> result(id_list->length);
   CopyIds((u64 *)result.data(), (u64 *)ids, id_list->length);
@@ -180,8 +180,8 @@ std::vector<BufferID> LocalGetBufferIdList(MetadataManager *mdm,
 void LocalGetBufferIdList(Arena *arena, MetadataManager *mdm, BlobID blob_id,
                           BufferIdArray *buffer_ids) {
   Heap *id_heap = GetIdHeap(mdm);
-  BufferIdList *id_list =
-    (BufferIdList *)HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
+  IdList *id_list =
+    (IdList *)HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
   BufferID *ids = (BufferID *)HeapOffsetToPtr(id_heap, id_list->head_offset);
   buffer_ids->ids = PushArray<BufferID>(arena, id_list->length);
   buffer_ids->length = id_list->length;

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -279,6 +279,13 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       req.respond(result);
     };
 
+  function<void(const request&, TargetID id)> rpc_get_remaining_capacity =
+    [context](const request &req, TargetID id) {
+      u64 result = LocalGetRemainingCapacity(context, id);
+
+      req.respond(result);
+    };
+
   // TODO(chogan): Only need this on mdm->global_system_view_state_node_id.
   // Probably should move it to a completely separate tl::engine.
   function<void(const request&, std::vector<i64>)> rpc_update_global_system_view_state =
@@ -333,6 +340,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                     rpc_increment_refcount).disable_response();
   rpc_server->define("RemoteDecrementRefcount",
                     rpc_decrement_refcount).disable_response();
+  rpc_server->define("RemoteGetRemainingCapacity", rpc_get_remaining_capacity);
   rpc_server->define("RemoteUpdateGlobalSystemViewState",
                      rpc_update_global_system_view_state).disable_response();
   rpc_server->define("RemoteGetGlobalDeviceCapacities",

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -65,6 +65,19 @@ void serialize(A &ar, BlobID &blob_id) {
   ar & blob_id.as_int;
 }
 
+/**
+ *  Lets Thallium know how to serialize a TargetID.
+ *
+ * This function is called implicitly by Thallium.
+ *
+ * @param ar An archive provided by Thallium.
+ * @param target_id The TargetID to serialize.
+ */
+template<typename A>
+void serialize(A &ar, TargetID &target_id) {
+  ar & target_id.as_int;
+}
+
 #ifndef THALLIUM_USE_CEREAL
 /**
  *  Lets Thallium know how to serialize a MapType.

--- a/test/common.h
+++ b/test/common.h
@@ -163,6 +163,7 @@ SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
   mdm->rpc_state_offset = (u8 *)rpc->state - shmem_base;
 
   InitMetadataManager(mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
+  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config);
 
   // NOTE(chogan): Store the metadata_manager_offset right after the
   // buffer_pool_offset so other processes can pick it up.

--- a/test/common.h
+++ b/test/common.h
@@ -37,6 +37,7 @@ const char rpc_server_name[] = "sockets://localhost:8080";
 
 void InitTestConfig(Config *config) {
   config->num_devices = 4;
+  config->num_targets = 4;
   assert(config->num_devices < kMaxDevices);
 
   for (int dev = 0; dev < config->num_devices; ++dev) {

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -24,6 +24,7 @@ int main(int argc, char **argv) {
   hermes::ParseConfig(&arena, argv[1], &config);
 
   Assert(config.num_devices == 4);
+  Assert(config.num_targets == 4);
   for (int i = 0; i < config.num_devices; ++i) {
     Assert(config.capacities[i] == MEGABYTES(50));
     Assert(config.block_sizes[i] == KILOBYTES(4));

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -1,6 +1,7 @@
 # Test configuration for Ares cluster
 
 num_devices = 4;
+num_targets = 4;
 
 capacities_mb = {50, 50, 50, 50};
 block_sizes_kb = {4, 4, 4, 4};

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -1,6 +1,7 @@
 # Test configuration
 
 num_devices = 4;
+num_targets = 4;
 
 capacities_mb = {128, 512, 1024, 4096};
 block_sizes_kb = {4, 4, 4, 4};

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -1,6 +1,7 @@
 # Test configuration
 
 num_devices = 4;
+num_targets = 4;
 
 capacities_mb = {50, 50, 50, 50};
 block_sizes_kb = {4, 4, 4, 4};


### PR DESCRIPTION
* Split `Device` (previously `Tier`) into `Target` and `Device`. Initially, we stick to one Target per device.

* DPE uses node level capacities by default (via `GetRemainingNodeCapacities`) instead of global capacities. In the future we need the ability to escalate to neighborhoods and to the whole cluster (after we have a topology manager). `GetNodeTargets` returns a list of the default `TargetID`s that belong to the node of the calling rank.

* Renamed `BufferIdList` to `IdList`, since all IDs can be represented by a `u64`. Renamed `BlobIdList` to `ChunkedIdList` for the same reason. The difference between the two is that `ChunkedIdList`s can shrink or grow in
  multiples of `kIdListChunkSize`, while the `IdList` remains the same size for its entire lifetime.

* MDM stores `node_targets`, which is a default list of the targets available to its node

* Factored `AllocateIdList` out of `LocalAllocateBufferIdList`.

* `Device::has_fallocate` should default to `false`.