### PR TITLE
Style cleanup and cpplint workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v2
 
+      - name: Setup python
+        uses: actions/setup-python@v1
+
+      - name: Run cpplint
+        run: pip install cpplint==1.5.4 && cpplint --recursive --exclude=src/stb_ds.h .
+
       - name: Cache Spack packages
         uses: actions/cache@v2
         id: spack-cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,3 +359,8 @@ install(
   DESTINATION
     ${HERMES_INSTALL_DATA_DIR}/cmake/hermes
 )
+
+add_custom_target(lint
+  COMMAND cpplint --recursive --exclude=${CMAKE_CURRENT_SOURCE_DIR}/src/stb_ds.h
+  --exclude=${CMAKE_CURRENT_SOURCE_DIR}/build ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,2 @@
+set noparent
+filter=-build/header_guard,-legal/copyright,-build/include_subdir,-runtime/references,-readability/casting,-runtime/int,-build/include,-build/c++11,-build/c++14

--- a/gotcha_intercept/gotcha_mpi_io.cc
+++ b/gotcha_intercept/gotcha_mpi_io.cc
@@ -23,51 +23,65 @@ typedef int (hermes_MPI_File_close_fp)(MPI_File *fh);
 int hermes_MPI_File_close(MPI_File *fh);
 
 gotcha_wrappee_handle_t orig_MPI_File_open_handle;
-typedef int (hermes_MPI_File_open_fp)(MPI_Comm comm, char *filename, int amode, 
+typedef int (hermes_MPI_File_open_fp)(MPI_Comm comm, char *filename, int amode,
                                       MPI_Info info, MPI_File *fh);
-int hermes_MPI_File_open(MPI_Comm comm, char *filename, int amode, MPI_Info info, 
-                         MPI_File *fh);
+int hermes_MPI_File_open(MPI_Comm comm, char *filename, int amode,
+                         MPI_Info info, MPI_File *fh);
 
 gotcha_wrappee_handle_t orig_MPI_File_seek_handle;
-typedef int (hermes_MPI_File_seek_fp)(MPI_File fh, MPI_Offset offset, int whence);
+typedef int (hermes_MPI_File_seek_fp)(MPI_File fh, MPI_Offset offset,
+                                      int whence);
 int hermes_MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
 
 gotcha_wrappee_handle_t orig_MPI_File_read_handle;
 typedef int (hermes_MPI_File_read_fp)(MPI_File fh, void *buf, int count,
                                    MPI_Datatype datatype, MPI_Status *status);
-int hermes_MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
-                         MPI_Status *status);
+int hermes_MPI_File_read(MPI_File fh, void *buf, int count,
+                         MPI_Datatype datatype, MPI_Status *status);
 
 gotcha_wrappee_handle_t orig_MPI_File_write_handle;
 typedef int (hermes_MPI_File_write_fp)(MPI_File fh, void *buf, int count,
-                                       MPI_Datatype datatype, MPI_Status *status);
-int hermes_MPI_File_write(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
-                          MPI_Status *status);
+                                       MPI_Datatype datatype,
+                                       MPI_Status *status);
+int hermes_MPI_File_write(MPI_File fh, void *buf, int count,
+                          MPI_Datatype datatype, MPI_Status *status);
 
 gotcha_wrappee_handle_t orig_MPI_File_read_at_handle;
-typedef int (hermes_MPI_File_read_at_fp)(MPI_File fh, MPI_Offset offset, void *buf, 
-                                         int count, MPI_Datatype datatype, 
+typedef int (hermes_MPI_File_read_at_fp)(MPI_File fh, MPI_Offset offset,
+                                         void *buf, int count,
+                                         MPI_Datatype datatype,
                                          MPI_Status *status);
-int hermes_MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, 
-                            int count, MPI_Datatype datatype, MPI_Status *status);
+int hermes_MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
+                            int count, MPI_Datatype datatype,
+                            MPI_Status *status);
 
 gotcha_wrappee_handle_t orig_MPI_File_write_at_handle;
-typedef int (hermes_MPI_File_write_at_fp)(MPI_File fh, MPI_Offset offset, void *buf,
-                                          int count, MPI_Datatype datatype, 
+typedef int (hermes_MPI_File_write_at_fp)(MPI_File fh, MPI_Offset offset,
+                                          void *buf, int count,
+                                          MPI_Datatype datatype,
                                           MPI_Status *status);
-int hermes_MPI_File_write_at(MPI_File fh, MPI_Offset offset, void *buf, 
-                             int count, MPI_Datatype datatype, MPI_Status *status);
+int hermes_MPI_File_write_at(MPI_File fh, MPI_Offset offset, void *buf,
+                             int count, MPI_Datatype datatype,
+                             MPI_Status *status);
 
-struct gotcha_binding_t wrap_mpi_io [] = {
-        { "MPI_Finalize", (void *)hermes_MPI_Finalize, &orig_MPI_Finalize_handle },
+struct gotcha_binding_t wrap_mpi_io[] = {
+        { "MPI_Finalize", (void *)hermes_MPI_Finalize,
+          &orig_MPI_Finalize_handle },
         { "MPI_Init", (void *)hermes_MPI_Init, &orig_MPI_Init_handle },
-        { "MPI_File_close", (void *)hermes_MPI_File_close, &orig_MPI_File_close_handle },
-        { "MPI_File_open", (void *)hermes_MPI_File_open, &orig_MPI_File_open_handle },
-        { "MPI_File_seek", (void *)hermes_MPI_File_seek, &orig_MPI_File_seek_handle },
-        { "MPI_File_read", (void *)hermes_MPI_File_read, &orig_MPI_File_read_handle },
-        { "MPI_File_write", (void *)hermes_MPI_File_write, &orig_MPI_File_write_handle },
-        { "MPI_File_read_at", (void *)hermes_MPI_File_read_at, &orig_MPI_File_read_at_handle },
-        { "MPI_File_write_at", (void *)hermes_MPI_File_write_at, &orig_MPI_File_write_at_handle },
+        { "MPI_File_close", (void *)hermes_MPI_File_close,
+          &orig_MPI_File_close_handle },
+        { "MPI_File_open", (void *)hermes_MPI_File_open,
+          &orig_MPI_File_open_handle },
+        { "MPI_File_seek", (void *)hermes_MPI_File_seek,
+          &orig_MPI_File_seek_handle },
+        { "MPI_File_read", (void *)hermes_MPI_File_read,
+          &orig_MPI_File_read_handle },
+        { "MPI_File_write", (void *)hermes_MPI_File_write,
+          &orig_MPI_File_write_handle },
+        { "MPI_File_read_at", (void *)hermes_MPI_File_read_at,
+          &orig_MPI_File_read_at_handle },
+        { "MPI_File_write_at", (void *)hermes_MPI_File_write_at,
+          &orig_MPI_File_write_at_handle },
 };
 
 void init_gotcha_mpi_io() {
@@ -87,10 +101,10 @@ int hermes_MPI_Finalize(void) {
     fflush(stdout);
   }
 
-  hermes_MPI_Finalize_fp *orig_MPI_Finalize = 
+  hermes_MPI_Finalize_fp *orig_MPI_Finalize =
     (hermes_MPI_Finalize_fp *)gotcha_get_wrappee(orig_MPI_Finalize_handle);
   ret = orig_MPI_Finalize();
- 
+
   return ret;
 }
 
@@ -107,7 +121,7 @@ int hermes_MPI_Init(int *argc, char ***argv) {
     fflush(stdout);
   }
 
-  hermes_MPI_Init_fp *orig_MPI_Init = 
+  hermes_MPI_Init_fp *orig_MPI_Init =
     (hermes_MPI_Init_fp *)gotcha_get_wrappee(orig_MPI_Init_handle);
   ret = orig_MPI_Init(argc, argv);
 
@@ -127,14 +141,14 @@ int hermes_MPI_File_close(MPI_File *fh) {
     fflush(stdout);
   }
 
-  hermes_MPI_File_close_fp *orig_MPI_File_close = 
+  hermes_MPI_File_close_fp *orig_MPI_File_close =
     (hermes_MPI_File_close_fp *)gotcha_get_wrappee(orig_MPI_File_close_handle);
   ret = orig_MPI_File_close(fh);
 
   return ret;
 }
 
-int hermes_MPI_File_open(MPI_Comm comm, char *filename, int amode, 
+int hermes_MPI_File_open(MPI_Comm comm, char *filename, int amode,
                          MPI_Info info, MPI_File *fh) {
   /** check if path matches prefix */
   bool path_match = 1;
@@ -148,7 +162,7 @@ int hermes_MPI_File_open(MPI_Comm comm, char *filename, int amode,
     fflush(stdout);
   }
 
-  hermes_MPI_File_open_fp *orig_hermes_MPI_File_open = 
+  hermes_MPI_File_open_fp *orig_hermes_MPI_File_open =
     (hermes_MPI_File_open_fp *)gotcha_get_wrappee(orig_MPI_File_open_handle);
   ret = orig_hermes_MPI_File_open(comm, filename, amode, info, fh);
 
@@ -174,7 +188,7 @@ int hermes_MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence) {
   return ret;
 }
 
-int hermes_MPI_File_read(MPI_File fh, void *buf, int count, 
+int hermes_MPI_File_read(MPI_File fh, void *buf, int count,
                          MPI_Datatype datatype, MPI_Status *status) {
   /** check if path matches prefix */
   bool path_match = 1;
@@ -183,19 +197,19 @@ int hermes_MPI_File_read(MPI_File fh, void *buf, int count,
   printf("In wrapper hermes_MPI_File_read\n");
   fflush(stdout);
 
-   if (path_match) {
+  if (path_match) {
     printf("Intercepting function MPI_File_read()\n");
     fflush(stdout);
   }
 
-  hermes_MPI_File_read_fp *orig_MPI_File_read = 
+  hermes_MPI_File_read_fp *orig_MPI_File_read =
     (hermes_MPI_File_read_fp *)gotcha_get_wrappee(orig_MPI_File_read_handle);
   ret = orig_MPI_File_read(fh, buf, count, datatype, status);
 
   return ret;
 }
 
-int hermes_MPI_File_write(MPI_File fh, void *buf, int count, 
+int hermes_MPI_File_write(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Status *status) {
   /** check if path matches prefix */
   bool path_match = 1;
@@ -209,15 +223,16 @@ int hermes_MPI_File_write(MPI_File fh, void *buf, int count,
     fflush(stdout);
   }
 
-  hermes_MPI_File_write_fp *orig_MPI_File_write = 
+  hermes_MPI_File_write_fp *orig_MPI_File_write =
     (hermes_MPI_File_write_fp *)gotcha_get_wrappee(orig_MPI_File_write_handle);
   ret = orig_MPI_File_write(fh, buf, count, datatype, status);
 
   return ret;
 }
 
-int hermes_MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, 
-                            int count, MPI_Datatype datatype, MPI_Status *status) {
+int hermes_MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
+                            int count, MPI_Datatype datatype,
+                            MPI_Status *status) {
   /** check if path matches prefix */
   bool path_match = 1;
   int ret = 0;
@@ -230,15 +245,17 @@ int hermes_MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
     fflush(stdout);
   }
 
-  hermes_MPI_File_read_at_fp *orig_MPI_File_read_at = 
-    (hermes_MPI_File_read_at_fp *)gotcha_get_wrappee(orig_MPI_File_read_at_handle);
+  hermes_MPI_File_read_at_fp *orig_MPI_File_read_at =
+    (hermes_MPI_File_read_at_fp *)
+    gotcha_get_wrappee(orig_MPI_File_read_at_handle);
   ret = orig_MPI_File_read_at(fh, offset, buf, count, datatype, status);
 
   return ret;
 }
 
-int hermes_MPI_File_write_at(MPI_File fh, MPI_Offset offset, void *buf, 
-                             int count, MPI_Datatype datatype, MPI_Status *status) {
+int hermes_MPI_File_write_at(MPI_File fh, MPI_Offset offset, void *buf,
+                             int count, MPI_Datatype datatype,
+                             MPI_Status *status) {
   /** check if path matches prefix */
   bool path_match = 1;
   int ret = 0;
@@ -251,10 +268,10 @@ int hermes_MPI_File_write_at(MPI_File fh, MPI_Offset offset, void *buf,
     fflush(stdout);
   }
 
-  hermes_MPI_File_write_at_fp *orig_MPI_File_write_at = 
-    (hermes_MPI_File_write_at_fp *)gotcha_get_wrappee(orig_MPI_File_write_at_handle);
+  hermes_MPI_File_write_at_fp *orig_MPI_File_write_at =
+    (hermes_MPI_File_write_at_fp *)
+    gotcha_get_wrappee(orig_MPI_File_write_at_handle);
   ret = orig_MPI_File_write_at(fh, offset, buf, count, datatype, status);
 
   return ret;
 }
-

--- a/gotcha_intercept/gotcha_mpi_io.h
+++ b/gotcha_intercept/gotcha_mpi_io.h
@@ -1,6 +1,6 @@
 #ifndef GOTCHA_MPI_IO_H_
 #define GOTCHA_MPI_IO_H_
 
-void init_gotcha_mpi_io ();
+void init_gotcha_mpi_io();
 
 #endif  // GOTCHA_MPI_IO_H_

--- a/gotcha_intercept/gotcha_posix.cc
+++ b/gotcha_intercept/gotcha_posix.cc
@@ -11,11 +11,13 @@ extern "C" {
 #define FUNC_COUNT(wraps) ((sizeof(wraps) / sizeof(wraps[0])))
 
 gotcha_wrappee_handle_t orig_pwrite_handle;
-typedef ssize_t (hermes_pwrite_fp)(int fd, const void *buf, size_t count, off_t offset);
+typedef ssize_t (hermes_pwrite_fp)(int fd, const void *buf, size_t count,
+                                   off_t offset);
 ssize_t hermes_pwrite(int fd, const void *buf, size_t count, off_t offset);
 
 gotcha_wrappee_handle_t orig_pread_handle;
-typedef ssize_t (hermes_pread_fp)(int fd, void *buf, size_t count, off_t offset);
+typedef ssize_t (hermes_pread_fp)(int fd, void *buf, size_t count,
+                                  off_t offset);
 ssize_t hermes_pread(int fd, void *buf, size_t count, off_t offset);
 
 gotcha_wrappee_handle_t orig_lseek_handle;
@@ -30,7 +32,7 @@ gotcha_wrappee_handle_t orig_read_handle;
 typedef ssize_t (hermes_read_fp)(int fd, void *buf, size_t count);
 ssize_t hermes_read(int fd, void *buf, size_t count);
 
-struct gotcha_binding_t wrap_posix [] = {
+struct gotcha_binding_t wrap_posix[] = {
         { "pwrite", (void *)hermes_pwrite, &orig_pwrite_handle },
         { "pread", (void *)hermes_pread, &orig_pread_handle },
         { "lseek", (void *)hermes_lseek, &orig_lseek_handle },
@@ -38,7 +40,7 @@ struct gotcha_binding_t wrap_posix [] = {
         { "read", (void *)hermes_read, &orig_read_handle },
 };
 
-void init_gotcha_posix () {
+void init_gotcha_posix() {
   gotcha_wrap(wrap_posix, FUNC_COUNT(wrap_posix), "hermes");
 }
 
@@ -55,7 +57,7 @@ ssize_t hermes_pwrite(int fd, const void *buf, size_t count, off_t offset) {
     fflush(stdout);
   }
 
-  hermes_pwrite_fp *orig_pwrite = 
+  hermes_pwrite_fp *orig_pwrite =
     (hermes_pwrite_fp *)gotcha_get_wrappee(orig_pwrite_handle);
   ret = orig_pwrite(fd, buf, count, offset);
 
@@ -75,7 +77,7 @@ ssize_t hermes_pread(int fd, void *buf, size_t count, off_t offset) {
     fflush(stdout);
   }
 
-  hermes_pread_fp *orig_pread = 
+  hermes_pread_fp *orig_pread =
     (hermes_pread_fp *)gotcha_get_wrappee(orig_pread_handle);
   ret = orig_pread(fd, buf, count, offset);
 
@@ -83,7 +85,7 @@ ssize_t hermes_pread(int fd, void *buf, size_t count, off_t offset) {
 }
 
 off_t hermes_lseek(int fd, off_t offset, int whence) {
-   /** check if path matches prefix */
+  /** check if path matches prefix */
   bool path_match = 1;
   off_t ret = 0;
 
@@ -95,7 +97,7 @@ off_t hermes_lseek(int fd, off_t offset, int whence) {
     fflush(stdout);
   }
 
-  hermes_lseek_fp *orig_lseek = 
+  hermes_lseek_fp *orig_lseek =
     (hermes_lseek_fp *)gotcha_get_wrappee(orig_lseek_handle);
   ret = orig_lseek(fd, offset, whence);
 
@@ -114,7 +116,7 @@ ssize_t hermes_write(int fd, const void *buf, size_t count) {
     printf("Intercepting function write()\n");
     fflush(stdout);
   }
-  hermes_write_fp *orig_write = 
+  hermes_write_fp *orig_write =
     (hermes_write_fp *)gotcha_get_wrappee(orig_write_handle);
   ret = orig_write(fd, buf, count);
 
@@ -134,10 +136,9 @@ ssize_t hermes_read(int fd, void *buf, size_t count) {
     fflush(stdout);
   }
 
-  hermes_read_fp *orig_read = 
+  hermes_read_fp *orig_read =
     (hermes_read_fp *)gotcha_get_wrappee(orig_read_handle);
   ret = orig_read(fd, buf, count);
 
   return ret;
 }
-

--- a/gotcha_intercept/gotcha_posix.h
+++ b/gotcha_intercept/gotcha_posix.h
@@ -1,6 +1,6 @@
 #ifndef GOTCHA_POSIX_H_
 #define GOTCHA_POSIX_H_
 
-void init_gotcha_posix ();
+void init_gotcha_posix();
 
 #endif  // GOTCHA_POSIX_H_

--- a/gotcha_intercept/gotcha_stdio.cc
+++ b/gotcha_intercept/gotcha_stdio.cc
@@ -18,18 +18,20 @@ typedef int (hermes_fclose_fp)(FILE *stream);
 int hermes_fclose(FILE *stream);
 
 gotcha_wrappee_handle_t orig_fwrite_handle;
-typedef size_t (hermes_fwrite_fp)(const void *ptr, size_t size, size_t count, FILE *stream);
-size_t hermes_fwrite( const void *ptr, size_t size, size_t count, FILE *stream);
+typedef size_t (hermes_fwrite_fp)(const void *ptr, size_t size, size_t count,
+                                  FILE *stream);
+size_t hermes_fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
 
 gotcha_wrappee_handle_t orig_fread_handle;
-typedef size_t (hermes_fread_fp)(void * ptr, size_t size, size_t count, FILE *stream);
+typedef size_t (hermes_fread_fp)(void * ptr, size_t size, size_t count,
+                                 FILE *stream);
 size_t hermes_fread(void * ptr, size_t size, size_t count, FILE *stream);
 
 gotcha_wrappee_handle_t orig_fseek_handle;
 typedef size_t (hermes_fseek_fp)(FILE * stream, long int offset, int origin);
 size_t hermes_fseek(FILE * stream, long int offset, int origin);
 
-struct gotcha_binding_t wrap_stdio [] = {
+struct gotcha_binding_t wrap_stdio[] = {
         { "fopen", (void *)hermes_fopen, &orig_fopen_handle },
         { "fclose", (void *)hermes_fclose, &orig_fclose_handle },
         { "fwrite", (void *)hermes_fwrite, &orig_fwrite_handle },
@@ -53,7 +55,8 @@ FILE * hermes_fopen(const char *filename, const char * mode) {
     printf("Intercepting function fopen()\n");
     fflush(stdout);
   }
-  hermes_fopen_fp *orig_fopen = (hermes_fopen_fp *)gotcha_get_wrappee(orig_fopen_handle);
+  hermes_fopen_fp *orig_fopen =
+    (hermes_fopen_fp *)gotcha_get_wrappee(orig_fopen_handle);
   fp = orig_fopen(filename, mode);
 
   return fp;
@@ -72,7 +75,8 @@ int hermes_fclose(FILE *stream) {
     fflush(stdout);
   }
 
-  hermes_fclose_fp *orig_fclose = (hermes_fclose_fp *)gotcha_get_wrappee(orig_fclose_handle);
+  hermes_fclose_fp *orig_fclose =
+    (hermes_fclose_fp *)gotcha_get_wrappee(orig_fclose_handle);
   ret = orig_fclose(stream);
 
   return ret;
@@ -88,13 +92,14 @@ size_t hermes_fwrite(const void *ptr, size_t size, size_t count, FILE *stream) {
 
   if (path_match) {
     printf("Intercepting function fwrite()\n");
-    fflush(stdout); 
-  }      
+    fflush(stdout);
+  }
 
-  hermes_fwrite_fp *orig_fwrite = (hermes_fwrite_fp *)gotcha_get_wrappee(orig_fwrite_handle);
+  hermes_fwrite_fp *orig_fwrite =
+    (hermes_fwrite_fp *)gotcha_get_wrappee(orig_fwrite_handle);
   ret = orig_fwrite(ptr, size, count, stream);
-          
-  return ret; 
+
+  return ret;
 }
 
 size_t hermes_fread(void * ptr, size_t size, size_t count, FILE *stream) {
@@ -110,13 +115,14 @@ size_t hermes_fread(void * ptr, size_t size, size_t count, FILE *stream) {
     fflush(stdout);
   }
 
-  hermes_fread_fp *orig_fread = (hermes_fread_fp *)gotcha_get_wrappee(orig_fread_handle);
+  hermes_fread_fp *orig_fread =
+    (hermes_fread_fp *)gotcha_get_wrappee(orig_fread_handle);
   ret = orig_fread(ptr, size, count, stream);
 
-  return ret; 
+  return ret;
 }
 
-size_t hermes_fseek (FILE * stream, long int offset, int origin) {
+size_t hermes_fseek(FILE * stream, long int offset, int origin) {
   /** check if path matches prefix */
   bool path_match = 1;
   size_t ret = 0;
@@ -129,9 +135,9 @@ size_t hermes_fseek (FILE * stream, long int offset, int origin) {
     fflush(stdout);
   }
 
-  hermes_fseek_fp *orig_fseek = (hermes_fseek_fp *)gotcha_get_wrappee(orig_fseek_handle);
+  hermes_fseek_fp *orig_fseek =
+    (hermes_fseek_fp *)gotcha_get_wrappee(orig_fseek_handle);
   ret = orig_fseek(stream, offset, origin);
-  
+
   return ret;
 }
-

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -1,9 +1,12 @@
 #include "bucket.h"
+
+#include <iostream>
+#include <vector>
+
 #include "buffer_pool.h"
 #include "metadata_management.h"
 #include "data_placement_engine.h"
 
-#include <iostream>
 
 namespace hermes {
 
@@ -176,5 +179,5 @@ Status Bucket::Destroy(Context &ctx) {
   return ret;
 }
 
-} // api namespace
-} // hermes namespace
+}  // namespace api
+}  // namespace hermes

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "glog/logging.h"
 
@@ -24,7 +25,7 @@ class Bucket {
   /** internal Hermes object owned by Bucket */
   std::shared_ptr<Hermes> hermes_;
 
-  // TODO: Think about the Big Three
+  // TODO(chogan): Think about the Big Three
   Bucket() : name_(""), id_{0, 0}, hermes_(nullptr) {
     LOG(INFO) << "Create NULL Bucket " << std::endl;
   }
@@ -113,7 +114,7 @@ class Bucket {
   /** destroy this bucket */
   /** ctx controls "aggressiveness */
   Status Destroy(Context &ctx);
-}; // Bucket class
+};
 
 template<typename T>
 Status Bucket::Put(const std::string &name, const std::vector<T> &data,
@@ -184,7 +185,7 @@ Status Bucket::Put(std::vector<std::string> &names,
   return ret;
 }
 
-}  // api namespace
-}  // hermes namespace
+}  // namespace api
+}  // namespace hermes
 
 #endif  // BUCKET_H_

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -20,7 +20,8 @@ Status RenameBucket(const std::string &old_name,
   (void)ctx;
   Status ret = 0;
 
-  LOG(INFO) << "Renaming Bucket from " << old_name << " to " << new_name << '\n';
+  LOG(INFO) << "Renaming Bucket from " << old_name << " to "
+            << new_name << '\n';
 
   return ret;
 }
@@ -68,7 +69,7 @@ void Hermes::Finalize(bool force_rpc_shutdown) {
                    IsApplicationCore(), force_rpc_shutdown);
 }
 
-} // namespace api
+}  // namespace api
 
 ArenaInfo GetArenaInfo(Config *config) {
   size_t page_size = sysconf(_SC_PAGESIZE);
@@ -85,8 +86,7 @@ ArenaInfo GetArenaInfo(Config *config) {
     if (i < kArenaType_Count-1) {
       pages = std::floor(config->arena_percentages[i] * total_pages);
       pages_left -= pages;
-    }
-    else {
+    } else {
       pages = pages_left;
       pages_left = 0;
     }
@@ -103,7 +103,6 @@ ArenaInfo GetArenaInfo(Config *config) {
 SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
                                    ArenaInfo *arena_info, Arena *arenas,
                                    RpcContext *rpc) {
-
   size_t shmem_size = (arena_info->total -
                        arena_info->sizes[kArenaType_Transient]);
   u8 *shmem_base = InitSharedMemory(config->buffer_pool_shmem_name, shmem_size);

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -252,14 +252,13 @@ namespace api {
 
 std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
                                    bool is_adapter) {
-
   hermes::Config config = {};
-  const size_t config_memory_size = KILOBYTES(16);
-  hermes::u8 config_memory[config_memory_size];
+  const size_t kConfigMemorySize = KILOBYTES(16);
+  hermes::u8 config_memory[kConfigMemorySize];
 
   if (config_file) {
     hermes::Arena config_arena = {};
-    hermes::InitArena(&config_arena, config_memory_size, config_memory);
+    hermes::InitArena(&config_arena, kConfigMemorySize, config_memory);
     hermes::ParseConfig(&config_arena, config_file, &config);
   } else {
     InitDefaultConfig(&config);
@@ -268,7 +267,6 @@ std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
   std::shared_ptr<Hermes> result = InitHermes(&config, is_daemon, is_adapter);
 
   return result;
-
 }
 
 }  // namespace api

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <set>
 #include <iostream>
+#include <vector>
 
 #include "glog/logging.h"
 
@@ -34,7 +35,7 @@ class Hermes {
 
   Hermes() {}
 
-  Hermes(SharedMemoryContext context) : context_(context) {}
+  explicit Hermes(SharedMemoryContext context) : context_(context) {}
 
   void Display_bucket() {
     for (auto it = bucket_list_.begin(); it != bucket_list_.end(); ++it)
@@ -52,7 +53,7 @@ class Hermes {
   void AppBarrier();
   int GetProcessRank();
   int GetNumProcesses();
-  void Finalize(bool force_rpc_shutdown=false);
+  void Finalize(bool force_rpc_shutdown = false);
 
   // MPI comms.
   // proxy/reference to Hermes core
@@ -95,16 +96,15 @@ Status TransferBlob(const Bucket &src_bkt,
                     const std::string &dst_blob_name,
                     Context &ctx);
 
-std::shared_ptr<api::Hermes> InitHermes(const char *config_file=NULL,
-                                        bool is_daemon=false,
-                                        bool is_adapter=false);
+std::shared_ptr<api::Hermes> InitHermes(const char *config_file = NULL,
+                                        bool is_daemon = false,
+                                        bool is_adapter = false);
 
-}  // api namespace
+}  // namespace api
 
+std::shared_ptr<api::Hermes> InitHermesDaemon(char *config_file = NULL);
+std::shared_ptr<api::Hermes> InitHermesClient(const char *config_file = NULL);
 
-std::shared_ptr<api::Hermes> InitHermesDaemon(char *config_file=NULL);
-std::shared_ptr<api::Hermes> InitHermesClient(const char *config_file=NULL);
-
-}  // hermes namespace
+}  // namespace hermes
 
 #endif  // HERMES_H_

--- a/src/api/id.h
+++ b/src/api/id.h
@@ -8,11 +8,11 @@ namespace hermes {
 namespace api {
 
 template<class Tag, class T, T default_value>
-  
+
 class ID {
  private:
   T m_val_;
-    
+
  public:
   static ID Invalid() { return ID(); }
 
@@ -27,9 +27,9 @@ class ID {
 
   friend bool operator==(ID a, ID b) { return a.m_val == b.m_val; }
   friend bool operator!=(ID a, ID b) { return a.m_val != b.m_val; }
-}; // class ID
+};
 
-}  // api namespace
-}  // hermes namespace
+}  // namespace api
+}  // namespace hermes
 
 #endif  // ID_H_

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -1,10 +1,14 @@
 #include "vbucket.h"
 
+#include <utility>
+#include <vector>
+
 namespace hermes {
 
 namespace api {
 
-Status VBucket::Link(std::string blob_name, std::string bucket_name, Context& ctx) {
+Status VBucket::Link(std::string blob_name, std::string bucket_name,
+                     Context& ctx) {
   (void)ctx;
   Status ret = 0;
 
@@ -17,7 +21,8 @@ Status VBucket::Link(std::string blob_name, std::string bucket_name, Context& ct
   return ret;
 }
 
-Status VBucket::Unlink(std::string blob_name, std::string bucket_name, Context& ctx) {
+Status VBucket::Unlink(std::string blob_name, std::string bucket_name,
+                       Context& ctx) {
   (void)ctx;
   Status ret = 0;
 
@@ -91,8 +96,8 @@ template<class Predicate>
 std::vector<std::string> VBucket::GetTraits(Predicate pred, Context& ctx) {
   (void)ctx;
 
-  LOG(INFO) << "Getting the subset of attached traits satisfying pred in VBucket "
-            << name_ << '\n';
+  LOG(INFO) << "Getting the subset of attached traits satisfying pred in "
+            << "VBucket " << name_ << '\n';
   return std::vector<std::string>();
 }
 
@@ -103,5 +108,5 @@ Status VBucket::Delete(Context& ctx) {
   return Status();
 }
 
-} // api namepsace
-} // hermes namespace
+}  // namespace api
+}  // namespace hermes

--- a/src/api/vbucket.h
+++ b/src/api/vbucket.h
@@ -4,78 +4,81 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "glog/logging.h"
 
 #include "hermes.h"
 
 namespace hermes {
-  
+
 namespace api {
-  
+
 class VBucket {
  private:
   std::string name_;
-	std::list<std::pair<std::string,std::string>> linked_blobs_;
-      
+  std::list<std::pair<std::string, std::string>> linked_blobs_;
+
  public:
   /** internal Hermes object owned by vbucket */
   std::shared_ptr<Hermes> hermes_;
-      
+
   VBucket(std::string initial_name, std::shared_ptr<Hermes> const &h)
-	  : name_(initial_name), hermes_(h) {
+    : name_(initial_name), hermes_(h) {
     LOG(INFO) << "Create VBucket " << initial_name << std::endl;
-		if (hermes_->vbucket_list_.find(initial_name) == hermes_->vbucket_list_.end())
-		  hermes_->vbucket_list_.insert(initial_name);
-		else
-			std::cerr << "VBucket " << initial_name << " exists\n";
-  };
-      
+    if (hermes_->vbucket_list_.find(initial_name) ==
+        hermes_->vbucket_list_.end())
+      hermes_->vbucket_list_.insert(initial_name);
+    else
+      std::cerr << "VBucket " << initial_name << " exists\n";
+  }
+
   ~VBucket() {
     name_.clear();
     linked_blobs_.clear();
   }
-      
+
   /** get the name of vbucket */
   std::string GetName() const {
     return this->name_;
   }
-	
-	/** link a blob to this vbucket */
-  Status Link(std::string blob_name, std::string bucket_name, Context &ctx);
-	
-	/** unlink a blob from this vbucket */
-  Status Unlink(std::string blob_name, std::string bucket_name, Context &ctx);
-	
-	/** check if blob is in this vbucket */
-	Status Contain_blob(std::string blob_name, std::string bucket_name);
-	
-	/** get a blob linked to this vbucket */
-	Blob& Get_blob(std::string blob_name, std::string bucket_name);
-	
-	/** retrieves the subset of links satisfying pred */
-	/** could return iterator */
-	template<class Predicate>
-	std::vector<std::string> GetLinks(Predicate pred, Context &ctx);
-	
-	typedef int (TraitFunc)(Blob &blob, void *trait);
-	
-	/** attach a trait to this vbucket */
-	Status Attach(void *trait, TraitFunc *func, Context& ctx);
-	
-	/** detach a trait to this vbucket */
-  Status Detach(void *trait, Context& ctx);
-	
-	/** retrieves the subset of attached traits satisfying pred */
-	template<class Predicate>
-	std::vector<std::string> GetTraits(Predicate pred, Context& ctx);
-	
-	/** delete a vBucket */
-	/** decrements the links counts of blobs in buckets */
-	Status Delete(Context& ctx);
-}; // class VBucket
 
-}  // api
-}  // hermes
+  /** link a blob to this vbucket */
+  Status Link(std::string blob_name, std::string bucket_name, Context &ctx);
+
+  /** unlink a blob from this vbucket */
+  Status Unlink(std::string blob_name, std::string bucket_name, Context &ctx);
+
+  /** check if blob is in this vbucket */
+  Status Contain_blob(std::string blob_name, std::string bucket_name);
+
+  /** get a blob linked to this vbucket */
+  Blob& Get_blob(std::string blob_name, std::string bucket_name);
+
+  /** retrieves the subset of links satisfying pred */
+  /** could return iterator */
+  template<class Predicate>
+  std::vector<std::string> GetLinks(Predicate pred, Context &ctx);
+
+  typedef int (TraitFunc)(Blob &blob, void *trait);
+
+  /** attach a trait to this vbucket */
+  Status Attach(void *trait, TraitFunc *func, Context& ctx);
+
+  /** detach a trait to this vbucket */
+  Status Detach(void *trait, Context& ctx);
+
+  /** retrieves the subset of attached traits satisfying pred */
+  template<class Predicate>
+  std::vector<std::string> GetTraits(Predicate pred, Context& ctx);
+
+  /** delete a vBucket */
+  /** decrements the links counts of blobs in buckets */
+  Status Delete(Context& ctx);
+};  // class VBucket
+
+}  // namespace api
+}  // namespace hermes
 
 #endif  //  VBUCKET_H_

--- a/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
+++ b/src/buffer_pool_visualizer/buffer_pool_visualizer.cc
@@ -14,7 +14,7 @@ Heap *GetIdHeap(MetadataManager *mdm);
 Heap *GetMapHeap(MetadataManager *mdm);
 }  // namespace hermes
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 enum Color {
   kColor_Red,
@@ -158,7 +158,8 @@ void DrawWrappingRect(SDL_Rect *rect, int width, int pad, SDL_Surface *surface,
 // NOTE(chogan): This won't work if we allow non-ram headers to be dormant
 // because getting the next dormant header can swap headers out of their preset
 // index range
-static Range GetHeaderIndexRange(SharedMemoryContext *context, DeviceID device_id) {
+static Range GetHeaderIndexRange(SharedMemoryContext *context,
+                                 DeviceID device_id) {
   Range result = {};
   BufferPool *pool = GetBufferPoolFromContext(context);
 
@@ -355,7 +356,6 @@ static int DrawFileBuffers(SharedMemoryContext *context, SDL_Surface *surface,
   }
 
   return final_y + h;
-
 }
 
 static void DrawEndOfRamBuffers(SharedMemoryContext *context,
@@ -432,7 +432,8 @@ static void ReloadSharedMemory(SharedMemoryContext *context, char *shmem_name) {
   *context = new_context;
 }
 
-static void PrintBufferCounts(SharedMemoryContext *context, DeviceID device_id) {
+static void PrintBufferCounts(SharedMemoryContext *context,
+                              DeviceID device_id) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   BufferHeader *headers = GetHeadersBase(context);
   std::vector<int> buffer_counts(pool->num_slabs[device_id], 0);
@@ -463,7 +464,8 @@ static void PrintBufferCounts(SharedMemoryContext *context, DeviceID device_id) 
   SDL_Log("Total live headers: %d\n", total_headers);
 }
 
-static void PrintFreeListSizes(SharedMemoryContext *context, DeviceID device_id) {
+static void PrintFreeListSizes(SharedMemoryContext *context,
+                               DeviceID device_id) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   int total_free_headers = 0;
 

--- a/src/communication.h
+++ b/src/communication.h
@@ -50,7 +50,7 @@ struct CommunicationContext {
 
 size_t InitCommunication(CommunicationContext *comm, Arena *arena,
                          size_t trans_arena_size_per_node,
-                         bool is_daemon=false, bool is_adapter=false);
+                         bool is_daemon = false, bool is_adapter = false);
 
 inline void WorldBarrier(CommunicationContext *comm) {
   comm->world_barrier(comm->state);

--- a/src/communication_mpi.cc
+++ b/src/communication_mpi.cc
@@ -177,7 +177,8 @@ size_t MpiAssignIDsToNodes(CommunicationContext *comm,
   MPI_Allreduce(ranks_per_node_local.data(), ranks_per_node.data(),
                 comm->num_nodes, MPI_INT, MPI_SUM, mpi_state->world_comm);
 
-  size_t result = trans_arena_size_per_node / (size_t)ranks_per_node[comm->node_id - 1];
+  size_t result =
+    trans_arena_size_per_node / (size_t)ranks_per_node[comm->node_id - 1];
 
   DestroyArena(&scratch_arena);
 

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -127,11 +127,11 @@ EntireFile ReadEntireFile(Arena *arena, const char *path) {
       long file_size = ftell(fstream);
 
       if (file_size > 0) {
-
         if ((u32)file_size <= arena->capacity) {
           fseek(fstream, 0, SEEK_SET);
           result.data = PushArray<u8>(arena, file_size);
-          [[maybe_unused]] int items_read = fread(result.data, file_size, 1, fstream);
+          [[maybe_unused]] int items_read = fread(result.data, file_size, 1,
+                                                  fstream);
           assert(items_read == 1);
           result.size = file_size;
         } else {
@@ -175,7 +175,7 @@ inline bool BeginsComment(char c) {
 }
 
 inline bool EndOfComment(char c) {
-  bool result = (c == '\n') || ( c == '\r' );
+  bool result = (c == '\n') || (c == '\r');
 
   return result;
 }
@@ -601,8 +601,8 @@ Token *ParseCharArrayString(Token *tok, char *arr) {
 
 void RequireNumDevices(Config *config) {
   if (config->num_devices == 0) {
-    LOG(FATAL) << "The configuration variable 'num_devices' must be defined first"
-               << std::endl;
+    LOG(FATAL) << "The configuration variable 'num_devices' must be defined "
+               << "first" << std::endl;
   }
 }
 
@@ -646,7 +646,6 @@ void CheckConstraints(Config *config) {
 }
 
 void ParseTokens(TokenList *tokens, Config *config) {
-
   Token *tok = tokens->head;
   while (tok) {
     ConfigVariable var = GetConfigVariable(tok);
@@ -698,8 +697,8 @@ void ParseTokens(TokenList *tokens, Config *config) {
       case ConfigVariable_SlabUnitSizes: {
         RequireNumDevices(config);
         RequireNumSlabs(config);
-        tok = ParseIntListList(tok, config->slab_unit_sizes, config->num_devices,
-                               config->num_slabs);
+        tok = ParseIntListList(tok, config->slab_unit_sizes,
+                               config->num_devices, config->num_slabs);
         break;
       }
       case ConfigVariable_DesiredSlabPercentages: {

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -73,7 +73,8 @@ Status RoundRobinPlacement(SharedMemoryContext *context, RpcContext *rpc,
     // If size is greater than 64KB
     // Split the blob or not
     if (blob_sizes[i] > KILOBYTES(64)) {
-      std::uniform_int_distribution<std::mt19937::result_type> distribution(0,1);
+      std::uniform_int_distribution<std::mt19937::result_type>
+        distribution(0, 1);
       number = distribution(rng);
     }
 
@@ -101,13 +102,13 @@ Status RoundRobinPlacement(SharedMemoryContext *context, RpcContext *rpc,
       // Construct the vector for the splitted blob
       std::vector<size_t> new_blob_size;
       size_t blob_each_portion {blob_sizes[i]/split_num};
-      for (int j {0}; j<split_num-1; ++j) {
+      for (int j {0}; j < split_num - 1; ++j) {
         new_blob_size.push_back(blob_each_portion);
       }
       new_blob_size.push_back(blob_sizes[i] -
                               blob_each_portion*(split_num-1));
 
-      for (size_t k {0}; k<new_blob_size.size(); ++k) {
+      for (size_t k {0}; k < new_blob_size.size(); ++k) {
         size_t dst {global_state.size()};
         DataPlacementEngine dpe;
         size_t device_pos {dpe.getCountDevice()};
@@ -123,13 +124,13 @@ Status RoundRobinPlacement(SharedMemoryContext *context, RpcContext *rpc,
         }
         if (dst == global_state.size()) {
           HERMES_NOT_IMPLEMENTED_YET;
-          std::cerr << "Buffer device not found for splitted blob! Go to PFS.\n";
+          std::cerr
+            << "Buffer device not found for splitted blob! Go to PFS.\n";
         }
       }
       output.push_back(schema);
-    }
+    } else {
     // Blob size is less than 64KB or do not split
-    else {
       size_t dst {global_state.size()};
       DataPlacementEngine dpe;
       size_t device_pos {dpe.getCountDevice()};

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -172,7 +172,8 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
     // If size is greater than 64KB
     // Split the blob or not
     if (blob_sizes[i] > KILOBYTES(64)) {
-      std::uniform_int_distribution<std::mt19937::result_type> distribution(0,1);
+      std::uniform_int_distribution<std::mt19937::result_type>
+        distribution(0, 1);
       number = distribution(rng);
     }
 
@@ -200,15 +201,15 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
       // Construct the vector for the splitted blob
       std::vector<size_t> new_blob_size;
       size_t blob_each_portion {blob_sizes[i]/split_num};
-      for (int j {0}; j<split_num-1; ++j) {
+      for (int j {0}; j < split_num - 1; ++j) {
         new_blob_size.push_back(blob_each_portion);
       }
       new_blob_size.push_back(blob_sizes[i] -
                               blob_each_portion*(split_num-1));
 
-      for (size_t k {0}; k<new_blob_size.size(); ++k) {
+      for (size_t k {0}; k < new_blob_size.size(); ++k) {
         size_t dst {node_state.size()};
-        auto itlow = ordered_cap.lower_bound (new_blob_size[k]);
+        auto itlow = ordered_cap.lower_bound(new_blob_size[k]);
         if (itlow == ordered_cap.end()) {
           HERMES_NOT_IMPLEMENTED_YET;
           assert(!"No buffer device has enough capacity! Go to PFS.\n");
@@ -219,7 +220,7 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
         dst = dst_distribution(rng);
         schema.push_back(std::make_pair(new_blob_size[k], dst));
 
-        for (auto it=itlow; it!=ordered_cap.end(); ++it) {
+        for (auto it = itlow; it != ordered_cap.end(); ++it) {
           if ((*it).second == dst) {
             ordered_cap.insert(std::pair<u64, size_t>(
                                (*it).first-new_blob_size[k], (*it).second));
@@ -229,9 +230,8 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
         }
       }
       output.push_back(schema);
-    }
-    // Blob size is less than 64KB or do not split
-    else {
+    } else {
+      // Blob size is less than 64KB or do not split
       PlacementSchema schema;
       size_t dst {node_state.size()};
       auto itlow = ordered_cap.lower_bound(blob_sizes[i]);
@@ -243,7 +243,7 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
       std::uniform_int_distribution<std::mt19937::result_type>
         dst_distribution((*itlow).second, node_state.size()-1);
       dst = dst_distribution(rng);
-      for (auto it=itlow; it!=ordered_cap.end(); ++it) {
+      for (auto it = itlow; it != ordered_cap.end(); ++it) {
         if ((*it).second == dst) {
           ordered_cap.insert(std::pair<u64, size_t>(
                              (*it).first-blob_sizes[i], (*it).second));
@@ -272,10 +272,10 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
   // will need the ability to escalate to neighborhoods, and the entire cluster.
   std::vector<u64> node_state = GetRemainingNodeCapacities(context);
   std::vector<f32> bandwidths = GetBandwidths(context);
-  // TODO (KIMMY): size of constraints should be from context
+  // TODO(KIMMY): size of constraints should be from context
   std::vector<MPConstraint*> blob_constrt(blob_sizes.size() +
                                           node_state.size()*3-1);
-  std::vector<std::vector<MPVariable*>> blob_fraction (blob_sizes.size());
+  std::vector<std::vector<MPVariable*>> blob_fraction(blob_sizes.size());
   MPSolver solver("LinearOpt", MPSolver::GLOP_LINEAR_PROGRAMMING);
   int num_constrts {0};
 
@@ -284,7 +284,7 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
     blob_constrt[num_constrts+i] = solver.MakeRowConstraint(1, 1);
     blob_fraction[i].resize(node_state.size());
 
-    // TODO (KIMMY): consider remote nodes?
+    // TODO(KIMMY): consider remote nodes?
     for (size_t j {0}; j < node_state.size(); ++j) {
       std::string var_name {"blob_dst_" + std::to_string(i) + "_" +
                             std::to_string(j)};
@@ -350,7 +350,7 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
 
   for (size_t i {0}; i < blob_sizes.size(); ++i) {
     PlacementSchema schema;
-    size_t device_pos {0}; // to track the device with most data
+    size_t device_pos {0};  // to track the device with most data
     auto largest_bulk{blob_fraction[i][0]->solution_value()*blob_sizes[i]};
     // NOTE: could be inefficient if there are hundreds of devices
     for (size_t j {1}; j < node_state.size(); ++j) {
@@ -362,7 +362,7 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
       if (j == device_pos)
         continue;
       double check_frac_size {blob_fraction[i][j]->solution_value()*
-                              blob_sizes[i]}; // blob fraction size
+                              blob_sizes[i]};  // blob fraction size
       size_t frac_size_cast = static_cast<size_t>(check_frac_size);
       // If size to this destination is not 0, push to result
       if (frac_size_cast != 0) {
@@ -371,7 +371,8 @@ Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
       }
     }
     // Push the rest data to device device_pos
-    schema.push_back(std::make_pair(blob_sizes[i]-blob_partial_sum, device_pos));
+    schema.push_back(std::make_pair(blob_sizes[i]-blob_partial_sum,
+                                    device_pos));
     output.push_back(schema);
   }
 
@@ -385,8 +386,8 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
   (void)api_context;
   Status result = 0;
 
-  // TODO(chogan): Return a PlacementSchema that minimizes a cost function F given
-  // a set of N Devices and a blob, while satisfying a policy P.
+  // TODO(chogan): Return a PlacementSchema that minimizes a cost function F
+  // given a set of N Devices and a blob, while satisfying a policy P.
 
   switch (api_context.policy) {
     // TODO(KIMMY): check device capacity against blob size

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -11,7 +11,7 @@ using api::Status;
 class DataPlacementEngine {
   static inline size_t count_device_ {};
 
-public:
+ public:
   size_t getCountDevice() const {return count_device_;}
   void setCountDevice(size_t new_count_device) {
     count_device_ = new_count_device;

--- a/src/debug_state.h
+++ b/src/debug_state.h
@@ -8,11 +8,11 @@ struct DebugHeapAllocation {
   u32 size;
 };
 
-const int global_debug_max_allocations = 256;
+const int kGlobalDebugMaxAllocations = 256;
 
 struct DebugState {
   u8 *shmem_base;
-  DebugHeapAllocation allocations[global_debug_max_allocations];
+  DebugHeapAllocation allocations[kGlobalDebugMaxAllocations];
   TicketMutex mutex;
   u32 allocation_count;
 };

--- a/src/memory_management.cc
+++ b/src/memory_management.cc
@@ -310,15 +310,16 @@ FreeBlock *FindFirstFit(Heap *heap, u32 desired_size) {
 }
 
 #if 0
-FreeBlock *FindBestFit(FreeBlock *head, size_t desired_size, u32 threshold=0) {
+FreeBlock *FindBestFit(FreeBlock *head, size_t desired_size,
+                       u32 threshold = 0) {
   FreeBlock *result = 0;
   FreeBlock *prev = head;
   FreeBlock *smallest_prev = head;
   u32 smallest_wasted = 0xFFFFFFFF;
 
-  while(head && smallest_wasted > threshold) {
+  while (head && smallest_wasted > threshold) {
     if (head->size >= desired_size) {
-      u32 wasted_space = head->size - desired_size ;
+      u32 wasted_space = head->size - desired_size;
       if (wasted_space < smallest_wasted) {
         smallest_wasted = wasted_space;
         result = head;
@@ -359,8 +360,9 @@ u8 *HeapPushSize(Heap *heap, u32 size) {
       header->size = actual_size;
       result = (u8 *)(header + 1);
 
-      HERMES_DEBUG_TRACK_ALLOCATION(header, header->size + sizeof(FreeBlockHeader),
-                             heap->grows_up);
+      HERMES_DEBUG_TRACK_ALLOCATION(header,
+                                    header->size + sizeof(FreeBlockHeader),
+                                    heap->grows_up);
 
       u32 extent_adustment = heap->grows_up ? 0 : sizeof(FreeBlock);
 
@@ -389,7 +391,8 @@ void HeapFree(Heap *heap, void *ptr) {
     if (heap->grows_up) {
       new_block = (FreeBlock *)header;
     } else {
-      new_block = (FreeBlock *)((u8 *)(header + 1) + header->size - sizeof(FreeBlock));
+      new_block =
+        (FreeBlock *)((u8 *)(header + 1) + header->size - sizeof(FreeBlock));
     }
     new_block->size = size + sizeof(FreeBlockHeader);
 
@@ -409,7 +412,6 @@ void HeapFree(Heap *heap, void *ptr) {
 }
 
 void *HeapRealloc(Heap *heap, void *ptr, size_t size) {
-
   if (ptr) {
     // NOTE(chogan): We only support malloc behavior for now. The stb_ds.h hash
     // map uses STBDS_REALLOC for its malloc style allocations. We just give the

--- a/src/memory_management.h
+++ b/src/memory_management.h
@@ -231,7 +231,7 @@ void GrowArena(Arena *arena, size_t new_size);
  *
  * @return A pointer to the beginning of a contiguous region of @p size bytes.
  */
-u8 *PushSize(Arena *arena, size_t size, size_t alignment=8);
+u8 *PushSize(Arena *arena, size_t size, size_t alignment = 8);
 
 /**
  * Returns a pointer to a raw region of bytes that are cleared to zero.
@@ -244,7 +244,7 @@ u8 *PushSize(Arena *arena, size_t size, size_t alignment=8);
  *
  * @return A pointer to the beginning of a contiguous region of @p size zeros.
  */
-u8 *PushSizeAndClear(Arena *arena, size_t size, size_t alignment=8);
+u8 *PushSizeAndClear(Arena *arena, size_t size, size_t alignment = 8);
 
 /**
  * Reserves space for and returns a pointer to a T instance.
@@ -258,7 +258,7 @@ u8 *PushSizeAndClear(Arena *arena, size_t size, size_t alignment=8);
  * @return A pointer to an uninitialized `T` instance.
  */
 template<typename T>
-inline T *PushStruct(Arena *arena, size_t alignment=8) {
+inline T *PushStruct(Arena *arena, size_t alignment = 8) {
   T *result = reinterpret_cast<T *>(PushSize(arena, sizeof(T), alignment));
 
   return result;
@@ -276,7 +276,7 @@ inline T *PushStruct(Arena *arena, size_t alignment=8) {
  * @return A pointer to a `T` instance with all members initialized to zero.
  */
 template<typename T>
-inline T *PushClearedStruct(Arena *arena, size_t alignment=8) {
+inline T *PushClearedStruct(Arena *arena, size_t alignment = 8) {
   T *result = reinterpret_cast<T *>(PushSizeAndClear(arena, sizeof(T),
                                                      alignment));
 
@@ -296,7 +296,7 @@ inline T *PushClearedStruct(Arena *arena, size_t alignment=8) {
  * @return A pointer to the first `T` instance in the uninitialized array.
  */
 template<typename T>
-inline T *PushArray(Arena *arena, int count, size_t alignment=8) {
+inline T *PushArray(Arena *arena, int count, size_t alignment = 8) {
   T *result = reinterpret_cast<T *>(PushSize(arena, sizeof(T) * count,
                                              alignment));
 
@@ -314,7 +314,7 @@ inline T *PushArray(Arena *arena, int count, size_t alignment=8) {
  * @return A pointer to the first `T` instance in the array.
  */
 template<typename T>
-inline T *PushClearedArray(Arena *arena, int count, size_t alignment=8) {
+inline T *PushClearedArray(Arena *arena, int count, size_t alignment = 8) {
   T *result = reinterpret_cast<T *>(PushSizeAndClear(arena, sizeof(T) * count,
                                                      alignment));
 
@@ -336,7 +336,7 @@ inline T *HeapPushArray(Heap *heap, u32 count) {
   return result;
 }
 
-Heap *InitHeapInArena(Arena *arena, bool grows_up=true, u16 alignment=8);
+Heap *InitHeapInArena(Arena *arena, bool grows_up = true, u16 alignment = 8);
 void HeapFree(Heap *heap, void *ptr);
 void *HeapRealloc(Heap *heap, void *ptr, size_t size);
 u32 GetHeapOffset(Heap *heap, u8 *ptr);

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -398,7 +398,6 @@ void FreeBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
 
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
                             const char *blob_name, BlobID blob_id) {
-
   std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
   ReleaseBuffers(context, rpc, buffer_ids);
   FreeBufferIdList(context, rpc, blob_id);
@@ -596,7 +595,6 @@ SystemViewState *GetLocalSystemViewState(SharedMemoryContext *context) {
 }
 
 std::vector<u64> LocalGetGlobalDeviceCapacities(SharedMemoryContext *context) {
-
   SystemViewState *global_svs = GetGlobalSystemViewState(context);
 
   std::vector<u64> result(global_svs->num_devices);
@@ -609,7 +607,6 @@ std::vector<u64> LocalGetGlobalDeviceCapacities(SharedMemoryContext *context) {
 
 std::vector<u64> GetGlobalDeviceCapacities(SharedMemoryContext *context,
                                          RpcContext *rpc) {
-
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   u32 target_node = mdm->global_system_view_state_node_id;
 
@@ -636,7 +633,6 @@ SystemViewState *GetGlobalSystemViewState(SharedMemoryContext *context) {
 
 void LocalUpdateGlobalSystemViewState(SharedMemoryContext *context,
                                       std::vector<i64> adjustments) {
-
   for (size_t i = 0; i < adjustments.size(); ++i) {
     SystemViewState *state = GetGlobalSystemViewState(context);
     if (adjustments[i]) {
@@ -691,7 +687,6 @@ SystemViewState *CreateSystemViewState(Arena *arena, Config *config) {
 
 void InitMetadataManager(MetadataManager *mdm, Arena *arena, Config *config,
                          int node_id) {
-
   // NOTE(chogan): All MetadataManager offsets are relative to the address of
   // the MDM itself.
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -60,7 +60,6 @@ enum class TraitID : u8 {
 };
 
 struct Stats {
-
 };
 
 const int kIdListChunkSize = 10;
@@ -271,6 +270,6 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 
-} // namespace hermes
+}  // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -59,7 +59,7 @@ std::string GetProtocol(RpcContext *rpc);
 #if defined(HERMES_RPC_THALLIUM)
 #include "rpc_thallium.h"
 #else
-#error RPC implementation required (e.g., -DHERMES_RPC_THALLIUM).
+#error "RPC implementation required (e.g., -DHERMES_RPC_THALLIUM)."
 #endif
 
 #endif  // HERMES_RPC_H_

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -90,14 +90,12 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   function<void(const request&, BufferID, std::vector<u8>, size_t)>
     rpc_write_buffer_by_id = [context](const request &req, BufferID id,
                                        std::vector<u8> data, size_t offset) {
-
       Blob blob = {};
       blob.size = data.size();
       blob.data = data.data();
       size_t result = LocalWriteBufferById(context, id, blob, offset);
 
       req.respond(result);
-
     };
 
   function<void(const request&, BufferID)> rpc_read_buffer_by_id =
@@ -288,7 +286,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
 
   // TODO(chogan): Only need this on mdm->global_system_view_state_node_id.
   // Probably should move it to a completely separate tl::engine.
-  function<void(const request&, std::vector<i64>)> rpc_update_global_system_view_state =
+  function<void(const request&, std::vector<i64>)>
+    rpc_update_global_system_view_state =
     [context](const request &req, std::vector<i64> adjustments) {
       (void)req;
       LocalUpdateGlobalSystemViewState(context, adjustments);
@@ -352,7 +351,6 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
 void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
                                             RpcContext *rpc, Arena *arena,
                                             double sleep_ms) {
-
   struct ThreadArgs {
     SharedMemoryContext *context;
     RpcContext *rpc;
@@ -422,15 +420,15 @@ std::string GetServerName(RpcContext *rpc, u32 node_id) {
   std::string host_number = GetHostNumberAsString(rpc, node_id);
   std::string host_name = (std::string(rpc->base_hostname) + host_number +
                            std::string(rpc->hostname_suffix));
-  const int max_ip_address_size = 16;
-  char ip_address[max_ip_address_size];
+  const int kMaxIpAddressSize = 16;
+  char ip_address[kMaxIpAddressSize];
   // TODO(chogan): @errorhandling
   // TODO(chogan): @optimization Could cache the last N hostname->IP mappings to
   // avoid excessive syscalls. Should profile first.
   struct hostent *hostname_info = gethostbyname(host_name.c_str());
   in_addr **addr_list = (struct in_addr **)hostname_info->h_addr_list;
   // TODO(chogan): @errorhandling
-  strncpy(ip_address, inet_ntoa(*addr_list[0]), max_ip_address_size);
+  strncpy(ip_address, inet_ntoa(*addr_list[0]), kMaxIpAddressSize);
 
   std::string result = std::string(tl_state->server_name_prefix);
 

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -116,7 +116,8 @@ static inline ThalliumState *GetThalliumState(RpcContext *rpc) {
 }
 
 template<typename ReturnType, typename... Ts>
-ReturnType RpcCall(RpcContext *rpc, u32 node_id, const char *func_name, Ts... args) {
+ReturnType RpcCall(RpcContext *rpc, u32 node_id, const char *func_name,
+                   Ts... args) {
   std::string server_name = GetServerName(rpc, node_id);
   std::string protocol = GetProtocol(rpc);
 

--- a/test/bucket_test.cc
+++ b/test/bucket_test.cc
@@ -13,22 +13,26 @@ struct MyTrait {
   // optional function pointer if only known at runtime
 };
 
-void add_buffer_to_vector(hermes::api::Blob &vector, const char *buffer, uLongf length) {
-  for (uLongf character_index = 0; character_index < length; character_index++) {
+void add_buffer_to_vector(hermes::api::Blob &vector, const char *buffer,
+                          uLongf length) {
+  for (uLongf character_index = 0; character_index < length;
+       character_index++) {
     char current_character = buffer[character_index];
     vector.push_back(current_character);
   }
 }
 
-// The Trait implementer must define callbacks that match the VBucket::TraitFunc type.
+// The Trait implementer must define callbacks that match the VBucket::TraitFunc
+// type.
 int compress_blob(hermes::api::Blob &blob, void *trait) {
   MyTrait *my_trait = (MyTrait *)trait;
 
-  // If Hermes is already linked with a compression library, you can call the function directly here.
-  // If not, the symbol will have to be dynamically loaded and probably stored as a pointer in the Trait.
+  // If Hermes is already linked with a compression library, you can call the
+  // function directly here. If not, the symbol will have to be dynamically
+  // loaded and probably stored as a pointer in the Trait.
   uLongf source_length = blob.size();
   uLongf destination_length = compressBound(source_length);
-  char *destination_data = new char [destination_length];
+  char *destination_data = new char[destination_length];
 
   LOG(INFO) << "Compressing blob\n";
 
@@ -36,10 +40,10 @@ int compress_blob(hermes::api::Blob &blob, void *trait) {
     return Z_MEM_ERROR;
 
   int return_value = compress2((Bytef *) destination_data,
-                               &destination_length, (Bytef *) blob.data(), source_length,
-                               my_trait->compress_level);
+                               &destination_length, (Bytef *) blob.data(),
+                               source_length, my_trait->compress_level);
   hermes::api::Blob destination {0};
-  //TODO: where to store compressed data
+  // TODO(KIMMY): where to store compressed data
   add_buffer_to_vector(destination, destination_data, destination_length);
   delete [] destination_data;
 
@@ -47,8 +51,7 @@ int compress_blob(hermes::api::Blob &blob, void *trait) {
 }
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   int mpi_threads_provided;
   MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
   if (mpi_threads_provided < MPI_THREAD_MULTIPLE) {
@@ -69,8 +72,8 @@ int main(int argc, char **argv)
 
     hermes::api::Bucket my_bucket("compression", hermes_app, ctx);
     hermes_app->Display_bucket();
-    hermes::api::Blob p1 (1024*1024*400, 255);
-    hermes::api::Blob p2 (p1);
+    hermes::api::Blob p1(1024*1024*400, 255);
+    hermes::api::Blob p2(p1);
     my_bucket.Put("Blob1", p1, ctx);
     my_bucket.Put("Blob2", p2, ctx);
 
@@ -87,18 +90,18 @@ int main(int argc, char **argv)
     hermes_app->Display_vbucket();
     my_vb.Link("Blob1", "compression", ctx);
     my_vb.Link("Blob2", "compression", ctx);
-    if(my_vb.Contain_blob("Blob1", "compression") == 1)
+    if (my_vb.Contain_blob("Blob1", "compression") == 1)
       std::cout << "Found Blob1 from compression bucket in VBucket VB1\n";
     else
       std::cout << "Not found Blob1 from compression bucket in VBucket VB1\n";
-    if(my_vb.Contain_blob("Blob2", "compression") == 1)
+    if (my_vb.Contain_blob("Blob2", "compression") == 1)
       std::cout << "Found Blob2 from compression bucket in VBucket VB1\n";
     else
       std::cout << "Not found Blob2 from compression bucket in VBucket VB1\n";
 
     // compression level
     struct MyTrait trait {6};
-    my_vb.Attach(&trait, compress_blob, ctx);   // compress action to data starts
+    my_vb.Attach(&trait, compress_blob, ctx);  // compress action to data starts
 
     ///////
     my_vb.Unlink("Blob1", "VB1", ctx);

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -24,7 +24,7 @@
  * node).
  */
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 using hermes::testing::Timer;
 namespace hapi = hermes::api;
 
@@ -42,7 +42,8 @@ TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
   for (int i = 0; i < iters; ++i) {
     get_timer.resumeTime();
     std::vector<BufferID> ret =
-      hermes::RpcCall<std::vector<BufferID>>(rpc, rpc->node_id, "GetBuffers", schema);
+      hermes::RpcCall<std::vector<BufferID>>(rpc, rpc->node_id, "GetBuffers",
+                                             schema);
     get_timer.pauseTime();
 
     if (ret.size() == 0) {
@@ -124,10 +125,9 @@ double TestMergeBuffers(SharedMemoryContext *context, RpcContext *rpc,
 }
 
 struct FileMapper {
-
   Blob blob;
 
-  FileMapper(const char *path) {
+  explicit FileMapper(const char *path) {
     FILE *f = fopen(path, "r");
     blob = {};
     if (f) {

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -19,7 +19,7 @@
 namespace hapi = hermes::api;
 
 void TestGetBuffers(hapi::Hermes *hermes) {
-  using namespace hermes;
+  using namespace hermes;  // NOLINT(*)
   SharedMemoryContext *context = &hermes->context_;
   BufferPool *pool = GetBufferPoolFromContext(context);
   DeviceID device_id = 0;
@@ -57,7 +57,7 @@ void TestGetBuffers(hapi::Hermes *hermes) {
 }
 
 void TestGetBandwidths(hermes::SharedMemoryContext *context) {
-  using namespace hermes;
+  using namespace hermes;  // NOLINT(*)
   std::vector<f32> bandwidths = GetBandwidths(context);
   Config config;
   InitDefaultConfig(&config);
@@ -76,7 +76,6 @@ void PrintUsage(char *program) {
 }
 
 int main(int argc, char **argv) {
-
   int option = -1;
   char *config_file = 0;
   bool test_get_buffers = false;

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -8,7 +8,6 @@
 #include "test_utils.h"
 
 int main(int argc, char **argv) {
-
   if (argc < 2) {
     fprintf(stderr, "Expected a path to a hermes.conf file\n");
     exit(-1);
@@ -16,10 +15,10 @@ int main(int argc, char **argv) {
 
   hermes::Config config = {};
 
-  const size_t config_memory_size = KILOBYTES(7);
-  hermes::u8 config_memory[config_memory_size];
+  const size_t kConfigMemorySize = KILOBYTES(7);
+  hermes::u8 config_memory[kConfigMemorySize];
   hermes::Arena arena = {};
-  hermes::InitArena(&arena, config_memory_size, config_memory);
+  hermes::InitArena(&arena, kConfigMemorySize, config_memory);
 
   hermes::ParseConfig(&arena, argv[1], &config);
 

--- a/test/dpe_optimization_test.cc
+++ b/test/dpe_optimization_test.cc
@@ -4,7 +4,7 @@
 
 #include "hermes.h"
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 namespace hermes {
 namespace testing {
@@ -14,8 +14,8 @@ struct SystemViewState {
   u64 bandwidth[kMaxDevices];
   int num_devices;
 };
-}  // namespace hermes
 }  // namespace testing
+}  // namespace hermes
 
 testing::SystemViewState InitSystemViewState() {
   testing::SystemViewState result = {};
@@ -67,14 +67,14 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
   using operations_research::MPObjective;
 
   PlacementSchema result;
-  // TODO (KIMMY): use kernel function of system view
+  // TODO(KIMMY): use kernel function of system view
   testing::SystemViewState state {GetSystemViewState()};
 
   std::vector<MPConstraint*> blob_constrt(blobs.size()+state.num_devices*3-1);
-  std::vector<std::vector<MPVariable*>> blob_fraction (blobs.size());
+  std::vector<std::vector<MPVariable*>> blob_fraction(blobs.size());
   MPSolver solver("LinearOpt", MPSolver::GLOP_LINEAR_PROGRAMMING);
   int num_constrts {0};
-  // TODO (KIMMY): placement ratio number will be from policy in the future
+  // TODO(KIMMY): placement ratio number will be from policy in the future
   const int placement_ratio {-10};
 
   // Sum of fraction of each blob is 1
@@ -82,7 +82,7 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
     blob_constrt[num_constrts+i] = solver.MakeRowConstraint(1, 1);
     blob_fraction[i].resize(state.num_devices);
 
-    // TODO (KIMMY): consider remote nodes?
+    // TODO(KIMMY): consider remote nodes?
     for (int j {0}; j < state.num_devices; ++j) {
       std::string var_name {"blob_dst_" + std::to_string(i) + "_" +
                             std::to_string(j)};
@@ -123,7 +123,7 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
       blob_constrt[num_constrts+j]->SetCoefficient(
         blob_fraction[i][j+1], static_cast<double>(blobs[i].size()));
       blob_constrt[num_constrts+j]->SetCoefficient(
-        blob_fraction[i][j], 
+        blob_fraction[i][j],
         static_cast<double>(blobs[i].size())*placement_ratio);
     }
   }
@@ -145,7 +145,7 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
   }
 
   for (size_t i {0}; i < blobs.size(); ++i) {
-    int device_pos {0}; // to track the device with most data
+    int device_pos {0};  // to track the device with most data
     auto largest_bulk{blob_fraction[i][0]->solution_value()*blobs[i].size()};
     // NOTE: could be inefficient if there are hundreds of devices
     for (int j {1}; j < state.num_devices; ++j) {
@@ -157,7 +157,7 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
       if (j == device_pos)
         continue;
       double check_frac_size {blob_fraction[i][j]->solution_value()*
-                              blobs[i].size()}; // blob fraction size
+                              blobs[i].size()};  // blob fraction size
       size_t frac_size_cast = static_cast<size_t>(check_frac_size);
       // If size to this destination is not 0, push to result
       if (frac_size_cast != 0) {
@@ -166,18 +166,18 @@ PlacementSchema PerfOrientedPlacement(std::vector<hermes::api::Blob> blobs) {
       }
     }
     // Push the rest data to device_pos
-    result.push_back(std::make_pair(blobs[i].size()-blob_partial_sum, device_pos));
+    result.push_back(std::make_pair(blobs[i].size()-blob_partial_sum,
+                                    device_pos));
   }
 
   return result;
 }
 
-int main()
-{
-  hermes::api::Blob p1 (1024*1024, 255);
-  hermes::api::Blob p2 (1024*1024*2, 255);
-  hermes::api::Blob p3 (1024*1024*4, 255);
-  hermes::api::Blob p4 (1024*1024*7, 255);
+int main() {
+  hermes::api::Blob p1(1024*1024, 255);
+  hermes::api::Blob p2(1024*1024*2, 255);
+  hermes::api::Blob p3(1024*1024*4, 255);
+  hermes::api::Blob p4(1024*1024*7, 255);
   std::vector<hermes::api::Blob> input_blobs;
   input_blobs.push_back(p1);
   input_blobs.push_back(p2);
@@ -191,10 +191,12 @@ int main()
   UpdateSystemViewState(schema1);
 
   for (auto [size, device] : schema1) {
-    std::cout << "placing " << size << " at device " << device << '\n' << std::flush;
+    std::cout << "placing " << size << " at device " << device << '\n'
+              << std::flush;
   }
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -203,9 +205,9 @@ int main()
   }
   std::cout << '\n' << '\n' << '\n'<< std::flush;
 
-  hermes::api::Blob p5 (1024*1024*0.5, 255);
-  hermes::api::Blob p6 (1024*1024*20, 255);
-  hermes::api::Blob p7 (1024*1024*4, 255);
+  hermes::api::Blob p5(1024*1024*0.5, 255);
+  hermes::api::Blob p6(1024*1024*20, 255);
+  hermes::api::Blob p7(1024*1024*4, 255);
   input_blobs.clear();
   input_blobs.push_back(p5);
   input_blobs.push_back(p6);
@@ -215,10 +217,12 @@ int main()
   UpdateSystemViewState(schema2);
 
   for (auto [size, device] : schema2) {
-    std::cout << "placing " << size << " at device " << device << '\n' << std::flush;
+    std::cout << "placing " << size << " at device " << device << '\n'
+              << std::flush;
   }
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -227,11 +231,11 @@ int main()
   }
   std::cout << '\n' << '\n' << '\n'<< std::flush;
 
-  hermes::api::Blob p8 (1024*1024*0.5, 255);
-  hermes::api::Blob p9 (1024*1024*20, 255);
-  hermes::api::Blob p10 (1024*1024*1, 255);
-  hermes::api::Blob p11 (1024*1024*4, 255);
-  hermes::api::Blob p12 (1024*1024*10, 255);
+  hermes::api::Blob p8(1024*1024*0.5, 255);
+  hermes::api::Blob p9(1024*1024*20, 255);
+  hermes::api::Blob p10(1024*1024*1, 255);
+  hermes::api::Blob p11(1024*1024*4, 255);
+  hermes::api::Blob p12(1024*1024*10, 255);
   input_blobs.clear();
   input_blobs.push_back(p8);
   input_blobs.push_back(p9);
@@ -243,10 +247,12 @@ int main()
   UpdateSystemViewState(schema3);
 
   for (auto [size, device] : schema3) {
-    std::cout << "placing " << size << " at device " << device << '\n' << std::flush;
+    std::cout << "placing " << size << " at device " << device << '\n'
+              << std::flush;
   }
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -114,15 +114,15 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
       // Construct the vector for the splitted blob
       std::vector<size_t> new_blob_size;
       size_t blob_each_portion {blobs[i].size()/split_num};
-      for (int j {0}; j<split_num-1; ++j) {
+      for (int j {0}; j < split_num - 1; ++j) {
         new_blob_size.push_back(blob_each_portion);
       }
       new_blob_size.push_back(blobs[i].size() -
                               blob_each_portion*(split_num-1));
 
-      for (size_t k {0}; k<new_blob_size.size(); ++k) {
+      for (size_t k {0}; k < new_blob_size.size(); ++k) {
         int dst {state.num_devices};
-        auto itlow = ordered_cap.lower_bound (new_blob_size[k]);
+        auto itlow = ordered_cap.lower_bound(new_blob_size[k]);
         if (itlow == ordered_cap.end()) {
           std::cerr << "No target has enough capacity (max "
                     << ordered_cap.rbegin()->first
@@ -134,7 +134,7 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
           dst_distribution((*itlow).second, state.num_devices-1);
         dst = dst_distribution(rng);
         result.push_back(std::make_pair(new_blob_size[k], dst));
-        for (auto it=itlow; it!=ordered_cap.end(); ++it) {
+        for (auto it = itlow; it != ordered_cap.end(); ++it) {
           if ((*it).second == dst) {
             ordered_cap.insert(std::pair<size_t, size_t>(
                                  (*it).first-new_blob_size[k], (*it).second));
@@ -143,9 +143,8 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
           }
         }
       }
-    }
-    // Blob size is less than 64KB or do not split
-    else {
+    } else {
+      // Blob size is less than 64KB or do not split
       std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
       int dst {state.num_devices};
       auto itlow = ordered_cap.lower_bound(blobs[i].size());

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -6,7 +6,7 @@
 
 #include "hermes.h"
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 namespace hermes {
 namespace testing {
@@ -16,8 +16,8 @@ struct SystemViewState {
   u64 bandwidth[kMaxDevices];
   int num_devices;
 };
-}  // namespace hermes
 }  // namespace testing
+}  // namespace hermes
 
 testing::SystemViewState InitSystemViewState() {
   testing::SystemViewState result = {};
@@ -64,7 +64,7 @@ void UpdateSystemViewState(PlacementSchema schema) {
 
 PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
   PlacementSchema result;
-  // TODO (KIMMY): use kernel function of system view
+  // TODO(KIMMY): use kernel function of system view
   testing::SystemViewState state {GetSystemViewState()};
   std::multimap<u64, int> ordered_cap;
 
@@ -77,11 +77,12 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
     std::random_device dev;
     std::mt19937 rng(dev());
     int number {0};
-    
+
     // If size is greater than 64KB
     // Decision about split the blob or not
     if (blobs[i].size() > KILOBYTES(64)) {
-      std::uniform_int_distribution<std::mt19937::result_type> distribution(0,1);
+      std::uniform_int_distribution<std::mt19937::result_type>
+        distribution(0, 1);
       number = distribution(rng);
     }
 
@@ -92,9 +93,11 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
       // Not split the blob if size is less than 64KB
       if (blobs[i].size() > KILOBYTES(64) && blobs[i].size() <= KILOBYTES(256))
         split_option = 2;
-      else if (blobs[i].size() > KILOBYTES(256) && blobs[i].size() <= MEGABYTES(1))
+      else if (blobs[i].size() > KILOBYTES(256) &&
+               blobs[i].size() <= MEGABYTES(1))
         split_option = 5;
-      else if (blobs[i].size() > MEGABYTES(1) && blobs[i].size() <= MEGABYTES(4))
+      else if (blobs[i].size() > MEGABYTES(1) &&
+               blobs[i].size() <= MEGABYTES(4))
         split_option = 8;
       else
         split_option = 10;
@@ -102,80 +105,79 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
       int split_range[] = { 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
       std::vector<int> split_choice(split_range, split_range+split_option-1);
 
-     // Random pickup a number from split_choice to split the blob
-     std::uniform_int_distribution<std::mt19937::result_type>
-       position(0, split_choice.size()-1);
-     int split_num = split_choice[position(rng)];
-     std::cout << "split blob into " << split_num << '\n' << std::flush;
+      // Random pickup a number from split_choice to split the blob
+      std::uniform_int_distribution<std::mt19937::result_type>
+        position(0, split_choice.size()-1);
+      int split_num = split_choice[position(rng)];
+      std::cout << "split blob into " << split_num << '\n' << std::flush;
 
-     // Construct the vector for the splitted blob
-     std::vector<size_t> new_blob_size;
-     size_t blob_each_portion {blobs[i].size()/split_num};
-     for (int j {0}; j<split_num-1; ++j) {
-       new_blob_size.push_back(blob_each_portion);
-     }
-     new_blob_size.push_back(blobs[i].size() -
-                             blob_each_portion*(split_num-1));
+      // Construct the vector for the splitted blob
+      std::vector<size_t> new_blob_size;
+      size_t blob_each_portion {blobs[i].size()/split_num};
+      for (int j {0}; j<split_num-1; ++j) {
+        new_blob_size.push_back(blob_each_portion);
+      }
+      new_blob_size.push_back(blobs[i].size() -
+                              blob_each_portion*(split_num-1));
 
-     for (size_t k {0}; k<new_blob_size.size(); ++k) {
-       int dst {state.num_devices};
-       auto itlow = ordered_cap.lower_bound (new_blob_size[k]);
-       if (itlow == ordered_cap.end()) {
-         std::cerr << "No target has enough capacity (max "
-                   << ordered_cap.rbegin()->first
-                   << ") for the blob with size " << new_blob_size[k] << ")\n"
-                   << std::flush;
-       }
+      for (size_t k {0}; k<new_blob_size.size(); ++k) {
+        int dst {state.num_devices};
+        auto itlow = ordered_cap.lower_bound (new_blob_size[k]);
+        if (itlow == ordered_cap.end()) {
+          std::cerr << "No target has enough capacity (max "
+                    << ordered_cap.rbegin()->first
+                    << ") for the blob with size " << new_blob_size[k] << ")\n"
+                    << std::flush;
+        }
 
-       std::uniform_int_distribution<std::mt19937::result_type>
-         dst_distribution((*itlow).second, state.num_devices-1);
-       dst = dst_distribution(rng);
-       result.push_back(std::make_pair(new_blob_size[k], dst));
-       for (auto it=itlow; it!=ordered_cap.end(); ++it) {
-         if ((*it).second == dst) {
-           ordered_cap.insert(std::pair<size_t, size_t>(
-                              (*it).first-new_blob_size[k], (*it).second));
-           ordered_cap.erase(it);
-           break;
-         }
-       }
-     }
-   }
-   // Blob size is less than 64KB or do not split
-   else {
-     std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
-     int dst {state.num_devices};
-     auto itlow = ordered_cap.lower_bound (blobs[i].size());
-     if (itlow == ordered_cap.end()) {
-       std::cerr << "No target has enough capacity (max "
-                 << ordered_cap.rbegin()->first << " for the blob with size "
-                 << blobs[i].size() << '\n' << std::flush;
-     }
+        std::uniform_int_distribution<std::mt19937::result_type>
+          dst_distribution((*itlow).second, state.num_devices-1);
+        dst = dst_distribution(rng);
+        result.push_back(std::make_pair(new_blob_size[k], dst));
+        for (auto it=itlow; it!=ordered_cap.end(); ++it) {
+          if ((*it).second == dst) {
+            ordered_cap.insert(std::pair<size_t, size_t>(
+                                 (*it).first-new_blob_size[k], (*it).second));
+            ordered_cap.erase(it);
+            break;
+          }
+        }
+      }
+    }
+    // Blob size is less than 64KB or do not split
+    else {
+      std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
+      int dst {state.num_devices};
+      auto itlow = ordered_cap.lower_bound(blobs[i].size());
+      if (itlow == ordered_cap.end()) {
+        std::cerr << "No target has enough capacity (max "
+                  << ordered_cap.rbegin()->first << " for the blob with size "
+                  << blobs[i].size() << '\n' << std::flush;
+      }
 
-     std::uniform_int_distribution<std::mt19937::result_type>
-       dst_distribution((*itlow).second, state.num_devices-1);
-     dst = dst_distribution(rng);
-     for (auto it=itlow; it!=ordered_cap.end(); ++it) {
-       if ((*it).second == dst) {
-         ordered_cap.insert(std::pair<size_t, size_t>(
-                            (*it).first-blobs[i].size(), (*it).second));
-         ordered_cap.erase(it);
-         break;
-       }
-     }
-     result.push_back(std::make_pair(blobs[i].size(), dst));
+      std::uniform_int_distribution<std::mt19937::result_type>
+        dst_distribution((*itlow).second, state.num_devices-1);
+      dst = dst_distribution(rng);
+      for (auto it=itlow; it != ordered_cap.end(); ++it) {
+        if ((*it).second == dst) {
+          ordered_cap.insert(std::pair<size_t, size_t>(
+                               (*it).first-blobs[i].size(), (*it).second));
+          ordered_cap.erase(it);
+          break;
+        }
+      }
+      result.push_back(std::make_pair(blobs[i].size(), dst));
     }
   }
 
   return result;
 }
 
-int main()
-{
-  hermes::api::Blob p1 (1024*1024, 255);
-  hermes::api::Blob p2 (1024*1024*2, 255);
-  hermes::api::Blob p3 (1024*1024*4, 255);
-  hermes::api::Blob p4 (1024*1024*7, 255);
+int main() {
+  hermes::api::Blob p1(1024*1024, 255);
+  hermes::api::Blob p2(1024*1024*2, 255);
+  hermes::api::Blob p3(1024*1024*4, 255);
+  hermes::api::Blob p4(1024*1024*7, 255);
   std::vector<hermes::api::Blob> input_blobs;
   input_blobs.push_back(p1);
   input_blobs.push_back(p2);
@@ -183,9 +185,10 @@ int main()
   input_blobs.push_back(p4);
 
   InitSystemViewState();
-  
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -197,8 +200,9 @@ int main()
   PlacementSchema schema1 = RandomPlacement(input_blobs);
 
   UpdateSystemViewState(schema1);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -207,9 +211,9 @@ int main()
   }
   std::cout << '\n' << '\n' << std::flush;
 
-  hermes::api::Blob p5 (1024*1024*0.5, 255);
-  hermes::api::Blob p6 (1024*1024*20, 255);
-  hermes::api::Blob p7 (1024*1024*4, 255);
+  hermes::api::Blob p5(1024*1024*0.5, 255);
+  hermes::api::Blob p6(1024*1024*20, 255);
+  hermes::api::Blob p7(1024*1024*4, 255);
   input_blobs.clear();
   input_blobs.push_back(p5);
   input_blobs.push_back(p6);
@@ -217,8 +221,9 @@ int main()
   PlacementSchema schema2 = RandomPlacement(input_blobs);
 
   UpdateSystemViewState(schema2);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -227,11 +232,11 @@ int main()
   }
   std::cout << '\n' << '\n' << std::flush;
 
-  hermes::api::Blob p8 (1024*1024*0.5, 255);
-  hermes::api::Blob p9 (1024*1024*20, 255);
-  hermes::api::Blob p10 (1024*1024*1, 255);
-  hermes::api::Blob p11 (1024*1024*4, 255);
-  hermes::api::Blob p12 (1024*1024*10, 255);
+  hermes::api::Blob p8(1024*1024*0.5, 255);
+  hermes::api::Blob p9(1024*1024*20, 255);
+  hermes::api::Blob p10(1024*1024*1, 255);
+  hermes::api::Blob p11(1024*1024*4, 255);
+  hermes::api::Blob p12(1024*1024*10, 255);
   input_blobs.clear();
   input_blobs.push_back(p8);
   input_blobs.push_back(p9);
@@ -241,8 +246,9 @@ int main()
   PlacementSchema schema3 = RandomPlacement(input_blobs);
 
   UpdateSystemViewState(schema3);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/

--- a/test/dpe_roundrobin_test.cc
+++ b/test/dpe_roundrobin_test.cc
@@ -6,7 +6,7 @@
 
 #include "hermes.h"
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 namespace hermes {
 namespace testing {
@@ -18,8 +18,8 @@ struct SystemViewState {
   u64 bandwidth[kMaxDevices];
   int num_devices;
 };
-}  // namespace hermes
 }  // namespace testing
+}  // namespace hermes
 
 testing::SystemViewState InitSystemViewState() {
   testing::SystemViewState result = {};
@@ -66,7 +66,7 @@ void UpdateSystemViewState(PlacementSchema schema) {
 
 PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
   PlacementSchema result;
-  // TODO (KIMMY): use kernel function of system view
+  // TODO(KIMMY): use kernel function of system view
   testing::SystemViewState state {GetSystemViewState()};
   std::multimap<u64, int> ordered_cap;
 
@@ -75,11 +75,12 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
     std::random_device dev;
     std::mt19937 rng(dev());
     int number {0};
-    
+
     // If size is greater than 64KB
     // Decision about split the blob or not
     if (blobs[i].size() > KILOBYTES(64)) {
-      std::uniform_int_distribution<std::mt19937::result_type> distribution(0,1);
+      std::uniform_int_distribution<std::mt19937::result_type>
+        distribution(0, 1);
       number = distribution(rng);
     }
 
@@ -90,9 +91,11 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
       // Not split the blob if size is less than 64KB
       if (blobs[i].size() > KILOBYTES(64) && blobs[i].size() <= KILOBYTES(256))
         split_option = 2;
-      else if (blobs[i].size() > KILOBYTES(256) && blobs[i].size() <= MEGABYTES(1))
+      else if (blobs[i].size() > KILOBYTES(256) &&
+               blobs[i].size() <= MEGABYTES(1))
         split_option = 5;
-      else if (blobs[i].size() > MEGABYTES(1) && blobs[i].size() <= MEGABYTES(4))
+      else if (blobs[i].size() > MEGABYTES(1) &&
+               blobs[i].size() <= MEGABYTES(4))
         split_option = 8;
       else
         split_option = 10;
@@ -109,13 +112,13 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
      // Construct the vector for the splitted blob
      std::vector<size_t> new_blob_size;
      size_t blob_each_portion {blobs[i].size()/split_num};
-     for (int j {0}; j<split_num-1; ++j) {
+     for (int j {0}; j < split_num - 1; ++j) {
        new_blob_size.push_back(blob_each_portion);
      }
      new_blob_size.push_back(blobs[i].size() -
                              blob_each_portion*(split_num-1));
 
-     for (size_t k {0}; k<new_blob_size.size(); ++k) {
+     for (size_t k {0}; k < new_blob_size.size(); ++k) {
        int dst {state.num_devices};
        size_t device_pos {hermes::testing::COUNT_DEVICE};
        for (int j {0}; j < state.num_devices; ++j) {
@@ -132,9 +135,8 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
          std::cerr << "Device not found for the splitted blob!\n";
        }
      }
-   }
-   // Blob size is less than 64KB or do not split
-   else {
+    } else {
+     // Blob size is less than 64KB or do not split
      int dst {state.num_devices};
      size_t device_pos {hermes::testing::COUNT_DEVICE};
      for (int j {0}; j < state.num_devices; ++j) {
@@ -156,12 +158,11 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
   return result;
 }
 
-int main()
-{
-  hermes::api::Blob p1 (1024*1024, 255);
-  hermes::api::Blob p2 (1024*1024*2, 255);
-  hermes::api::Blob p3 (1024*1024*4, 255);
-  hermes::api::Blob p4 (1024*1024*7, 255);
+int main() {
+  hermes::api::Blob p1(1024*1024, 255);
+  hermes::api::Blob p2(1024*1024*2, 255);
+  hermes::api::Blob p3(1024*1024*4, 255);
+  hermes::api::Blob p4(1024*1024*7, 255);
   std::vector<hermes::api::Blob> input_blobs;
   input_blobs.push_back(p1);
   input_blobs.push_back(p2);
@@ -169,9 +170,10 @@ int main()
   input_blobs.push_back(p4);
 
   InitSystemViewState();
-  
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -183,8 +185,9 @@ int main()
   PlacementSchema schema1 = RoundRobinPlacement(input_blobs);
 
   UpdateSystemViewState(schema1);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -193,9 +196,9 @@ int main()
   }
   std::cout << '\n' << '\n' << std::flush;
 
-  hermes::api::Blob p5 (1024*1024*0.5, 255);
-  hermes::api::Blob p6 (1024*1024*20, 255);
-  hermes::api::Blob p7 (1024*1024*4, 255);
+  hermes::api::Blob p5(1024*1024*0.5, 255);
+  hermes::api::Blob p6(1024*1024*20, 255);
+  hermes::api::Blob p7(1024*1024*4, 255);
   input_blobs.clear();
   input_blobs.push_back(p5);
   input_blobs.push_back(p6);
@@ -203,8 +206,9 @@ int main()
   PlacementSchema schema2 = RoundRobinPlacement(input_blobs);
 
   UpdateSystemViewState(schema2);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/
@@ -213,11 +217,11 @@ int main()
   }
   std::cout << '\n' << '\n' << std::flush;
 
-  hermes::api::Blob p8 (1024*1024*0.5, 255);
-  hermes::api::Blob p9 (1024*1024*20, 255);
-  hermes::api::Blob p10 (1024*1024*1, 255);
-  hermes::api::Blob p11 (1024*1024*4, 255);
-  hermes::api::Blob p12 (1024*1024*10, 255);
+  hermes::api::Blob p8(1024*1024*0.5, 255);
+  hermes::api::Blob p9(1024*1024*20, 255);
+  hermes::api::Blob p10(1024*1024*1, 255);
+  hermes::api::Blob p11(1024*1024*4, 255);
+  hermes::api::Blob p12(1024*1024*10, 255);
   input_blobs.clear();
   input_blobs.push_back(p8);
   input_blobs.push_back(p9);
@@ -227,8 +231,9 @@ int main()
   PlacementSchema schema3 = RoundRobinPlacement(input_blobs);
 
   UpdateSystemViewState(schema3);
-  for(int i {0}; i < globalSystemViewState.num_devices; ++i) {
-    std::cout << "device[" << i << "]: " << globalSystemViewState.bytes_available[i]
+  for (int i {0}; i < globalSystemViewState.num_devices; ++i) {
+    std::cout << "device[" << i << "]: "
+              << globalSystemViewState.bytes_available[i]
               << '\n' << std::flush;
     std::cout << "available ratio["<< i << "]: "
               << static_cast<double>(globalSystemViewState.bytes_available[i])/

--- a/test/end_to_end_test.cc
+++ b/test/end_to_end_test.cc
@@ -12,7 +12,7 @@ void TestPutGetBucket(hapi::Bucket &bucket, int app_rank, int app_size) {
   size_t bytes_per_rank = KILOBYTES(8);
   if (app_size) {
     size_t data_size = KILOBYTES(8);
-    bytes_per_rank = data_size / app_size ;
+    bytes_per_rank = data_size / app_size;
     size_t remaining_bytes = data_size % app_size;
 
     if (app_rank == app_size - 1) {
@@ -68,7 +68,6 @@ void TestBulkTransfer(std::shared_ptr<hapi::Hermes> hermes, int app_rank) {
 }
 
 int main(int argc, char **argv) {
-
   int mpi_threads_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
   if (mpi_threads_provided < MPI_THREAD_MULTIPLE) {

--- a/test/memory_test.cc
+++ b/test/memory_test.cc
@@ -1,7 +1,7 @@
 #include "test_utils.h"
 #include "memory_management.h"
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 const int kNumVals = 8;
 
@@ -21,7 +21,6 @@ void CheckArrayU64(SixtyFourBytes *s, u64 val) {
   }
 }
 void TestFillFreeBlocks(Heap *heap) {
-
   SixtyFourBytes *s1 = HeapPushStruct<SixtyFourBytes>(heap);
   FillArrayU64(s1, 1);
   SixtyFourBytes *s2 = HeapPushStruct<SixtyFourBytes>(heap);
@@ -68,8 +67,6 @@ void TestFillFreeBlocks(Heap *heap) {
 }
 
 int main() {
-
-
   Arena arena = InitArenaAndAllocate(KILOBYTES(4));
 
   TemporaryMemory temporary_memory = BeginTemporaryMemory(&arena);

--- a/test/mpi_test.c
+++ b/test/mpi_test.c
@@ -4,16 +4,15 @@
 
 #include "gotcha_mpi_io.h"
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   MPI_File fh;
   int buf[1000], rank;
 
   init_gotcha_mpi_io();
 
-  MPI_Init(0,0);
+  MPI_Init(0, 0);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  MPI_File_open(MPI_COMM_WORLD, "test.out", 
+  MPI_File_open(MPI_COMM_WORLD, "test.out",
                 MPI_MODE_CREATE|MPI_MODE_WRONLY, MPI_INFO_NULL, &fh);
 
   if (rank == 0)

--- a/test/stb_map_test.cc
+++ b/test/stb_map_test.cc
@@ -12,10 +12,9 @@
 #define STB_DS_IMPLEMENTATION
 #include "stb_ds.h"
 
-using namespace hermes;
+using namespace hermes;  // NOLINT(*)
 
 int main() {
-
   Arena arena = InitArenaAndAllocate(MEGABYTES(32));
   TemporaryMemory temp_memory = BeginTemporaryMemory(&arena);
   Heap *heap = InitHeapInArena(&arena, true, 8);

--- a/test/stdio_test.c
+++ b/test/stdio_test.c
@@ -3,14 +3,14 @@
 
 #include "gotcha_stdio.h"
 
-int main () {
+int main() {
   FILE * pFile;
   char buffer[] = { 'x' , 'y' , 'z' };
 
   init_gotcha_stdio();
 
-  pFile = fopen ("myfile.bin", "wb");
-  fwrite (buffer , sizeof(char), sizeof(buffer), pFile);
-  fclose (pFile);
+  pFile = fopen("myfile.bin", "wb");
+  fwrite(buffer , sizeof(char), sizeof(buffer), pFile);
+  fclose(pFile);
   return 0;
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -12,7 +12,7 @@ namespace testing {
 // TODO(chogan): Keep time in generic units and only convert the duration at the
 // end
 class Timer {
-public:
+ public:
   Timer():elapsed_time(0) {}
   void resumeTime() {
     t1 = std::chrono::high_resolution_clock::now();
@@ -25,7 +25,7 @@ public:
   double getElapsedTime() {
     return elapsed_time;
   }
-private:
+ private:
   std::chrono::high_resolution_clock::time_point t1;
   double elapsed_time;
 };


### PR DESCRIPTION
* Aligned the code base with the Google style guide.
* Added a cpplint step to the workflow, so CI will tell us if the style is off.
* Added a cmake target to run the linter. Just run `make lint`(assuming you've run `pip install cpplint`).

@jya-kmu , This will probably make it annoying to merge your DPE testing, so we can wait to merge this PR until you are finished with that work if you want. Also, if there is anything you find especially annoying about the Google style, feel free to exclude it from the checks. Just add the category to the `filter` key in `CPPLINT.cfg`.