### PR TITLE
Add BufferOrganizer and Swap Space

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -45,6 +45,9 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
         blobs[0][i] = data[i];
       }
       ret = PlaceBlobs(schemas, blobs, names);
+    } else {
+      // TODO(chogan): Trigger BufferOrganizer
+      // TODO(chogan): Set Status
     }
   }
 

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -46,8 +46,15 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
       }
       ret = PlaceBlobs(schemas, blobs, names);
     } else {
-      // TODO(chogan): Trigger BufferOrganizer
-      // TODO(chogan): Set Status
+      hermes::Blob blob = {};
+      blob.data = (u8 *)data;
+      blob.size = size;
+      SwapBlob swap_blob =  WriteToSwap(&hermes_->context_, blob, name,
+                                        hermes_->rpc_.node_id);
+      UpdateSwapMetadata(&hermes_->context_, (char *)name.c_str(), swap_blob);
+      // TODO(chogan): TriggerBufferOrganizer(swap_blob);
+      // TODO(chogan): Signify in Status that the Blob went to swap space
+      ret = 0;
     }
   }
 

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -123,7 +123,6 @@ size_t Bucket::Get(const std::string &name, Blob &user_blob, Context &ctx) {
                                               &buffer_sizes);
         ret = ReadBlobFromBuffers(&hermes_->context_, &hermes_->rpc_, &blob,
                                   &buffer_ids, buffer_sizes);
-
       }
     }
   }

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -7,7 +7,6 @@
 #include "metadata_management.h"
 #include "data_placement_engine.h"
 
-
 namespace hermes {
 
 namespace api {
@@ -46,15 +45,7 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
       }
       ret = PlaceBlobs(schemas, blobs, names);
     } else {
-      hermes::Blob blob = {};
-      blob.data = (u8 *)data;
-      blob.size = size;
-
-      u32 target_node = hermes_->rpc_.node_id;
-      SwapBlob swap_blob =  WriteToSwap(&hermes_->context_, blob, target_node);
-      std::vector<BufferID> buffer_ids = SwapBlobToVec(swap_blob);
-      AttachBlobToBucket(&hermes_->context_, &hermes_->rpc_, name.c_str(),
-                         id_, buffer_ids, true);
+      PutToSwap(&hermes_->context_, &hermes_->rpc_, name, id_, data, size);
       // TriggerBufferOrganizer(&hermes_->rpc_, swap_blob);
       ret = 0;
       // TODO(chogan): @errorhandling Signify in Status that the Blob went to

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -52,7 +52,7 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
         retries = ctx.buffer_organizer_retries;
       }
 
-      TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, swap_blob,
+      TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, name, swap_blob,
                              retries);
       ret = 0;
       // TODO(chogan): @errorhandling Signify in Status that the Blob went to

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -50,14 +50,15 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
       blob.data = (u8 *)data;
       blob.size = size;
 
-      MetadataManager *mdm = GetMetadataManagerFromContext(&hermes_->context_);
-      u32 target_node = HashString(mdm, &hermes_->rpc_, name.c_str());
+      u32 target_node = hermes_->rpc_.node_id;
       SwapBlob swap_blob =  WriteToSwap(&hermes_->context_, blob, target_node);
-      UpdateSwapMetadata(&hermes_->context_, &hermes_->rpc_, name.c_str(),
-                         swap_blob);
-      // TODO(chogan): TriggerBufferOrganizer(swap_blob);
-      // TODO(chogan): Signify in Status that the Blob went to swap space
+      std::vector<BufferID> buffer_ids = SwapBlobToVec(swap_blob);
+      AttachBlobToBucket(&hermes_->context_, &hermes_->rpc_, name.c_str(),
+                         id_, buffer_ids, true);
+      // TriggerBufferOrganizer(&hermes_->rpc_, swap_blob);
       ret = 0;
+      // TODO(chogan): @errorhandling Signify in Status that the Blob went to
+      // swap space
     }
   }
 

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -47,13 +47,8 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
     } else {
       SwapBlob swap_blob = PutToSwap(&hermes_->context_, &hermes_->rpc_, name,
                                      id_, data, size);
-      int retries = Context::default_buffer_organizer_retries;
-      if (ctx.buffer_organizer_retries != retries) {
-        retries = ctx.buffer_organizer_retries;
-      }
-
       TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, name, swap_blob,
-                             retries);
+                             ctx.buffer_organizer_retries);
       ret = 0;
       // TODO(chogan): @errorhandling Signify in Status that the Blob went to
       // swap space

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -49,9 +49,12 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
       hermes::Blob blob = {};
       blob.data = (u8 *)data;
       blob.size = size;
-      SwapBlob swap_blob =  WriteToSwap(&hermes_->context_, blob, name,
-                                        hermes_->rpc_.node_id);
-      UpdateSwapMetadata(&hermes_->context_, (char *)name.c_str(), swap_blob);
+
+      MetadataManager *mdm = GetMetadataManagerFromContext(&hermes_->context_);
+      u32 target_node = HashString(mdm, &hermes_->rpc_, name.c_str());
+      SwapBlob swap_blob =  WriteToSwap(&hermes_->context_, blob, target_node);
+      UpdateSwapMetadata(&hermes_->context_, &hermes_->rpc_, name.c_str(),
+                         swap_blob);
       // TODO(chogan): TriggerBufferOrganizer(swap_blob);
       // TODO(chogan): Signify in Status that the Blob went to swap space
       ret = 0;

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -173,7 +173,7 @@ Status Bucket::Put(std::vector<std::string> &names,
         PutToSwap(&hermes_->context_, &hermes_->rpc_, id_, blobs, names);
 
       for (int i = 0; i < swapped_blobs.size(); ++i) {
-        TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy,
+        TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, names[i],
                                swapped_blobs[i], ctx.buffer_organizer_retries);
       }
       ret = 0;

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -75,6 +75,9 @@ class Bucket {
   Status Put(std::vector<std::string> &names,
              std::vector<std::vector<T>> &blobs, Context &ctx);
 
+  /** Get the size in bytes of the Blob referred to by `name` */
+  size_t GetBlobSize(Arena *arena, const std::string &name, Context &ctx);
+
   /** get a blob on this bucket */
   /** - if user_blob.size() == 0 => return the minimum buffer size needed */
   /** - if user_blob.size() > 0 => copy user_blob.size() bytes */

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -177,8 +177,15 @@ Status Bucket::Put(std::vector<std::string> &names,
     if (ret == 0) {
       ret = PlaceBlobs(schemas, blobs, names);
     } else {
-      // TODO(chogan): Trigger BufferOrganizer
-      // TODO(chogan): Set Status
+      std::vector<SwapBlob> swapped_blobs =
+        PutToSwap(&hermes_->context_, &hermes_->rpc_, id_, blobs, names);
+
+      for (int i = 0; i < swapped_blobs.size(); ++i) {
+        // TODO(chogan): TriggerBufferOrganizer()
+      }
+      ret = 0;
+      // TODO(chogan): @errorhandling Signify in Status that the Blobs went to
+      // swap space
     }
   } else {
     // TODO(chogan): @errorhandling

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -100,6 +100,9 @@ class Bucket {
   /** Returns true if the Bucket contains a Blob called `name` */
   bool ContainsBlob(const std::string &name);
 
+  /** Returns true if the Blob called `name` in this bucket is in swap space */
+  bool BlobIsInSwap(const std::string &name);
+
   /** get a list of blob names filtered by pred */
   template<class Predicate>
   std::vector<std::string> GetBlobNames(Predicate pred, Context &ctx);

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -136,23 +136,12 @@ Status Bucket::PlaceBlobs(std::vector<PlacementSchema> &schemas,
   for (size_t i = 0; i < schemas.size(); ++i) {
     PlacementSchema &schema = schemas[i];
     if (schema.size()) {
-      std::vector<BufferID> buffer_ids = GetBuffers(&hermes_->context_, schema);
-      if (buffer_ids.size()) {
-        LOG(INFO) << "Attaching blob " << names[i] << " to Bucket "
-                  << name_ << std::endl;
-        hermes::Blob blob = {};
-        blob.data = (u8 *)blobs[i].data();
-        blob.size = blobs[i].size() * sizeof(T);
-        WriteBlobToBuffers(&hermes_->context_, &hermes_->rpc_, blob,
-                           buffer_ids);
-
-        // NOTE(chogan): Update all metadata associated with this Put
-        AttachBlobToBucket(&hermes_->context_, &hermes_->rpc_, names[i].c_str(),
-                           id_, buffer_ids);
-      } else {
-        // TODO(chogan): @errorhandling
-        result = 1;
-      }
+      hermes::Blob blob = {};
+      blob.data = (u8 *)blobs[i].data();
+      blob.size = blobs[i].size() * sizeof(T);
+      // TODO(chogan): @errorhandling What about partial failure?
+      result = PlaceBlob(&hermes_->context_, &hermes_->rpc_, schema, blob,
+                         names[i].c_str(), id_);
     } else {
       // TODO(chogan): @errorhandling
       result = 1;

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -176,6 +176,9 @@ Status Bucket::Put(std::vector<std::string> &names,
 
     if (ret == 0) {
       ret = PlaceBlobs(schemas, blobs, names);
+    } else {
+      // TODO(chogan): Trigger BufferOrganizer
+      // TODO(chogan): Set Status
     }
   } else {
     // TODO(chogan): @errorhandling

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -184,7 +184,8 @@ Status Bucket::Put(std::vector<std::string> &names,
         PutToSwap(&hermes_->context_, &hermes_->rpc_, id_, blobs, names);
 
       for (int i = 0; i < swapped_blobs.size(); ++i) {
-        // TODO(chogan): TriggerBufferOrganizer()
+        TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy,
+                               swapped_blobs[i], ctx.buffer_organizer_retries);
       }
       ret = 0;
       // TODO(chogan): @errorhandling Signify in Status that the Blobs went to

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -225,18 +225,18 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
     std::string host_number = GetHostNumberAsString(&result->rpc_,
                                                     result->rpc_.node_id);
 
-    std::string rpc_server_addr = config->rpc_protocol + "://";
-
-    if (!config->rpc_domain.empty()) {
-      rpc_server_addr += config->rpc_domain + "/";
-    }
-    rpc_server_addr += (config->rpc_server_base_name + host_number +
-                        config->rpc_server_suffix + ":" +
-                        std::to_string(config->rpc_port));
-
+    std::string rpc_server_addr = GetRpcAddress(config, host_number,
+                                                config->rpc_port);
     result->rpc_.start_server(&result->context_, &result->rpc_,
                               &result->trans_arena_, rpc_server_addr.c_str(),
                               config->rpc_num_threads);
+
+    std::string bo_address = GetRpcAddress(config, host_number,
+                                           config->buffer_organizer_port);
+    int bo_threads = 1;
+    StartBufferOrganizer(&result->context_, &result->rpc_, bo_address.c_str(),
+                         bo_threads);
+
     double sleep_ms = config->system_view_state_update_interval_ms;
     StartGlobalSystemViewStateUpdateThread(&result->context_, &result->rpc_,
                                            &result->trans_arena_,

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -242,7 +242,7 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
                                            config->buffer_organizer_port);
     int bo_threads = 1;
     StartBufferOrganizer(&result->context_, &result->rpc_, bo_address.c_str(),
-                         bo_threads);
+                         bo_threads, config->buffer_organizer_port);
 
     double sleep_ms = config->system_view_state_update_interval_ms;
     StartGlobalSystemViewStateUpdateThread(&result->context_, &result->rpc_,

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -135,7 +135,7 @@ SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
   mdm->rpc_state_offset = (u8 *)rpc->state - shmem_base;
 
   InitMetadataManager(mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
-  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config);
+  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
 
   // NOTE(chogan): Store the metadata_manager_offset right after the
   // buffer_pool_offset so other processes can pick it up.

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -14,6 +14,8 @@ namespace hermes {
 
 namespace api {
 
+int Context::default_buffer_organizer_retries = 3;
+
 Status RenameBucket(const std::string &old_name,
                     const std::string &new_name,
                     Context &ctx) {
@@ -247,6 +249,9 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
                                            &result->trans_arena_,
                                            sleep_ms);
   }
+
+  api::Context::default_buffer_organizer_retries =
+    config->num_buffer_organizer_retries;
 
   WorldBarrier(&comm);
 

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -135,7 +135,8 @@ SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
   mdm->rpc_state_offset = (u8 *)rpc->state - shmem_base;
 
   InitMetadataManager(mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
-  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
+  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config,
+                      comm->node_id);
 
   // NOTE(chogan): Store the metadata_manager_offset right after the
   // buffer_pool_offset so other processes can pick it up.

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -14,7 +14,7 @@ namespace hermes {
 
 namespace api {
 
-int Context::default_buffer_organizer_retries = 3;
+int Context::default_buffer_organizer_retries;
 
 Status RenameBucket(const std::string &old_name,
                     const std::string &new_name,
@@ -240,6 +240,7 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
 
     std::string bo_address = GetRpcAddress(config, host_number,
                                            config->buffer_organizer_port);
+    // TODO(chogan): @config Probably want a configuration variable for this.
     int bo_threads = 1;
     StartBufferOrganizer(&result->context_, &result->rpc_, bo_address.c_str(),
                          bo_threads, config->buffer_organizer_port);

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -73,9 +73,13 @@ enum class PlacementPolicy {
 };
 
 struct Context {
-  PlacementPolicy policy;
+  static int default_buffer_organizer_retries;
 
-  Context() : policy(PlacementPolicy::kRoundRobin) {}
+  PlacementPolicy policy;
+  int buffer_organizer_retries;
+
+  Context() : policy(PlacementPolicy::kRoundRobin),
+              buffer_organizer_retries(default_buffer_organizer_retries) {}
 };
 
 struct TraitTag{};

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -17,8 +17,6 @@
 namespace hermes {
 namespace api {
 
-typedef int Status;
-
 class Hermes {
  public:
   std::set<std::string> bucket_list_;

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -103,6 +103,7 @@ std::shared_ptr<api::Hermes> InitHermes(const char *config_file = NULL,
 }  // namespace api
 
 std::shared_ptr<api::Hermes> InitHermesDaemon(char *config_file = NULL);
+std::shared_ptr<api::Hermes> InitHermesDaemon(Config *config);
 std::shared_ptr<api::Hermes> InitHermesClient(const char *config_file = NULL);
 
 }  // namespace hermes

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -6,17 +6,18 @@ namespace hermes {
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                      SwapBlob swap_blob, const std::string &name) {
   int result = 0;
-  std::vector<u8> blob_mem(swap_blob.size);
-  Blob blob = {};
-  blob.data = blob_mem.data();
-  blob.size = blob_mem.size();
-  size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
-
   std::vector<PlacementSchema> schemas;
-  std::vector<size_t> sizes(1, blob.size);
+  std::vector<size_t> sizes(1, swap_blob.size);
   api::Context ctx;
   Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
+
   if (ret == 0) {
+    std::vector<u8> blob_mem(swap_blob.size);
+    Blob blob = {};
+    blob.data = blob_mem.data();
+    blob.size = blob_mem.size();
+    size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
+
     ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
                     swap_blob.bucket_id);
   } else {

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -3,29 +3,6 @@
 
 namespace hermes {
 
-Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
-                 PlacementSchema &schema, Blob blob, char *name,
-                 BucketID bucket_id) {
-  Status result = 0;
-  std::vector<BufferID> buffer_ids = GetBuffers(context, schema);
-  if (buffer_ids.size()) {
-    MetadataManager *mdm = GetMetadataManagerFromContext(context);
-    char *bucket_name = ReverseGetFromStorage(mdm, bucket_id.as_int,
-                                              kMapType_Bucket);
-    LOG(INFO) << "Attaching blob " << name << " to Bucket "
-              << bucket_name << std::endl;
-    WriteBlobToBuffers(context, rpc, blob, buffer_ids);
-
-    // NOTE(chogan): Update all metadata associated with this Put
-    AttachBlobToBucket(context, rpc, name, bucket_id, buffer_ids);
-  } else {
-    // TODO(chogan): @errorhandling
-    result = 1;
-  }
-
-  return result;
-}
-
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                       SwapBlob swap_blob) {
   int result = 0;
@@ -38,7 +15,7 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
   std::vector<PlacementSchema> schemas;
   std::vector<size_t> sizes(1, blob.size);
   api::Context ctx;
-  api::Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
+  Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
   if (ret == 0) {
     MetadataManager *mdm = GetMetadataManagerFromContext(context);
     char *name = ReverseGetFromStorage(mdm, swap_blob.blob_id.as_int,

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -1,10 +1,47 @@
+#include "hermes.h"
+#include "data_placement_engine.h"
 
-void PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc) {
+namespace hapi = hermes::api;
+
+namespace hermes {
+
+int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
+                      SwapBlob swap_blob) {
+  int result = 0;
   // Read data from PFS into blob
-  // Call Put on that blob
+  std::vector<u8> blob_mem(swap_blob.size);
+  Blob blob = {};
+  blob.data = blob_mem.data();
+  blob.size = blob_mem.size();
+  size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
+
+  // std::vector<PlacementSchema> schemas;
+  // std::vector<size_t> sizes;
+  // api::Context ctx;
+  // api::Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
+  // if (ret == 0) {
+  //   std::vector<std::string> names(1, name);
+  //   std::vector<std::vector<u8>> blobs(1);
+  //   blobs[0].resize(size);
+  //   // TODO(chogan): Create a PreallocatedMemory allocator for std::vector so
+  //   // that a single-blob-Put doesn't perform a copy
+  //   for (size_t i = 0; i < size; ++i) {
+  //     blobs[0][i] = data[i];
+  //   }
+  //   ret = PlaceBlobs(schemas, blobs, names);
+  // } else {
+    // TODO(chogan): @errorhandling
+  // }
+
+  return result;
 }
 
-void MoveToTarget(SharedMemoryContext *context, RpcContext *rpc,
-                  TargetID dest) {
-  // Move blob from current location to dest
+int MoveToTarget(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id,
+                 TargetID dest) {
+// TODO(chogan): Move blob from current location to Target dest
+  HERMES_NOT_IMPLEMENTED_YET;
+  int result = 0;
+  return result;
 }
+
+}  // namespace hermes

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -1,0 +1,8 @@
+
+void PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc) {
+  
+}
+
+void MoveToTarget(SharedMemoryContext *context, RpcContext *rpc) {
+  
+}

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -4,7 +4,7 @@
 namespace hermes {
 
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                      SwapBlob swap_blob) {
+                     SwapBlob swap_blob, const std::string &name) {
   int result = 0;
   std::vector<u8> blob_mem(swap_blob.size);
   Blob blob = {};
@@ -17,10 +17,8 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
   api::Context ctx;
   Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
   if (ret == 0) {
-    MetadataManager *mdm = GetMetadataManagerFromContext(context);
-    char *name = ReverseGetFromStorage(mdm, swap_blob.blob_id.as_int,
-                                       kMapType_Blob);
-    ret = PlaceBlob(context, rpc, schemas[0], blob, name, swap_blob.bucket_id);
+    ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
+                    swap_blob.bucket_id);
   } else {
     // TODO(chogan): @errorhandling
     result = 1;

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -1,8 +1,10 @@
 
 void PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc) {
-  
+  // Read data from PFS into blob
+  // Call Put on that blob
 }
 
-void MoveToTarget(SharedMemoryContext *context, RpcContext *rpc) {
-  
+void MoveToTarget(SharedMemoryContext *context, RpcContext *rpc,
+                  TargetID dest) {
+  // Move blob from current location to dest
 }

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -1,37 +1,53 @@
 #include "hermes.h"
 #include "data_placement_engine.h"
 
-namespace hapi = hermes::api;
-
 namespace hermes {
+
+Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
+                 PlacementSchema &schema, Blob blob, char *name,
+                 BucketID bucket_id) {
+  Status result = 0;
+  std::vector<BufferID> buffer_ids = GetBuffers(context, schema);
+  if (buffer_ids.size()) {
+    MetadataManager *mdm = GetMetadataManagerFromContext(context);
+    char *bucket_name = ReverseGetFromStorage(mdm, bucket_id.as_int,
+                                              kMapType_Bucket);
+    LOG(INFO) << "Attaching blob " << name << " to Bucket "
+              << bucket_name << std::endl;
+    WriteBlobToBuffers(context, rpc, blob, buffer_ids);
+
+    // NOTE(chogan): Update all metadata associated with this Put
+    AttachBlobToBucket(context, rpc, name, bucket_id, buffer_ids);
+  } else {
+    // TODO(chogan): @errorhandling
+    result = 1;
+  }
+
+  return result;
+}
 
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                       SwapBlob swap_blob) {
   int result = 0;
-  // Read data from PFS into blob
   std::vector<u8> blob_mem(swap_blob.size);
   Blob blob = {};
   blob.data = blob_mem.data();
   blob.size = blob_mem.size();
   size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
 
-  // std::vector<PlacementSchema> schemas;
-  // std::vector<size_t> sizes;
-  // api::Context ctx;
-  // api::Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
-  // if (ret == 0) {
-  //   std::vector<std::string> names(1, name);
-  //   std::vector<std::vector<u8>> blobs(1);
-  //   blobs[0].resize(size);
-  //   // TODO(chogan): Create a PreallocatedMemory allocator for std::vector so
-  //   // that a single-blob-Put doesn't perform a copy
-  //   for (size_t i = 0; i < size; ++i) {
-  //     blobs[0][i] = data[i];
-  //   }
-  //   ret = PlaceBlobs(schemas, blobs, names);
-  // } else {
+  std::vector<PlacementSchema> schemas;
+  std::vector<size_t> sizes(1, blob.size);
+  api::Context ctx;
+  api::Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
+  if (ret == 0) {
+    MetadataManager *mdm = GetMetadataManagerFromContext(context);
+    char *name = ReverseGetFromStorage(mdm, swap_blob.blob_id.as_int,
+                                       kMapType_Blob);
+    ret = PlaceBlob(context, rpc, schemas[0], blob, name, swap_blob.bucket_id);
+  } else {
     // TODO(chogan): @errorhandling
-  // }
+    result = 1;
+  }
 
   return result;
 }

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1511,7 +1511,7 @@ SwapBlob PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
 size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
                   SwapBlob swap_blob) {
   u32 node_id = swap_blob.node_id;
-  if (OpenSwapFile(context, node_id)) {
+  if (OpenSwapFile(context, node_id) == 0) {
     if (fseek(context->swap_file, swap_blob.offset, SEEK_SET) != 0) {
       // TODO(chogan): @errorhandling
       HERMES_NOT_IMPLEMENTED_YET;

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1438,8 +1438,8 @@ size_t ReadBlobFromBuffers(SharedMemoryContext *context, RpcContext *rpc,
   return total_bytes_read;
 }
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
-  SwapBlob result = {};
+int OpenSwapFile(SharedMemoryContext *context, u32 node_id) {
+  int result = 0;
 
   if (!context->swap_file) {
     MetadataManager *mdm = GetMetadataManagerFromContext(context);
@@ -1448,27 +1448,38 @@ SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
 
     if (!context->swap_file) {
       // TODO(chogan): @errorhandling
-      HERMES_NOT_IMPLEMENTED_YET;
+      result = 1;
     }
   }
-  if (fseek(context->swap_file, 0, SEEK_END) != 0) {
-    // TODO(chogan): @errorhandling
-    HERMES_NOT_IMPLEMENTED_YET;
-  }
 
-  result.offset = ftell(context->swap_file);
-  if (result.offset == -1) {
-    // TODO(chogan): @errorhandling
-    HERMES_NOT_IMPLEMENTED_YET;
-  }
+  return result;
+}
 
-  // TODO(chogan): write data
-  if (fwrite(blob.data, 1, blob.size, context->swap_file) != blob.size) {
-    // TODO(chogan): @errorhandling
-    HERMES_NOT_IMPLEMENTED_YET;
-  }
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
+  SwapBlob result = {};
 
-  if (fflush(context->swap_file) != 0) {
+  if (OpenSwapFile(context, node_id) == 0) {
+    if (fseek(context->swap_file, 0, SEEK_END) != 0) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+
+    result.offset = ftell(context->swap_file);
+    if (result.offset == -1) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+
+    if (fwrite(blob.data, 1, blob.size, context->swap_file) != blob.size) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+
+    if (fflush(context->swap_file) != 0) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+  } else {
     // TODO(chogan): @errorhandling
     HERMES_NOT_IMPLEMENTED_YET;
   }
@@ -1492,8 +1503,27 @@ void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
   AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids, true);
 }
 
-void ReadFromSwap(SharedMemoryContext *context, Blob *blob,
+size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
                   SwapBlob swap_blob) {
+
+  if (OpenSwapFile(context, swap_blob.node_id)) {
+    if (fseek(context->swap_file, swap_blob.offset, SEEK_SET) != 0) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+
+    if (fread(blob.data, 1, swap_blob.size, context->swap_file) !=
+        swap_blob.size) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+
+  } else {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  return swap_blob.size;
 }
 
 }  // namespace hermes

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1438,14 +1438,13 @@ size_t ReadBlobFromBuffers(SharedMemoryContext *context, RpcContext *rpc,
   return total_bytes_read;
 }
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob,
-                     const std::string &name, u32 node_id) {
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
   SwapBlob result = {};
 
   if (!context->swap_file) {
     MetadataManager *mdm = GetMetadataManagerFromContext(context);
-    const char *swap_path = GetSwapFilename(mdm);
-    context->swap_file = fopen(swap_path, "a+");
+    std::string swap_path = GetSwapFilename(mdm, node_id);
+    context->swap_file = fopen(swap_path.c_str(), "a+");
 
     if (!context->swap_file) {
       // TODO(chogan): @errorhandling

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1268,10 +1268,19 @@ void ReleaseSharedMemoryContext(SharedMemoryContext *context) {
         int fclose_result = fclose(context->open_streams[device_id][slab]);
         if (fclose_result != 0) {
           // TODO(chogan): @errorhandling
+          HERMES_NOT_IMPLEMENTED_YET;
         }
       }
     }
   }
+
+  if (context->swap_file) {
+    if (fclose(context->swap_file) != 0) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+  }
+
   UnmapSharedMemory(context);
 }
 
@@ -1427,6 +1436,48 @@ size_t ReadBlobFromBuffers(SharedMemoryContext *context, RpcContext *rpc,
   assert(total_bytes_read == blob->size);
 
   return total_bytes_read;
+}
+
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob,
+                     const std::string &name, u32 node_id) {
+  SwapBlob result = {};
+
+  if (!context->swap_file) {
+    MetadataManager *mdm = GetMetadataManagerFromContext(context);
+    const char *swap_path = GetSwapFilename(mdm);
+    context->swap_file = fopen(swap_path, "a+");
+
+    if (!context->swap_file) {
+      // TODO(chogan): @errorhandling
+      HERMES_NOT_IMPLEMENTED_YET;
+    }
+  }
+  if (fseek(context->swap_file, 0, SEEK_END) != 0) {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  result.offset = ftell(context->swap_file);
+  if (result.offset == -1) {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  // TODO(chogan): write data
+  if (fwrite(blob.data, 1, blob.size, context->swap_file) != blob.size) {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  if (fflush(context->swap_file) != 0) {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  result.size = blob.size;
+  result.node_id = node_id;
+
+  return result;
 }
 
 }  // namespace hermes

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1492,7 +1492,8 @@ void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
   AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids, true);
 }
 
-void ReadFromSwap(SharedMemoryContext *context, Blob *blob, SwapBlob swap_blob) {
+void ReadFromSwap(SharedMemoryContext *context, Blob *blob,
+                  SwapBlob swap_blob) {
 }
 
 }  // namespace hermes

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1456,8 +1456,11 @@ int OpenSwapFile(SharedMemoryContext *context, u32 node_id) {
   return result;
 }
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, BlobID blob_id,
+                     BucketID bucket_id) {
   SwapBlob result = {};
+
+  u32 node_id = GetBlobNodeId(blob_id);
 
   if (OpenSwapFile(context, node_id) == 0) {
     if (fseek(context->swap_file, 0, SEEK_END) != 0) {
@@ -1485,8 +1488,9 @@ SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
     HERMES_NOT_IMPLEMENTED_YET;
   }
 
+  result.blob_id = blob_id;
+  result.bucket_id = bucket_id;
   result.size = blob.size;
-  result.node_id = node_id;
 
   return result;
 }
@@ -1508,7 +1512,8 @@ SwapBlob PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
 
 size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
                   SwapBlob swap_blob) {
-  if (OpenSwapFile(context, swap_blob.node_id)) {
+  u32 node_id = GetBlobNodeId(swap_blob.blob_id);
+  if (OpenSwapFile(context, node_id)) {
     if (fseek(context->swap_file, swap_blob.offset, SEEK_SET) != 0) {
       // TODO(chogan): @errorhandling
       HERMES_NOT_IMPLEMENTED_YET;

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -45,6 +45,7 @@
 #endif
 
 #include "metadata_management.cc"
+#include "buffer_organizer.cc"
 
 #if defined(HERMES_MDM_STORAGE_STBDS)
 #include "metadata_storage_stb_ds.cc"
@@ -1490,9 +1491,9 @@ SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
   return result;
 }
 
-void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
-               const std::string &name, BucketID bucket_id, const u8 *data,
-               size_t size) {
+SwapBlob PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
+                   const std::string &name, BucketID bucket_id, const u8 *data,
+                   size_t size) {
   hermes::Blob blob = {};
   blob.data = (u8 *)data;
   blob.size = size;
@@ -1501,6 +1502,8 @@ void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
   SwapBlob swap_blob =  WriteToSwap(context, blob, target_node);
   std::vector<BufferID> buffer_ids = SwapBlobToVec(swap_blob);
   AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids, true);
+
+  return swap_blob;
 }
 
 size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1479,4 +1479,20 @@ SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id) {
   return result;
 }
 
+void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
+               const std::string &name, BucketID bucket_id, const u8 *data,
+               size_t size) {
+  hermes::Blob blob = {};
+  blob.data = (u8 *)data;
+  blob.size = size;
+
+  u32 target_node = rpc->node_id;
+  SwapBlob swap_blob =  WriteToSwap(context, blob, target_node);
+  std::vector<BufferID> buffer_ids = SwapBlobToVec(swap_blob);
+  AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids, true);
+}
+
+void ReadFromSwap(SharedMemoryContext *context, Blob *blob, SwapBlob swap_blob) {
+}
+
 }  // namespace hermes

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1505,7 +1505,6 @@ void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
 
 size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
                   SwapBlob swap_blob) {
-
   if (OpenSwapFile(context, swap_blob.node_id)) {
     if (fseek(context->swap_file, swap_blob.offset, SEEK_SET) != 0) {
       // TODO(chogan): @errorhandling

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -371,9 +371,9 @@ struct Blob {
 };
 
 struct SwapBlob {
+  u32 node_id;
   u64 offset;
   u64 size;
-  BlobID blob_id;
   BucketID bucket_id;
 };
 
@@ -459,7 +459,7 @@ std::vector<f32> GetBandwidths(SharedMemoryContext *context);
 u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                     SwapBlob swap_blob);
+                     SwapBlob swap_blob, const std::string &blob_name);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob, const char *name,
                       BucketID bucket_id);

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -421,7 +421,8 @@ void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
                size_t size);
 
 SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id);
-size_t ReadFromSwap(SharedMemoryContext *context, Blob blob, SwapBlob swap_blob);
+size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
+                    SwapBlob swap_blob);
 
 /**
  * Returns a vector of bandwidths in MiB per second.

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -370,11 +370,23 @@ struct Blob {
   u64 size;
 };
 
+// NOTE(chogan): When adding members to this struct, it is important to also add
+// an entry to the SwapBlobMembers enum below.
 struct SwapBlob {
   u32 node_id;
   u64 offset;
   u64 size;
   BucketID bucket_id;
+};
+
+// TODO(chogan): @metaprogramming Generate this
+enum SwapBlobMembers {
+  SwapBlobMembers_NodeId,
+  SwapBlobMembers_Offset,
+  SwapBlobMembers_Size,
+  SwapBlobMembers_BucketId,
+
+  SwapBlobMembers_Count
 };
 
 /**

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -370,6 +370,15 @@ struct Blob {
   u64 size;
 };
 
+struct SwapBlob {
+  u32 node_id;
+  u64 offset;
+  u64 size;
+};
+
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob,
+                     const std::string &name, u32 node_id);
+
 /**
  * Sketch of how an I/O client might write.
  *

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -460,6 +460,9 @@ u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                      SwapBlob swap_blob);
+api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
+                      PlacementSchema &schema, Blob blob, const char *name,
+                      BucketID bucket_id);
 
 }  // namespace hermes
 

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -418,6 +418,10 @@ size_t LocalWriteBufferById(SharedMemoryContext *context, BufferID id,
 size_t LocalReadBufferById(SharedMemoryContext *context, BufferID id,
                            Blob *blob, size_t offset);
 
+void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
+               const std::string &name, BucketID bucket_id, const u8 *data,
+               size_t size);
+
 /**
  * Returns a vector of bandwidths in MiB per second.
  *

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -374,6 +374,7 @@ struct SwapBlob {
   u32 node_id;
   u64 offset;
   u64 size;
+  BlobID blob_id;
   BucketID bucket_id;
 };
 

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -371,7 +371,6 @@ struct Blob {
 };
 
 struct SwapBlob {
-  u32 node_id;
   u64 offset;
   u64 size;
   BlobID blob_id;
@@ -440,7 +439,8 @@ std::vector<SwapBlob> PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
   return result;
 }
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id);
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, BlobID blob_id,
+                     BucketID bucket_id);
 size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
                     SwapBlob swap_blob);
 

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -376,8 +376,7 @@ struct SwapBlob {
   u64 size;
 };
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob,
-                     const std::string &name, u32 node_id);
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id);
 
 /**
  * Sketch of how an I/O client might write.

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -376,8 +376,6 @@ struct SwapBlob {
   u64 size;
 };
 
-SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id);
-
 /**
  * Sketch of how an I/O client might write.
  *
@@ -421,6 +419,9 @@ size_t LocalReadBufferById(SharedMemoryContext *context, BufferID id,
 void PutToSwap(SharedMemoryContext *context, RpcContext *rpc,
                const std::string &name, BucketID bucket_id, const u8 *data,
                size_t size);
+
+SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id);
+size_t ReadFromSwap(SharedMemoryContext *context, Blob blob, SwapBlob swap_blob);
 
 /**
  * Returns a vector of bandwidths in MiB per second.

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -239,6 +239,7 @@ struct SharedMemoryContext {
   // TODO(chogan): Move these into a FileBufferingContext
   std::vector<std::vector<std::string>> buffering_filenames;
   FILE *open_streams[kMaxDevices][kMaxBufferPoolSlabs];
+  FILE *swap_file;
 };
 
 struct BufferIdArray;

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -55,6 +55,7 @@ enum ConfigVariable {
   ConfigVariable_TransientArenaPercentage,
   ConfigVariable_MountPoints,
   ConfigVariable_SwapMount,
+  ConfigVariable_NumBufferOrganizerRetries,
   ConfigVariable_MaxBucketsPerNode,
   ConfigVariable_MaxVBucketsPerNode,
   ConfigVariable_SystemViewStateUpdateInterval,
@@ -89,6 +90,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "transient_arena_percentage",
   "mount_points",
   "swap_mount",
+  "num_buffer_organizer_retries",
   "max_buckets_per_node",
   "max_vbuckets_per_node",
   "system_view_state_update_interval_ms",
@@ -749,6 +751,10 @@ void ParseTokens(TokenList *tokens, Config *config) {
       }
       case ConfigVariable_SwapMount: {
         config->swap_mount = ParseString(&tok);
+        break;
+      }
+      case ConfigVariable_NumBufferOrganizerRetries: {
+        config->num_buffer_organizer_retries = ParseInt(&tok);
         break;
       }
       case ConfigVariable_MaxBucketsPerNode: {

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -54,6 +54,7 @@ enum ConfigVariable {
   ConfigVariable_TransferWindowArenaPercentage,
   ConfigVariable_TransientArenaPercentage,
   ConfigVariable_MountPoints,
+  ConfigVariable_SwapMount,
   ConfigVariable_MaxBucketsPerNode,
   ConfigVariable_MaxVBucketsPerNode,
   ConfigVariable_SystemViewStateUpdateInterval,
@@ -87,6 +88,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "transfer_window_arena_percentage",
   "transient_arena_percentage",
   "mount_points",
+  "swap_mount",
   "max_buckets_per_node",
   "max_vbuckets_per_node",
   "system_view_state_update_interval_ms",
@@ -743,6 +745,10 @@ void ParseTokens(TokenList *tokens, Config *config) {
       case ConfigVariable_MountPoints: {
         RequireNumDevices(config);
         tok = ParseStringList(tok, config->mount_points, config->num_devices);
+        break;
+      }
+      case ConfigVariable_SwapMount: {
+        config->swap_mount = ParseString(&tok);
         break;
       }
       case ConfigVariable_MaxBucketsPerNode: {

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -21,7 +21,7 @@
 // 4. Add a case to ParseTokens for the new variable.
 // 5. Add the new variable to the Config struct.
 // 6. Add an Assert to config_parser_test.cc to test the functionality.
-// 7. Set a default value in InitTestConfig
+// 7. Set a default value in InitDefaultConfig
 
 namespace hermes {
 
@@ -63,6 +63,7 @@ enum ConfigVariable {
   ConfigVariable_RpcProtocol,
   ConfigVariable_RpcDomain,
   ConfigVariable_RpcPort,
+  ConfigVariable_BufferOrganizerPort,
   ConfigVariable_RpcHostNumberRange,
   ConfigVariable_RpcNumThreads,
 
@@ -95,6 +96,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "rpc_protocol",
   "rpc_domain",
   "rpc_port",
+  "buffer_organizer_port",
   "rpc_host_number_range",
   "rpc_num_threads",
 };
@@ -777,6 +779,10 @@ void ParseTokens(TokenList *tokens, Config *config) {
       }
       case ConfigVariable_RpcPort: {
         config->rpc_port = ParseInt(&tok);
+        break;
+      }
+      case ConfigVariable_BufferOrganizerPort: {
+        config->buffer_organizer_port = ParseInt(&tok);
         break;
       }
       case ConfigVariable_RpcHostNumberRange: {

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -47,7 +47,7 @@ Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
     }
 
     if (size_left > 0) {
-      // TODO(chogan): Trigger BufferOrganizer
+      // TODO(chogan): TriggerBufferOrganizer
       // EvictBuffers(eviction_schema);
       schema.clear();
     }

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -57,7 +57,7 @@ enum class ProcessKind {
 };
 
 enum ArenaType {
-  kArenaType_BufferPool,
+  kArenaType_BufferPool,  // This must always be first
   kArenaType_MetaData,
   kArenaType_Transient,
   kArenaType_TransferWindow,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -109,6 +109,7 @@ struct Config {
   std::string rpc_protocol;
   std::string rpc_domain;
   int rpc_port;
+  int buffer_organizer_port;
   int rpc_host_number_range[2];
   int rpc_num_threads;
 

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -104,6 +104,10 @@ struct Config {
   std::string mount_points[kMaxDevices];
   /** The mount point of the swap target. */
   std::string swap_mount;
+  /** The number of times the BufferOrganizer will attempt to place a swap blob
+   * into the hierarchy before giving up.*/
+  int num_buffer_organizer_retries;
+
   /** The hostname of the RPC server, minus any numbers that Hermes may
    * auto-generate when the rpc_hostNumber_range is specified. */
   std::string rpc_server_base_name;

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -102,6 +102,8 @@ struct Config {
    * empty string.
    */
   std::string mount_points[kMaxDevices];
+  /** The mount point of the swap target. */
+  std::string swap_mount;
   /** The hostname of the RPC server, minus any numbers that Hermes may
    * auto-generate when the rpc_hostNumber_range is specified. */
   std::string rpc_server_base_name;

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -36,6 +36,8 @@ constexpr int kMaxPathLength = 256;
 constexpr int kMaxBufferPoolShmemNameLength = 64;
 constexpr int kMaxDevices = 8;
 
+constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
+
 #define HERMES_NOT_IMPLEMENTED_YET \
   LOG(FATAL) << __func__ << " not implemented yet\n"
 

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -125,5 +125,14 @@ struct Config {
   char buffer_pool_shmem_name[kMaxBufferPoolShmemNameLength];
 };
 
+union BucketID {
+  struct {
+    u32 index;
+    u32 node_id;
+  } bits;
+
+  u64 as_int;
+};
+
 }  // namespace hermes
 #endif  // HERMES_TYPES_H_

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -136,5 +136,14 @@ union BucketID {
   u64 as_int;
 };
 
+union BlobID {
+  struct {
+    u32 buffer_ids_offset;
+    i32 node_id;
+  } bits;
+
+  u64 as_int;
+};
+
 }  // namespace hermes
 #endif  // HERMES_TYPES_H_

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -28,6 +28,10 @@ typedef double f64;
 
 typedef u16 DeviceID;
 
+namespace api {
+typedef int Status;
+}  // namespace api
+
 // TODO(chogan): These constants impose limits on the number of slabs, devices,
 // file path lengths, and shared memory name lengths, but eventually we should
 // allow arbitrary sizes of each.

--- a/src/memory_management.cc
+++ b/src/memory_management.cc
@@ -78,13 +78,16 @@ void GrowArena(Arena *arena, size_t new_size) {
     // TODO(chogan): @errorhandling
     HERMES_NOT_IMPLEMENTED_YET;
   }
-  void *new_base = (u8 *)realloc(arena->base, new_size);
-  if (new_base != arena->base) {
-    arena->base = (u8 *)new_base;
-    arena->capacity = new_size;
-  } else {
-    // TODO(chogan): @errorhandling
-    assert(!"GrowArena failed\n");
+
+  if (arena->capacity != new_size) {
+    void *new_base = (u8 *)realloc(arena->base, new_size);
+    if (new_base != arena->base) {
+      arena->base = (u8 *)new_base;
+      arena->capacity = new_size;
+    } else {
+      // TODO(chogan): @errorhandling
+      assert(!"GrowArena failed\n");
+    }
   }
 }
 

--- a/src/memory_management.cc
+++ b/src/memory_management.cc
@@ -74,6 +74,10 @@ size_t GetRemainingCapacity(Arena *arena) {
 }
 
 void GrowArena(Arena *arena, size_t new_size) {
+  if (new_size == 0) {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
   void *new_base = (u8 *)realloc(arena->base, new_size);
   if (new_base != arena->base) {
     arena->base = (u8 *)new_base;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -727,9 +727,9 @@ std::string GetSwapFilename(MetadataManager *mdm, u32 node_id) {
 }
 
 enum SwapBlobMembers {
+  SwapBlobMembers_NodeId,
   SwapBlobMembers_Offset,
   SwapBlobMembers_Size,
-  SwapBlobMembers_BlobId,
   SwapBlobMembers_BucketId,
 
   SwapBlobMembers_Count
@@ -738,9 +738,9 @@ enum SwapBlobMembers {
 std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
   static_assert((sizeof(swap_blob) / 8) == SwapBlobMembers_Count);
   std::vector<BufferID> result(SwapBlobMembers_Count);
+  result[SwapBlobMembers_NodeId].as_int = swap_blob.node_id;
   result[SwapBlobMembers_Offset].as_int = swap_blob.offset;
   result[SwapBlobMembers_Size].as_int = swap_blob.size;
-  result[SwapBlobMembers_BlobId].as_int = swap_blob.blob_id.as_int;
   result[SwapBlobMembers_BucketId].as_int = swap_blob.bucket_id.as_int;
 
   return result;
@@ -748,10 +748,10 @@ std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
 
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
   SwapBlob result = {};
-  if (vec.size() >= SwapBlobMembers_Count) {
+  if (vec.size() == SwapBlobMembers_Count) {
+    result.node_id = (u32)vec[SwapBlobMembers_NodeId].as_int;
     result.offset = vec[SwapBlobMembers_Offset].as_int;
     result.size = vec[SwapBlobMembers_Size].as_int;
-    result.blob_id.as_int = vec[SwapBlobMembers_BlobId].as_int;
     result.bucket_id.as_int = vec[SwapBlobMembers_BucketId].as_int;
   } else {
     // TODO(chogan): @errorhandling
@@ -765,10 +765,10 @@ SwapBlob IdArrayToSwapBlob(BufferIdArray ids) {
   SwapBlob result = {};
 
   static_assert((sizeof(result) / 8) == SwapBlobMembers_Count);
-  if (ids.length >= SwapBlobMembers_Count) {
+  if (ids.length == SwapBlobMembers_Count) {
+    result.node_id = (u32)ids.ids[SwapBlobMembers_NodeId].as_int;
     result.offset = ids.ids[SwapBlobMembers_Offset].as_int;
     result.size = ids.ids[SwapBlobMembers_Size].as_int;
-    result.blob_id.as_int = ids.ids[SwapBlobMembers_BlobId].as_int;
     result.bucket_id.as_int = ids.ids[SwapBlobMembers_BucketId].as_int;
   } else {
     // TODO(chogan): @errorhandling

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -557,9 +557,11 @@ u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id) {
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context) {
   std::vector<TargetID> targets = GetNodeTargets(context);
-  std::vector<u64> result(targets.size());
+  // NOTE(chogan): The last target is reserved as the "dumping ground"
+  size_t valid_targets = targets.size() - 1;
+  std::vector<u64> result(valid_targets);
 
-  for (size_t i = 0; i < targets.size(); ++i) {
+  for (size_t i = 0; i < valid_targets; ++i) {
     result[i] = LocalGetRemainingCapacity(context, targets[i]);
   }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -418,12 +418,11 @@ void FreeBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
 
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
                             const char *blob_name, BlobID blob_id) {
-  std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
-
   if (!BlobIsInSwap(blob_id)) {
+    std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
     ReleaseBuffers(context, rpc, buffer_ids);
   } else {
-    // TODO(chogan): Invalidate swap region
+    // TODO(chogan): Invalidate swap region once we have a SwapManager
   }
 
   FreeBufferIdList(context, rpc, blob_id);
@@ -434,12 +433,11 @@ void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
 
 void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
                           BlobID blob_id) {
-  std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
-
   if (!BlobIsInSwap(blob_id)) {
+    std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
     ReleaseBuffers(context, rpc, buffer_ids);
   } else {
-    // TODO(chogan): Invalidate swap region
+    // TODO(chogan): Invalidate swap region once we have a SwapManager
   }
 
   FreeBufferIdList(context, rpc, blob_id);

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -737,9 +737,31 @@ std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
 
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
   SwapBlob result = {};
-  result.node_id = (int)vec[0].as_int;
-  result.offset = vec[1].as_int;
-  result.size = vec[2].as_int;
+  // TODO(chogan): @metaprogramming count the members of the SwapBlob structure
+  if (vec.size() >= 3) {
+    result.node_id = (int)vec[0].as_int;
+    result.offset = vec[1].as_int;
+    result.size = vec[2].as_int;
+  } else {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
+
+  return result;
+}
+
+SwapBlob IdArrayToSwapBlob(BufferIdArray ids) {
+  SwapBlob result = {};
+
+  // TODO(chogan): @metaprogramming count the members of the SwapBlob structure
+  if (ids.length >= 3) {
+    result.node_id = (int)ids.ids[0].as_int;
+    result.offset = ids.ids[1].as_int;
+    result.size = ids.ids[2].as_int;
+  } else {
+    // TODO(chogan): @errorhandling
+    HERMES_NOT_IMPLEMENTED_YET;
+  }
 
   return result;
 }

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -685,6 +685,12 @@ SystemViewState *CreateSystemViewState(Arena *arena, Config *config) {
   return result;
 }
 
+const char *GetSwapFilename(MetadataManager *mdm) {
+  const char *result = (const char *)((u8 *)mdm + mdm->swap_filename_offset);
+
+  return result;
+}
+
 void InitMetadataManager(MetadataManager *mdm, Arena *arena, Config *config,
                          int node_id) {
   // NOTE(chogan): All MetadataManager offsets are relative to the address of

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -726,17 +726,11 @@ std::string GetSwapFilename(MetadataManager *mdm, u32 node_id) {
   return result;
 }
 
-enum SwapBlobMembers {
-  SwapBlobMembers_NodeId,
-  SwapBlobMembers_Offset,
-  SwapBlobMembers_Size,
-  SwapBlobMembers_BucketId,
-
-  SwapBlobMembers_Count
-};
-
 std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
-  static_assert((sizeof(swap_blob) / 8) == SwapBlobMembers_Count);
+  // TODO(chogan): @metaprogramming Improve this, since it currently only works
+  // if each member in SwapBlob (plus padding) is eight bytes.
+  static_assert((sizeof(SwapBlob) / 8) == SwapBlobMembers_Count);
+
   std::vector<BufferID> result(SwapBlobMembers_Count);
   result[SwapBlobMembers_NodeId].as_int = swap_blob.node_id;
   result[SwapBlobMembers_Offset].as_int = swap_blob.offset;
@@ -748,6 +742,7 @@ std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
 
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
   SwapBlob result = {};
+
   if (vec.size() == SwapBlobMembers_Count) {
     result.node_id = (u32)vec[SwapBlobMembers_NodeId].as_int;
     result.offset = vec[SwapBlobMembers_Offset].as_int;
@@ -764,7 +759,6 @@ SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
 SwapBlob IdArrayToSwapBlob(BufferIdArray ids) {
   SwapBlob result = {};
 
-  static_assert((sizeof(result) / 8) == SwapBlobMembers_Count);
   if (ids.length == SwapBlobMembers_Count) {
     result.node_id = (u32)ids.ids[SwapBlobMembers_NodeId].as_int;
     result.offset = ids.ids[SwapBlobMembers_Offset].as_int;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -485,10 +485,8 @@ void RenameBlob(SharedMemoryContext *context, RpcContext *rpc,
                 const std::string &old_name, const std::string &new_name) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   BlobID blob_id = GetBlobIdByName(context, rpc, old_name.c_str());
-  if (!IsNullBlobId(blob_id)) {
-    DeleteId(mdm, rpc, old_name, kMapType_Blob);
-    PutBlobId(mdm, rpc, new_name, blob_id);
-  }
+  DeleteId(mdm, rpc, old_name, kMapType_Blob);
+  PutBlobId(mdm, rpc, new_name, blob_id);
 }
 
 bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
@@ -496,14 +494,12 @@ bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
   BlobID blob_id = GetBlobIdByName(context, rpc, blob_name.c_str());
   bool result = false;
 
-  if (!IsNullBlobId(blob_id)) {
-    u32 target_node = bucket_id.bits.node_id;
-    if (target_node == rpc->node_id) {
-      result = LocalContainsBlob(context, bucket_id, blob_id);
-    } else {
-      result = RpcCall<bool>(rpc, target_node, "RemoteContainsBlob", bucket_id,
-                             blob_name);
-    }
+  u32 target_node = bucket_id.bits.node_id;
+  if (target_node == rpc->node_id) {
+    result = LocalContainsBlob(context, bucket_id, blob_id);
+  } else {
+    result = RpcCall<bool>(rpc, target_node, "RemoteContainsBlob", bucket_id,
+                           blob_name);
   }
 
   return result;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -557,11 +557,9 @@ u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id) {
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context) {
   std::vector<TargetID> targets = GetNodeTargets(context);
-  // NOTE(chogan): The last target is reserved as the "dumping ground"
-  size_t valid_targets = targets.size() - 1;
-  std::vector<u64> result(valid_targets);
+  std::vector<u64> result(targets.size());
 
-  for (size_t i = 0; i < valid_targets; ++i) {
+  for (size_t i = 0; i < targets.size(); ++i) {
     result[i] = LocalGetRemainingCapacity(context, targets[i]);
   }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -726,22 +726,29 @@ std::string GetSwapFilename(MetadataManager *mdm, u32 node_id) {
   return result;
 }
 
+// TEMP(chogan):
+const int kNumSwapBlobMembers = 5;
+
 std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
-  std::vector<BufferID> result(3);
+  static_assert((sizeof(swap_blob) / 8) == kNumSwapBlobMembers);
+  std::vector<BufferID> result(kNumSwapBlobMembers);
   result[0].as_int = swap_blob.node_id;
   result[1].as_int = swap_blob.offset;
   result[2].as_int = swap_blob.size;
+  result[3].as_int = swap_blob.blob_id.as_int;
+  result[4].as_int = swap_blob.bucket_id.as_int;
 
   return result;
 }
 
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
   SwapBlob result = {};
-  // TODO(chogan): @metaprogramming count the members of the SwapBlob structure
-  if (vec.size() >= 3) {
+  if (vec.size() >= kNumSwapBlobMembers) {
     result.node_id = (int)vec[0].as_int;
     result.offset = vec[1].as_int;
     result.size = vec[2].as_int;
+    result.blob_id.as_int = vec[3].as_int;
+    result.bucket_id.as_int = vec[4].as_int;
   } else {
     // TODO(chogan): @errorhandling
     HERMES_NOT_IMPLEMENTED_YET;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -726,29 +726,33 @@ std::string GetSwapFilename(MetadataManager *mdm, u32 node_id) {
   return result;
 }
 
-// TEMP(chogan):
-const int kNumSwapBlobMembers = 5;
+enum SwapBlobMembers {
+  SwapBlobMembers_Offset,
+  SwapBlobMembers_Size,
+  SwapBlobMembers_BlobId,
+  SwapBlobMembers_BucketId,
+
+  SwapBlobMembers_Count
+};
 
 std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob) {
-  static_assert((sizeof(swap_blob) / 8) == kNumSwapBlobMembers);
-  std::vector<BufferID> result(kNumSwapBlobMembers);
-  result[0].as_int = swap_blob.node_id;
-  result[1].as_int = swap_blob.offset;
-  result[2].as_int = swap_blob.size;
-  result[3].as_int = swap_blob.blob_id.as_int;
-  result[4].as_int = swap_blob.bucket_id.as_int;
+  static_assert((sizeof(swap_blob) / 8) == SwapBlobMembers_Count);
+  std::vector<BufferID> result(SwapBlobMembers_Count);
+  result[SwapBlobMembers_Offset].as_int = swap_blob.offset;
+  result[SwapBlobMembers_Size].as_int = swap_blob.size;
+  result[SwapBlobMembers_BlobId].as_int = swap_blob.blob_id.as_int;
+  result[SwapBlobMembers_BucketId].as_int = swap_blob.bucket_id.as_int;
 
   return result;
 }
 
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
   SwapBlob result = {};
-  if (vec.size() >= kNumSwapBlobMembers) {
-    result.node_id = (int)vec[0].as_int;
-    result.offset = vec[1].as_int;
-    result.size = vec[2].as_int;
-    result.blob_id.as_int = vec[3].as_int;
-    result.bucket_id.as_int = vec[4].as_int;
+  if (vec.size() >= SwapBlobMembers_Count) {
+    result.offset = vec[SwapBlobMembers_Offset].as_int;
+    result.size = vec[SwapBlobMembers_Size].as_int;
+    result.blob_id.as_int = vec[SwapBlobMembers_BlobId].as_int;
+    result.bucket_id.as_int = vec[SwapBlobMembers_BucketId].as_int;
   } else {
     // TODO(chogan): @errorhandling
     HERMES_NOT_IMPLEMENTED_YET;
@@ -760,11 +764,12 @@ SwapBlob VecToSwapBlob(std::vector<BufferID> &vec) {
 SwapBlob IdArrayToSwapBlob(BufferIdArray ids) {
   SwapBlob result = {};
 
-  // TODO(chogan): @metaprogramming count the members of the SwapBlob structure
-  if (ids.length >= 3) {
-    result.node_id = (int)ids.ids[0].as_int;
-    result.offset = ids.ids[1].as_int;
-    result.size = ids.ids[2].as_int;
+  static_assert((sizeof(result) / 8) == SwapBlobMembers_Count);
+  if (ids.length >= SwapBlobMembers_Count) {
+    result.offset = ids.ids[SwapBlobMembers_Offset].as_int;
+    result.size = ids.ids[SwapBlobMembers_Size].as_int;
+    result.blob_id.as_int = ids.ids[SwapBlobMembers_BlobId].as_int;
+    result.bucket_id.as_int = ids.ids[SwapBlobMembers_BucketId].as_int;
   } else {
     // TODO(chogan): @errorhandling
     HERMES_NOT_IMPLEMENTED_YET;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -123,6 +123,8 @@ struct MetadataManager {
   ptrdiff_t vbucket_map_offset;
   ptrdiff_t blob_map_offset;
 
+  ptrdiff_t swap_filename_offset;
+
   TicketMutex bucket_mutex;
   TicketMutex vbucket_mutex;
 
@@ -269,6 +271,7 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config);
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
+const char *GetSwapFilename(MetadataManager *mdm);
 
 }  // namespace hermes
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -203,7 +203,8 @@ BucketID GetOrCreateBucketId(SharedMemoryContext *context, RpcContext *rpc,
  */
 void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
                         const char *blob_name, BucketID bucket_id,
-                        const std::vector<BufferID> &buffer_ids);
+                        const std::vector<BufferID> &buffer_ids,
+                        bool is_swap_blob = false);
 
 /**
  *
@@ -216,6 +217,16 @@ void IncrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
  */
 void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID id);
+
+/**
+ *
+ */
+std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob);
+
+/**
+ *
+ */
+SwapBlob VecToSwapBlob(std::vector<BufferID> &vec);
 
 // internal
 u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);
@@ -274,8 +285,6 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
-void UpdateSwapMetadata(SharedMemoryContext *context, RpcContext *rpc,
-                        const char *blob_name, SwapBlob swap_blob);
 
 }  // namespace hermes
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -268,7 +268,7 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
                                             double slepp_ms);
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
-                         Arena *arena, Config *config);
+                         Arena *arena, Config *config, i32 node_id);
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 const char *GetSwapFilename(MetadataManager *mdm);

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -40,7 +40,7 @@ union VBucketID {
 union BlobID {
   struct {
     u32 buffer_ids_offset;
-    u32 node_id;
+    i32 node_id;
   } bits;
 
   u64 as_int;
@@ -272,6 +272,8 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 const char *GetSwapFilename(MetadataManager *mdm);
+void UpdateSwapMetadata(SharedMemoryContext *context, char *blob_name,
+                        SwapBlob swap_blob);
 
 }  // namespace hermes
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -28,15 +28,6 @@ union VBucketID {
   u64 as_int;
 };
 
-union BlobID {
-  struct {
-    u32 buffer_ids_offset;
-    i32 node_id;
-  } bits;
-
-  u64 as_int;
-};
-
 enum class TraitID : u8 {
   None,
   Placement,

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -19,15 +19,6 @@ enum MapType {
   kMapType_Blob,
 };
 
-union BucketID {
-  struct {
-    u32 index;
-    u32 node_id;
-  } bits;
-
-  u64 as_int;
-};
-
 union VBucketID {
   struct {
     u32 index;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -186,6 +186,17 @@ BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
 /**
  *
  */
+BlobID GetBlobIdByName(SharedMemoryContext *context, RpcContext *rpc,
+                       const char *name);
+
+/**
+ *
+ */
+bool BlobIsInSwap(BlobID id);
+
+/**
+ *
+ */
 BucketID GetOrCreateBucketId(SharedMemoryContext *context, RpcContext *rpc,
                              const std::string &name);
 
@@ -218,6 +229,11 @@ std::vector<BufferID> SwapBlobToVec(SwapBlob swap_blob);
  *
  */
 SwapBlob VecToSwapBlob(std::vector<BufferID> &vec);
+
+/**
+ *
+ */
+SwapBlob IdArrayToSwapBlob(BufferIdArray ids);
 
 // internal
 u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -123,7 +123,8 @@ struct MetadataManager {
   ptrdiff_t vbucket_map_offset;
   ptrdiff_t blob_map_offset;
 
-  ptrdiff_t swap_filename_offset;
+  ptrdiff_t swap_filename_prefix_offset;
+  ptrdiff_t swap_filename_suffix_offset;
 
   TicketMutex bucket_mutex;
   TicketMutex vbucket_mutex;
@@ -217,6 +218,7 @@ void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID id);
 
 // internal
+u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);
 MetadataManager *GetMetadataManagerFromContext(SharedMemoryContext *context);
 BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index);
 VBucketInfo *GetVBucketInfoByIndex(MetadataManager *mdm, u32 index);
@@ -271,9 +273,9 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config, i32 node_id);
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
-const char *GetSwapFilename(MetadataManager *mdm);
-void UpdateSwapMetadata(SharedMemoryContext *context, char *blob_name,
-                        SwapBlob swap_blob);
+std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
+void UpdateSwapMetadata(SharedMemoryContext *context, RpcContext *rpc,
+                        const char *blob_name, SwapBlob swap_blob);
 
 }  // namespace hermes
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -380,24 +380,28 @@ void SeedHashForStorage(size_t seed) {
 }
 
 void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
-                           Arena *arena, Config *config, i32 node_id) {
-  std::string swap_filename("swap" + std::to_string(node_id) + ".hermes");
+                           Arena *arena, Config *config) {
+  std::string swap_filename_prefix("swap");
   size_t swap_mount_length = config->swap_mount.size();
   bool ends_in_slash = config->swap_mount[swap_mount_length - 1] == '/';
   std::string full_swap_path = (config->swap_mount + (ends_in_slash ? "" : "/")
-                                + swap_filename);
+                                + swap_filename_prefix);
   size_t full_swap_path_size = full_swap_path.size() + 1;
 
   char *swap_filename_memory = PushArray<char>(arena, full_swap_path_size);
   memcpy(swap_filename_memory, full_swap_path.c_str(), full_swap_path.size());
   swap_filename_memory[full_swap_path.size()] = '\0';
+  mdm->swap_filename_prefix_offset = GetOffsetFromMdm(mdm, swap_filename_memory);
 
-  mdm->swap_filename_offset = GetOffsetFromMdm(mdm, swap_filename_memory);
+  const char swap_file_suffix[] = ".hermes";
+  char *swap_file_suffix_memory = PushArray<char>(arena, sizeof(swap_file_suffix));
+  memcpy(swap_file_suffix_memory, swap_file_suffix, sizeof(swap_file_suffix));
+  mdm->swap_filename_suffix_offset = GetOffsetFromMdm(mdm, swap_file_suffix_memory);
 }
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config, i32 node_id) {
-  InitSwapSpaceFilename(context, mdm, arena, config, node_id);
+  InitSwapSpaceFilename(context, mdm, arena, config);
 
   // Heaps
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -380,9 +380,8 @@ void SeedHashForStorage(size_t seed) {
 }
 
 void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
-                           Arena *arena, Config *config) {
-  // TODO(chogan): Make this name unique?
-  std::string swap_filename("swap.hermes");
+                           Arena *arena, Config *config, i32 node_id) {
+  std::string swap_filename("swap" + std::to_string(node_id) + ".hermes");
   size_t swap_mount_length = config->swap_mount.size();
   bool ends_in_slash = config->swap_mount[swap_mount_length - 1] == '/';
   std::string full_swap_path = (config->swap_mount + (ends_in_slash ? "" : "/")
@@ -397,8 +396,8 @@ void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
 }
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
-                         Arena *arena, Config *config) {
-  InitSwapSpaceFilename(context, mdm, arena, config);
+                         Arena *arena, Config *config, i32 node_id) {
+  InitSwapSpaceFilename(context, mdm, arena, config, node_id);
 
   // Heaps
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -391,12 +391,16 @@ void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
   char *swap_filename_memory = PushArray<char>(arena, full_swap_path_size);
   memcpy(swap_filename_memory, full_swap_path.c_str(), full_swap_path.size());
   swap_filename_memory[full_swap_path.size()] = '\0';
-  mdm->swap_filename_prefix_offset = GetOffsetFromMdm(mdm, swap_filename_memory);
+  mdm->swap_filename_prefix_offset =
+    GetOffsetFromMdm(mdm, swap_filename_memory);
 
   const char swap_file_suffix[] = ".hermes";
-  char *swap_file_suffix_memory = PushArray<char>(arena, sizeof(swap_file_suffix));
-  memcpy(swap_file_suffix_memory, swap_file_suffix, sizeof(swap_file_suffix));
-  mdm->swap_filename_suffix_offset = GetOffsetFromMdm(mdm, swap_file_suffix_memory);
+  char *swap_file_suffix_memory = PushArray<char>(arena,
+                                                  sizeof(swap_file_suffix));
+  memcpy(swap_file_suffix_memory, swap_file_suffix,
+         sizeof(swap_file_suffix));
+  mdm->swap_filename_suffix_offset =
+    GetOffsetFromMdm(mdm, swap_file_suffix_memory);
 }
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
@@ -438,6 +442,7 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
   mdm->bucket_map_offset = GetOffsetFromMdm(mdm, bucket_map);
   u32 bucket_map_num_bytes = map_heap->extent;
   total_map_capacity -= bucket_map_num_bytes;
+  assert(total_map_capacity > 0);
 
   // TODO(chogan): Just one map means better size estimate, but it's probably
   // slower because they'll all share a lock.
@@ -448,6 +453,7 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
   mdm->vbucket_map_offset = GetOffsetFromMdm(mdm, vbucket_map);
   u32 vbucket_map_num_bytes = map_heap->extent - bucket_map_num_bytes;
   total_map_capacity -= vbucket_map_num_bytes;
+  assert(total_map_capacity > 0);
 
   IdMap *blob_map = 0;
   // NOTE(chogan): Each map element requires twice its size for storage.

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -54,7 +54,8 @@ std::string GetProtocol(RpcContext *rpc);
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
                           const char *addr, int num_threads);
 void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
-                            SwapBlob swap_blob, int retries);
+                            const std::string &blob_name, SwapBlob swap_blob,
+                            int retries);
 }  // namespace hermes
 
 // TODO(chogan): I don't like that code similar to this is in buffer_pool.cc.

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -53,6 +53,8 @@ std::string GetServerName(RpcContext *rpc, u32 node_id);
 std::string GetProtocol(RpcContext *rpc);
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
                           const char *addr, int num_threads);
+void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
+                            SwapBlob swap_blob, int retries);
 }  // namespace hermes
 
 // TODO(chogan): I don't like that code similar to this is in buffer_pool.cc.

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -51,7 +51,8 @@ void FinalizeRpcContext(RpcContext *rpc, bool is_daemon);
 std::string GetHostNumberAsString(RpcContext *rpc, u32 node_id);
 std::string GetServerName(RpcContext *rpc, u32 node_id);
 std::string GetProtocol(RpcContext *rpc);
-
+void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
+                          const char *addr, int num_threads);
 }  // namespace hermes
 
 // TODO(chogan): I don't like that code similar to this is in buffer_pool.cc.

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -49,10 +49,11 @@ void InitRpcContext(RpcContext *rpc, u32 num_nodes, u32 node_id,
 void *CreateRpcState(Arena *arena);
 void FinalizeRpcContext(RpcContext *rpc, bool is_daemon);
 std::string GetHostNumberAsString(RpcContext *rpc, u32 node_id);
-std::string GetServerName(RpcContext *rpc, u32 node_id);
+std::string GetServerName(RpcContext *rpc, u32 node_id,
+                          bool is_buffer_organizer = false);
 std::string GetProtocol(RpcContext *rpc);
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
-                          const char *addr, int num_threads);
+                          const char *addr, int num_threads, int port);
 void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
                             const std::string &blob_name, SwapBlob swap_blob,
                             int retries);

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -359,7 +359,8 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
   LOG(INFO) << "Buffer organizer serving at " << rpc_server_name << " with "
             << num_threads << " RPC threads" << std::endl;
 
-  auto rpc_handle_event = [context](const tl::request &req) {
+  auto rpc_handle_event = [context](const tl::request &req, u32 node_id,
+                                    u64 offset, u64 size) {
     (void)req;
   };
 

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -394,6 +394,7 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
     (void)req;
     for (int i = 0; i < retries; ++i) {
       // TODO(chogan): MoveToTarget(context, rpc, target_id, swap_blob);
+      HERMES_NOT_IMPLEMENTED_YET;
       int result = 0;
       if (result == 0) {
         break;

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -362,7 +362,7 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
   auto rpc_handle_event = [context](const tl::request &req, u32 node_id,
                                     u64 offset, u64 size) {
     (void)req;
-    // TODO(chogan):
+    // TODO(chogan): Pass config.num_buffer_organizer_retries
   };
 
   rpc_server->define("BufferOrganizerHandleEvent",

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -362,9 +362,23 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
   auto rpc_handle_event = [context](const tl::request &req, u32 node_id,
                                     u64 offset, u64 size) {
     (void)req;
+    // TODO(chogan):
   };
 
-  rpc_server->define("RemoteHandleEvent", rpc_handle_event).disable_response();
+  rpc_server->define("BufferOrganizerHandleEvent",
+                     rpc_handle_event).disable_response();
+}
+
+void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
+                            SwapBlob swap_blob) {
+  // TEMP(chogan):
+  std::string server_name = "";
+  std::string protocol = GetProtocol(rpc);
+  tl::engine engine(protocol, THALLIUM_CLIENT_MODE, true);
+  tl::remote_procedure remote_proc = engine.define(func_name);
+  tl::endpoint server = engine.lookup(server_name);
+  remote_proc.disable_response();
+  remote_proc.on(server)(swap_blob.node_id, swap_blob.offset, swap_blob.size);
 }
 
 void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -221,7 +221,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
         u32 result = LocalAllocateBufferIdList(mdm, buffer_ids);
 
         req.respond(result);
-    };
+      };
 
   function<void(const request&, BucketID, const string&, const string&)>
     rpc_rename_bucket = [context, rpc](const request &req, BucketID id,
@@ -361,10 +361,11 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
 
   auto rpc_place_in_hierarchy = [context, rpc](const tl::request &req,
                                                SwapBlob swap_blob,
+                                               const std::string name,
                                                int retries) {
     (void)req;
     for (int i = 0; i < retries; ++i) {
-      int result = PlaceInHierarchy(context, rpc, swap_blob);
+      int result = PlaceInHierarchy(context, rpc, swap_blob, name);
       if (result == 0) {
         break;
       }
@@ -391,7 +392,8 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
 }
 
 void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
-                            SwapBlob swap_blob, int retries) {
+                            const std::string &blob_name, SwapBlob swap_blob,
+                            int retries) {
   // TEMP(chogan):
   std::string server_name = "";
   std::string protocol = GetProtocol(rpc);
@@ -400,7 +402,7 @@ void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
   tl::endpoint server = engine.lookup(server_name);
   remote_proc.disable_response();
   // TODO(chogan): Templatize?
-  remote_proc.on(server)(swap_blob, retries);
+  remote_proc.on(server)(swap_blob, blob_name, retries);
 }
 
 void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -81,9 +81,9 @@ void serialize(A &ar, TargetID &target_id) {
 
 template<typename A>
 void serialize(A &ar, SwapBlob &swap_blob) {
+  ar & swap_blob.node_id;
   ar & swap_blob.offset;
   ar & swap_blob.size;
-  ar & swap_blob.blob_id;
   ar & swap_blob.bucket_id;
 }
 

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -23,6 +23,7 @@ struct ThalliumState {
   char server_name_postfix[kMaxServerNamePostfix];
   std::atomic<bool> kill_requested;
   tl::engine *engine;
+  tl::engine *bo_engine;
   ABT_xstream execution_stream;
 };
 
@@ -108,6 +109,9 @@ void load(A &ar, MapType &map_type) {
   map_type = (MapType)val;
 }
 #endif
+
+std::string GetRpcAddress(Config *config, const std::string &host_number,
+                          int port);
 
 static inline ThalliumState *GetThalliumState(RpcContext *rpc) {
   ThalliumState *result = (ThalliumState *)rpc->state;

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -21,6 +21,7 @@ const int kMaxServerNamePostfix = 8;
 struct ThalliumState {
   char server_name_prefix[kMaxServerNamePrefix];
   char server_name_postfix[kMaxServerNamePostfix];
+  char bo_server_name_postfix[kMaxServerNamePostfix];
   std::atomic<bool> kill_requested;
   tl::engine *engine;
   tl::engine *bo_engine;

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -79,6 +79,14 @@ void serialize(A &ar, TargetID &target_id) {
   ar & target_id.as_int;
 }
 
+template<typename A>
+void serialize(A &ar, SwapBlob &swap_blob) {
+  ar & swap_blob.offset;
+  ar & swap_blob.size;
+  ar & swap_blob.blob_id;
+  ar & swap_blob.bucket_id;
+}
+
 #ifndef THALLIUM_USE_CEREAL
 /**
  *  Lets Thallium know how to serialize a MapType.

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -73,6 +73,8 @@ void InitDefaultConfig(Config *config) {
   config->mount_points[3] = "./";
   config->swap_mount = "./";
 
+  config->num_buffer_organizer_retries = 3;
+
   config->rpc_server_base_name = "localhost";
   config->rpc_server_suffix = "";
   config->rpc_protocol = "ofi+sockets";

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -77,6 +77,7 @@ void InitDefaultConfig(Config *config) {
   config->rpc_protocol = "ofi+sockets";
   config->rpc_domain = "";
   config->rpc_port = 8080;
+  config->buffer_organizer_port = 8081;
   config->rpc_num_threads = 1;
 
   config->max_buckets_per_node = 16;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -71,6 +71,7 @@ void InitDefaultConfig(Config *config) {
   config->mount_points[1] = "./";
   config->mount_points[2] = "./";
   config->mount_points[3] = "./";
+  config->swap_mount = "./";
 
   config->rpc_server_base_name = "localhost";
   config->rpc_server_suffix = "";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(bp ${LIBRT} hermes MPI::MPI_CXX
     $<$<BOOL:${HERMES_RPC_THALLIUM}>:thallium>)
 target_compile_definitions(bp
   PRIVATE $<$<BOOL:${HERMES_RPC_THALLIUM}>:HERMES_RPC_THALLIUM>)
-add_test(NAME "TestBufferPool" COMMAND "${CMAKE_BINARY_DIR}/bin/bp" "-b")
+add_test(NAME "TestBufferPool" COMMAND "${CMAKE_BINARY_DIR}/bin/bp" "-b" "-s")
 set_tests_properties("TestBufferPool" PROPERTIES ENVIRONMENT
   LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/data/asan.supp)
 

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -74,7 +74,11 @@ void TestSwap(std::shared_ptr<Hermes> hermes) {
   ctx.policy = hapi::PlacementPolicy::kRandom;
   hapi::Bucket bucket(std::string("swap_bucket"), hermes, ctx);
   hapi::Blob data(MEGABYTES(1), 'x');
-  bucket.Put(std::string("swap_blob"), data, ctx);
+  std::string blob_name("swap_blob");
+  bucket.Put(blob_name, data, ctx);
+
+  Assert(bucket.ContainsBlob(blob_name));
+
   bucket.Destroy(ctx);
 }
 
@@ -146,6 +150,8 @@ int main(int argc, char **argv) {
   if (test_swap) {
     hermes::Config config = {};
     InitDefaultConfig(&config);
+    // NOTE(chogan): Make capacities small so that a Put of 1MB will go to swap
+    // space
     config.capacities[0] = KILOBYTES(50);
     config.capacities[1] = 8;
     config.capacities[2] = 8;

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -79,6 +79,13 @@ void TestSwap(std::shared_ptr<Hermes> hermes) {
 
   Assert(bucket.ContainsBlob(blob_name));
 
+  hapi::Blob get_result;
+  size_t blob_size = bucket.Get(blob_name, get_result, ctx);
+  get_result.resize(blob_size);
+  blob_size = bucket.Get(blob_name, get_result, ctx);
+
+  Assert(get_result == data);
+
   bucket.Destroy(ctx);
 }
 

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -66,6 +66,7 @@ int main(int argc, char **argv) {
   Assert(config.rpc_protocol == "ofi+sockets");
   Assert(config.rpc_domain.empty());
   Assert(config.rpc_port == 8080);
+  Assert(config.buffer_organizer_port == 8081);
   Assert(config.rpc_host_number_range[0] == 0 &&
          config.rpc_host_number_range[1] == 0);
   Assert(config.rpc_num_threads == 1);

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
   Assert(config.mount_points[2] == "./");
   Assert(config.mount_points[3] == "./");
   Assert(config.swap_mount == "./");
+  Assert(config.num_buffer_organizer_retries == 3);
 
   Assert(config.max_buckets_per_node == 16);
   Assert(config.max_vbuckets_per_node == 8);

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
   Assert(config.mount_points[1] == "./");
   Assert(config.mount_points[2] == "./");
   Assert(config.mount_points[3] == "./");
+  Assert(config.swap_mount == "./");
 
   Assert(config.max_buckets_per_node == 16);
   Assert(config.max_vbuckets_per_node == 8);

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -39,6 +39,7 @@ rpc_server_suffix = "-40g";
 rpc_protocol = "ofi+verbs";
 rpc_domain = "mlx5_0";
 rpc_port = 8080;
+buffer_organizer_port = 8081;
 rpc_host_number_range = {29, 30};
 rpc_num_threads = 4;
 buffer_pool_shmem_name = "/hermes_buffer_pool_";

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -34,6 +34,7 @@ max_vbuckets_per_node = 8;
 system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
+swap_mount = "./";
 rpc_server_base_name = "ares-comp-";
 rpc_server_suffix = "-40g";
 rpc_protocol = "ofi+verbs";

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -35,6 +35,7 @@ system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
 swap_mount = "./";
+num_buffer_organizer_retries = 3;
 rpc_server_base_name = "ares-comp-";
 rpc_server_suffix = "-40g";
 rpc_protocol = "ofi+verbs";

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -37,6 +37,7 @@ mount_points = {"", "./", "./", "./"};
 rpc_server_base_name = "localhost";
 rpc_protocol = "ofi+sockets";
 rpc_port = 8080;
+buffer_organizer_port = 8081;
 rpc_host_number_range = {0, 0};
 rpc_num_threads = 1;
 buffer_pool_shmem_name = "/hermes_buffer_pool_";

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -34,6 +34,7 @@ max_vbuckets_per_node = 8;
 system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
+swap_mount = "./";
 rpc_server_base_name = "localhost";
 rpc_protocol = "ofi+sockets";
 rpc_port = 8080;

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -35,6 +35,7 @@ system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
 swap_mount = "./";
+num_buffer_organizer_retries = 3;
 rpc_server_base_name = "localhost";
 rpc_protocol = "ofi+sockets";
 rpc_port = 8080;

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -35,6 +35,7 @@ system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
 swap_mount = "./";
+num_buffer_organizer_retries = 3;
 rpc_server_base_name = "localhost";
 rpc_server_suffix = "";
 rpc_protocol = "ofi+sockets";

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -39,6 +39,7 @@ rpc_server_suffix = "";
 rpc_protocol = "ofi+sockets";
 rpc_domain = "";
 rpc_port = 8080;
+buffer_organizer_port = 8081;
 rpc_host_number_range = {0, 0};
 rpc_num_threads = 1;
 buffer_pool_shmem_name = "/hermes_buffer_pool_";

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -34,6 +34,7 @@ max_vbuckets_per_node = 8;
 system_view_state_update_interval_ms = 1000;
 
 mount_points = {"", "./", "./", "./"};
+swap_mount = "./";
 rpc_server_base_name = "localhost";
 rpc_server_suffix = "";
 rpc_protocol = "ofi+sockets";


### PR DESCRIPTION
When `CalculatePlacement` fails (whether from unsatisfiable constraints or outdated information) a `Put` will place the `Blob` in "swap space." Eventually, the swap space can be any kind of storage, but for now it's a set of files (1 per Hermes node) on a parallel file system. A configuration variable `swap_mount` controls the mounting point of the swap files. A `Blob` that is in the swap space is called a `SwapBlob`, and from the API's point of view, the `Blob` exists in the system just like any other blob. A `SwapBlob` is distinguished from a normal `Blob` by having a negative `node_id` filed in its `BlobID`. The function `BlobIsInSwap` hides this detail. After the system places a blob in the swap space, it then triggers the buffer organizer, which will attempt to move the blob from the swap space into the hierarchy. The number of attempts is controlled by the configuration variable `num_buffer_organizer_retries`. A future PR will move the I/O client stuff into its own file, but that would have made the diff harder to read in this PR.
