### PR TITLE
Pass policy via Context

### DIFF
--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -64,7 +64,16 @@ class Bucket;
 
 typedef std::vector<unsigned char> Blob;
 
-class Context {
+enum class PlacementPolicy {
+  kRandom,
+  kTopDown,
+  kMinimizeIoTime,
+};
+
+struct Context {
+  PlacementPolicy policy;
+
+  Context() : policy(PlacementPolicy::kRandom) {}
 };
 
 struct TraitTag{};

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -17,12 +17,6 @@ namespace hermes {
 
 using hermes::api::Status;
 
-enum class PlacementPolicy {
-  kRandom,
-  kTopDown,
-  kMinimizeIoTime,
-};
-
 // TODO(chogan): Unfinished sketch
 Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
                         std::vector<size_t> blob_sizes,
@@ -332,19 +326,16 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
   // TODO(chogan): Return a PlacementSchema that minimizes a cost function F given
   // a set of N Devices and a blob, while satisfying a policy P.
 
-  // TODO(chogan): This should be part of the Context
-  PlacementPolicy policy = PlacementPolicy::kRandom;
-
-  switch (policy) {
-    case PlacementPolicy::kRandom: {
+  switch (api_context.policy) {
+    case api::PlacementPolicy::kRandom: {
       result = RandomPlacement(context, rpc, blob_sizes, output);
       break;
     }
-    case PlacementPolicy::kTopDown: {
+    case api::PlacementPolicy::kTopDown: {
       result = TopDownPlacement(context, rpc, blob_sizes, output);
       break;
     }
-    case PlacementPolicy::kMinimizeIoTime: {
+    case api::PlacementPolicy::kMinimizeIoTime: {
       result = MinimizeIoTimePlacement(context, rpc, blob_sizes, output);
       break;
     }

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -34,7 +34,6 @@ struct TimingResult {
 };
 
 TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
-
   TimingResult result = {};
   PlacementSchema schema{std::make_pair(4096, 0)};
 

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -34,6 +34,7 @@ struct TimingResult {
 };
 
 TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
+
   TimingResult result = {};
   PlacementSchema schema{std::make_pair(4096, 0)};
 


### PR DESCRIPTION
* Allow passing the `PlacementPolicy` to the DPE via the `api::Context`. Defaults to random placement.
* Allow passing a `Config` to `InitHermes`. This should make testing more convenient. If you want the default config but with a few customized fields, you can do something like this:
```cpp
Config config = {};
InitDefaultConfig(&config);
config.capacities[0] = xx;
config.capacities[1] = yy;
config.capacities[2] = zz;

std::shared_ptr<hapi::Hermes> hermes = InitHermes(&config);
```
This might be more convenient than having a lot of `*.conf` files for each test, each of which repeating a lot of data.