### PR TITLE
Add MDM benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ option(HERMES_RPC_THALLIUM "Use Thallium as the RPC library." ON)
 option(HERMES_MDM_STORAGE_STBDS
   "Use the STB library and shared memory to store metadata" ON)
 option(HERMES_DEBUG_HEAP "Store Heap debug information for visualization." OFF)
+option(HERMES_BUILD_BENCHMARKS "Build the Hermes benchmark suite." OFF)
 
 if(BUILD_SHARED_LIBS)
   set(HERMES_BUILD_SHARED_LIBS 1)
@@ -320,6 +321,13 @@ endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL HERMES AND BUILD_TESTING)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
+endif()
+
+#-----------------------------------------------------------------------------
+# Benchmarks
+#-----------------------------------------------------------------------------
+if(HERMES_BUILD_BENCHMARKS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmarks)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_executable(mdm_bench mdm_bench.cc)
+target_link_libraries(mdm_bench hermes MPI::MPI_CXX
+  $<$<BOOL:${HERMES_RPC_THALLIUM}>:thallium>)
+target_compile_definitions(mdm_bench
+  PRIVATE $<$<BOOL:${HERMES_RPC_THALLIUM}>:HERMES_RPC_THALLIUM>)

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -142,8 +142,11 @@ void BenchRemote(const char *config_file) {
         double del_seconds =
           std::chrono::duration<double>(end_del - start_del).count();
 
-        printf("put,%d,%d,%f\n", app_size, payload_bytes, kRepeats / put_seconds);
-        printf("del,%d,%d,%f\n", app_size, payload_bytes, kRepeats / del_seconds);
+        double payload_megabytes = (payload_bytes * kRepeats) / 1024.0 / 1024.0;
+        printf("put,%d,%d,%f,%f\n", app_size, payload_bytes, kRepeats / put_seconds,
+               payload_megabytes / put_seconds);
+        printf("del,%d,%d,%f,%f\n", app_size, payload_bytes, kRepeats / del_seconds,
+               payload_megabytes / del_seconds);
         // printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
         // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
         //        max_get_seconds);

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -140,7 +140,6 @@ void BenchRemote(const char *config_file) {
     printf("app_comm size: %d\n", app_size);
 
     if (hermes->rpc_.node_id != 1) {
-
       for (hermes::u32 num_bytes = 8;
            num_bytes <= KILOBYTES(4);
            num_bytes *= 2) {

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -140,6 +140,9 @@ void BenchRemote(const char *config_file) {
         printf("del,remote,1,1,%d,%.8f\n", payload_bytes, del_seconds);
       }
     }
+
+    hermes->AppBarrier();
+
   } else {
     // Hermes core. No user code here.
   }

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -141,8 +141,8 @@ void BenchRemote(const char *config_file) {
         double del_seconds =
           std::chrono::duration<double>(end_del - start_del).count();
 
-        printf("%d,%f\n", payload_bytes, put_seconds / kRepeats);
-        printf("%d,%f\n", payload_bytes, del_seconds / kRepeats);
+        printf("%d,%f\n", payload_bytes, kRepeats / put_seconds);
+        printf("%d,%f\n", payload_bytes, kRepeats / del_seconds);
         // printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
         // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
         //        max_get_seconds);

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -98,7 +98,6 @@ void BenchRemote(const char *config_file) {
 
   if (hermes->IsApplicationCore()) {
     int app_rank = hermes->GetProcessRank();
-    int app_size = hermes->GetNumProcesses();
 
     if (app_rank == 0) {
       for (hermes::u32 i = 1; i <= KILOBYTES(4) / sizeof_id; i *= 2) {
@@ -130,24 +129,19 @@ void BenchRemote(const char *config_file) {
         FreeBufferIdList(&hermes->context_, &hermes->rpc_, blob_id);
         time_point end_del = now();
 
-        hermes->AppBarrier();
+        double put_seconds =
+          std::chrono::duration<double>(end_put - start_put).count();
+        double del_seconds =
+          std::chrono::duration<double>(end_del - start_del).count();
 
-        double max_put_seconds = GetMaxSeconds(start_put, end_put, hermes.get());
-        // double max_get_seconds = GetMaxSeconds(start_get, end_get, hermes.get());
-        double max_del_seconds = GetMaxSeconds(start_del, end_del, hermes.get());
-
-        if (hermes->IsFirstRankOnNode()) {
-          printf("put,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
-                 max_put_seconds);
-          // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
-          //        max_get_seconds);
-          printf("del,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
-                 max_del_seconds);
-        }
+        printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
+        // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+        //        max_get_seconds);
+        printf("del,remote,1,1,%d,%.8f\n", payload_bytes, del_seconds);
       }
     }
   } else {
-    // Hermes core. No user code here. 
+    // Hermes core. No user code here.
   }
 
   hermes->Finalize();
@@ -164,7 +158,6 @@ void PrintUsage(char *program) {
 }
 
 int main(int argc, char **argv) {
-
   int option = -1;
   bool bench_local = false;
   bool bench_remote = false;

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -47,18 +47,6 @@ int main(int argc, char **argv) {
       hermes::u32 location = LocalAllocateBufferIdList(mdm, buffer_ids);
       auto end = now();
 
-      if (i == 1) {
-        // NOTE(chogan): Prime the cache
-        hermes::BlobID blob_id = {};
-        blob_id.bits.node_id = app_rank;
-        blob_id.bits.buffer_ids_offset = location;
-        LocalFreeBufferIdList(&hermes->context_, blob_id);
-
-        start = now();
-        location = LocalAllocateBufferIdList(mdm, buffer_ids);
-        end = now();
-      }
-
       hermes::BlobID blob_id = {};
       blob_id.bits.node_id = app_rank;
       blob_id.bits.buffer_ids_offset = location;
@@ -72,7 +60,7 @@ int main(int argc, char **argv) {
       MPI_Reduce(&seconds, &max_seconds, 1, MPI_DOUBLE, MPI_MAX, 0, *app_comm);
 
       if (hermes->comm_.first_on_node) {
-        printf("local,1,%d,%d,%f\n", app_size, payload_bytes, max_seconds);
+        printf("put,local,1,%d,%d,%f\n", app_size, payload_bytes, max_seconds);
       }
     }
 

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -187,9 +187,8 @@ void BenchRemote(const char *config_file) {
           std::chrono::duration<double>(end_del - start_del).count();
 
         double total_get_seconds;
-        // TODO(chogan): Correct rank and comm
         MPI_Reduce(&local_get_seconds, &total_get_seconds, 1,
-                   MPI_DOUBLE, MPI_SUM, 0, *app_comm);
+                   MPI_DOUBLE, MPI_SUM, 0, client_comm);
         double avg_get_seconds = total_get_seconds / client_comm_size;
 
         // double payload_megabytes =

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -42,9 +42,22 @@ int main(int argc, char **argv) {
         id.bits.header_index = j;
         buffer_ids[j] = id;
       }
+
       auto start = now();
       hermes::u32 location = LocalAllocateBufferIdList(mdm, buffer_ids);
       auto end = now();
+
+      if (i == 1) {
+        // NOTE(chogan): Prime the cache
+        hermes::BlobID blob_id = {};
+        blob_id.bits.node_id = app_rank;
+        blob_id.bits.buffer_ids_offset = location;
+        LocalFreeBufferIdList(&hermes->context_, blob_id);
+
+        start = now();
+        location = LocalAllocateBufferIdList(mdm, buffer_ids);
+        end = now();
+      }
 
       hermes::BlobID blob_id = {};
       blob_id.bits.node_id = app_rank;

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -1,3 +1,6 @@
+#include <stdio.h>
+#include <unistd.h>
+
 #include <chrono>
 
 #include <mpi.h>
@@ -7,6 +10,7 @@
 
 namespace hapi = hermes::api;
 using std::chrono::time_point;
+const auto now = std::chrono::high_resolution_clock::now;
 
 double GetMaxSeconds(time_point<std::chrono::high_resolution_clock> start,
                      time_point<std::chrono::high_resolution_clock> end,
@@ -19,16 +23,7 @@ double GetMaxSeconds(time_point<std::chrono::high_resolution_clock> start,
   return max_seconds;
 }
 
-int main(int argc, char **argv) {
-  int mpi_threads_provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
-  if (mpi_threads_provided < MPI_THREAD_MULTIPLE) {
-    fprintf(stderr, "Didn't receive appropriate MPI threading specification\n");
-    return 1;
-  }
-
-  const auto now = std::chrono::high_resolution_clock::now;
-
+void BenchLocal() {
   hermes::Config config = {};
   hermes::InitDefaultConfig(&config);
 
@@ -80,7 +75,7 @@ int main(int argc, char **argv) {
       double max_get_seconds = GetMaxSeconds(start_get, end_get, hermes.get());
       double max_del_seconds = GetMaxSeconds(start_del, end_del, hermes.get());
 
-      if (hermes->comm_.first_on_node) {
+      if (hermes->IsFirstRankOnNode()) {
         printf("put,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
                max_put_seconds);
         printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
@@ -93,8 +88,136 @@ int main(int argc, char **argv) {
   } else {
     // Hermes core. No user code.
   }
+  hermes->Finalize();
+}
+
+void BenchRemote(const char *config_file) {
+  constexpr int sizeof_id = sizeof(hermes::BufferID);
+
+  std::shared_ptr<hapi::Hermes> hermes = hapi::InitHermes(config_file);
+
+  if (hermes->IsApplicationCore()) {
+    int app_rank = hermes->GetProcessRank();
+    int app_size = hermes->GetNumProcesses();
+
+    if (app_rank == 0) {
+      for (hermes::u32 i = 1; i <= KILOBYTES(4) / sizeof_id; i *= 2) {
+        int num_ids = i;
+        int payload_bytes = sizeof_id * num_ids;
+
+        // NOTE(chogan): Send data to the next node.
+        int target_node = hermes->GetNodeId() + 1;
+
+        std::vector<hermes::BufferID> buffer_ids(i);
+        for (hermes::u32 j = 0; j < i; ++j) {
+          hermes::BufferID id = {};
+          id.bits.node_id = target_node;
+          id.bits.header_index = j;
+          buffer_ids[j] = id;
+        }
+
+        time_point start_put = now();
+        hermes::u32 id_list_offset =
+          hermes::AllocateBufferIdList(&hermes->context_, &hermes->rpc_,
+                                       target_node, buffer_ids);
+        time_point end_put = now();
+
+        hermes::BlobID blob_id = {};
+        blob_id.bits.node_id = target_node;
+        blob_id.bits.buffer_ids_offset = id_list_offset;
+
+        time_point start_del = now();
+        FreeBufferIdList(&hermes->context_, &hermes->rpc_, blob_id);
+        time_point end_del = now();
+
+        hermes->AppBarrier();
+
+        double max_put_seconds = GetMaxSeconds(start_put, end_put, hermes.get());
+        // double max_get_seconds = GetMaxSeconds(start_get, end_get, hermes.get());
+        double max_del_seconds = GetMaxSeconds(start_del, end_del, hermes.get());
+
+        if (hermes->IsFirstRankOnNode()) {
+          printf("put,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+                 max_put_seconds);
+          // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+          //        max_get_seconds);
+          printf("del,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+                 max_del_seconds);
+        }
+      }
+    }
+  } else {
+    // Hermes core. No user code here. 
+  }
 
   hermes->Finalize();
+}
+
+void PrintUsage(char *program) {
+  fprintf(stderr, "Usage: %s -[rs]\n", program);
+  fprintf(stderr, "  -f\n");
+  fprintf(stderr, "     Name of configuration file.\n");
+  fprintf(stderr, "  -r\n");
+  fprintf(stderr, "     Bench remote operations only.\n");
+  fprintf(stderr, "  -s\n");
+  fprintf(stderr, "     Bench local performance on a single node.\n");
+}
+
+int main(int argc, char **argv) {
+
+  int option = -1;
+  bool bench_local = false;
+  bool bench_remote = false;
+  char *config_file = 0;
+
+  while ((option = getopt(argc, argv, "f:rs")) != -1) {
+    switch (option) {
+      case 'f': {
+        config_file = optarg;
+        break;
+      }
+      case 'r': {
+        bench_remote = true;
+        break;
+      }
+      case 's': {
+        bench_local = true;
+        break;
+      }
+      default:
+        PrintUsage(argv[0]);
+        return 1;
+    }
+  }
+
+  if (bench_remote && !config_file) {
+    fprintf(stderr, "Remote configuration option -r requires a config file name"
+            "with the -f option.\n");
+    return 1;
+  }
+
+  if (optind < argc) {
+    fprintf(stderr, "non-option ARGV-elements: ");
+    while (optind < argc) {
+      fprintf(stderr, "%s ", argv[optind++]);
+    }
+    fprintf(stderr, "\n");
+  }
+
+  int mpi_threads_provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
+  if (mpi_threads_provided < MPI_THREAD_MULTIPLE) {
+    fprintf(stderr, "Didn't receive appropriate MPI threading specification\n");
+    return 1;
+  }
+
+
+  if (bench_local) {
+    BenchLocal();
+  }
+  if (bench_remote) {
+    BenchRemote(config_file);
+  }
 
   MPI_Finalize();
 

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -1,0 +1,75 @@
+#include <chrono>
+
+#include <mpi.h>
+
+#include "hermes.h"
+#include "utils.h"
+
+namespace hapi = hermes::api;
+
+int main(int argc, char **argv) {
+  int mpi_threads_provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
+  if (mpi_threads_provided < MPI_THREAD_MULTIPLE) {
+    fprintf(stderr, "Didn't receive appropriate MPI threading specification\n");
+    return 1;
+  }
+
+  const auto now = std::chrono::high_resolution_clock::now;
+
+  hermes::Config config = {};
+  hermes::InitDefaultConfig(&config);
+
+  std::shared_ptr<hapi::Hermes> hermes = hermes::InitHermes(&config);
+
+  if (hermes->IsApplicationCore()) {
+    int app_rank = hermes->GetProcessRank();
+    int app_size = hermes->GetNumProcesses();
+
+    hermes::MetadataManager *mdm =
+      GetMetadataManagerFromContext(&hermes->context_);
+
+    constexpr int sizeof_id = sizeof(hermes::BufferID);
+
+    for (hermes::u32 i = 1; i <= KILOBYTES(4) / sizeof_id; i *= 2) {
+      int num_ids = i;
+      int payload_bytes = sizeof_id * num_ids;
+
+      std::vector<hermes::BufferID> buffer_ids(i);
+      for (hermes::u32 j = 0; j < i; ++j) {
+        hermes::BufferID id = {};
+        id.bits.node_id = app_rank;
+        id.bits.header_index = j;
+        buffer_ids[j] = id;
+      }
+      auto start = now();
+      hermes::u32 location = LocalAllocateBufferIdList(mdm, buffer_ids);
+      auto end = now();
+
+      hermes::BlobID blob_id = {};
+      blob_id.bits.node_id = app_rank;
+      blob_id.bits.buffer_ids_offset = location;
+      LocalFreeBufferIdList(&hermes->context_, blob_id);
+
+      hermes->AppBarrier();
+
+      double seconds = std::chrono::duration<double>(end - start).count();
+      double max_seconds = 0;
+      MPI_Comm *app_comm = (MPI_Comm *)hermes->GetAppCommunicator();
+      MPI_Reduce(&seconds, &max_seconds, 1, MPI_DOUBLE, MPI_MAX, 0, *app_comm);
+
+      if (hermes->comm_.first_on_node) {
+        printf("local,1,%d,%d,%f\n", app_size, payload_bytes, max_seconds);
+      }
+    }
+
+  } else {
+    // Hermes core. No user code.
+  }
+
+  hermes->Finalize();
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -6,6 +6,18 @@
 #include "utils.h"
 
 namespace hapi = hermes::api;
+using std::chrono::time_point;
+
+double GetMaxSeconds(time_point<std::chrono::high_resolution_clock> start,
+                     time_point<std::chrono::high_resolution_clock> end,
+                     hapi::Hermes *hermes) {
+  double seconds = std::chrono::duration<double>(end - start).count();
+  double max_seconds = 0;
+  MPI_Comm *app_comm = (MPI_Comm *)hermes->GetAppCommunicator();
+  MPI_Reduce(&seconds, &max_seconds, 1, MPI_DOUBLE, MPI_MAX, 0, *app_comm);
+
+  return max_seconds;
+}
 
 int main(int argc, char **argv) {
   int mpi_threads_provided;
@@ -43,24 +55,38 @@ int main(int argc, char **argv) {
         buffer_ids[j] = id;
       }
 
-      auto start = now();
+      time_point start_put = now();
       hermes::u32 location = LocalAllocateBufferIdList(mdm, buffer_ids);
-      auto end = now();
+      time_point end_put = now();
 
       hermes::BlobID blob_id = {};
       blob_id.bits.node_id = app_rank;
       blob_id.bits.buffer_ids_offset = location;
+
+      hermes::ScopedTemporaryMemory scratch(&hermes->trans_arena_);
+      hermes::BufferIdArray buffer_id_arr = {};
+
+      time_point start_get = now();
+      hermes::LocalGetBufferIdList(scratch, mdm, blob_id, &buffer_id_arr);
+      time_point end_get = now();
+
+      time_point start_del = now();
       LocalFreeBufferIdList(&hermes->context_, blob_id);
+      time_point end_del = now();
 
       hermes->AppBarrier();
 
-      double seconds = std::chrono::duration<double>(end - start).count();
-      double max_seconds = 0;
-      MPI_Comm *app_comm = (MPI_Comm *)hermes->GetAppCommunicator();
-      MPI_Reduce(&seconds, &max_seconds, 1, MPI_DOUBLE, MPI_MAX, 0, *app_comm);
+      double max_put_seconds = GetMaxSeconds(start_put, end_put, hermes.get());
+      double max_get_seconds = GetMaxSeconds(start_get, end_get, hermes.get());
+      double max_del_seconds = GetMaxSeconds(start_del, end_del, hermes.get());
 
       if (hermes->comm_.first_on_node) {
-        printf("put,local,1,%d,%d,%f\n", app_size, payload_bytes, max_seconds);
+        printf("put,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+               max_put_seconds);
+        printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+               max_get_seconds);
+        printf("del,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
+               max_del_seconds);
       }
     }
 

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -98,6 +98,7 @@ void BenchRemote(const char *config_file) {
 
   if (hermes->IsApplicationCore()) {
     int app_rank = hermes->GetProcessRank();
+    int app_size = hermes->GetNumProcesses();
 
     if (app_rank == 0) {
       for (hermes::u32 i = 1; i <= KILOBYTES(4) / sizeof_id; i *= 2) {
@@ -115,7 +116,7 @@ void BenchRemote(const char *config_file) {
           buffer_ids[j] = id;
         }
 
-        const int kRepeats = 64;
+        const int kRepeats = 1024;
 
         time_point start_put = now();
         hermes::u32 id_list_offsets[kRepeats] = {0};
@@ -141,8 +142,8 @@ void BenchRemote(const char *config_file) {
         double del_seconds =
           std::chrono::duration<double>(end_del - start_del).count();
 
-        printf("%d,%f\n", payload_bytes, kRepeats / put_seconds);
-        printf("%d,%f\n", payload_bytes, kRepeats / del_seconds);
+        printf("put,%d,%d,%f\n", app_size, payload_bytes, kRepeats / put_seconds);
+        printf("del,%d,%d,%f\n", app_size, payload_bytes, kRepeats / del_seconds);
         // printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
         // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
         //        max_get_seconds);

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -145,8 +145,7 @@ void BenchRemote(const char *config_file) {
         double payload_megabytes = (payload_bytes * kRepeats) / 1024.0 / 1024.0;
         printf("put,%d,%d,%f,%f\n", app_size, payload_bytes, kRepeats / put_seconds,
                payload_megabytes / put_seconds);
-        printf("del,%d,%d,%f,%f\n", app_size, payload_bytes, kRepeats / del_seconds,
-               payload_megabytes / del_seconds);
+        printf("del,%d,%d,%f\n", app_size, payload_bytes, kRepeats / del_seconds);
         // printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
         // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
         //        max_get_seconds);

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -143,9 +143,10 @@ void BenchRemote(const char *config_file) {
           std::chrono::duration<double>(end_del - start_del).count();
 
         double payload_megabytes = (payload_bytes * kRepeats) / 1024.0 / 1024.0;
-        printf("put,%d,%d,%f,%f\n", app_size, payload_bytes, kRepeats / put_seconds,
-               payload_megabytes / put_seconds);
-        printf("del,%d,%d,%f\n", app_size, payload_bytes, kRepeats / del_seconds);
+        printf("put,%d,%d,%f,%f\n", app_size, payload_bytes,
+               kRepeats / put_seconds, payload_megabytes / put_seconds);
+        printf("del,%d,%d,%f\n", app_size, payload_bytes,
+               kRepeats / del_seconds);
         // printf("put,remote,1,1,%d,%.8f\n", payload_bytes, put_seconds);
         // printf("get,local,1,%d,%d,%.8f\n", app_size, payload_bytes,
         //        max_get_seconds);

--- a/benchmarks/mdm_bench.cc
+++ b/benchmarks/mdm_bench.cc
@@ -67,8 +67,8 @@ void Run(int target_node, int rank, int comm_size, int num_requests,
 
     FreeBufferIdList(&hermes->context_, &hermes->rpc_, blob_id);
 
-    // TODO(chogan): Time 'put' and 'delete' once they are optimized. For now they
-    // are too slow so we just time 'get'.
+    // TODO(chogan): Time 'put' and 'delete' once they are optimized. For now
+    // they are too slow so we just time 'get'.
     double avg_get_seconds = GetAvgSeconds(start_get, end_get, hermes, comm);
 
     if (rank == 0) {

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -66,6 +66,12 @@ int Hermes::GetNumProcesses() {
   return result;
 }
 
+void *Hermes::GetAppCommunicator() {
+  void *result = hermes::GetAppCommunicator(&comm_);
+
+  return result;
+}
+
 void Hermes::Finalize(bool force_rpc_shutdown) {
   hermes::Finalize(&context_, &comm_, &rpc_, shmem_name_.c_str(), &trans_arena_,
                    IsApplicationCore(), force_rpc_shutdown);

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -147,8 +147,7 @@ SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
   mdm->rpc_state_offset = (u8 *)rpc->state - shmem_base;
 
   InitMetadataManager(mdm, &arenas[kArenaType_MetaData], config, comm->node_id);
-  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config,
-                      comm->node_id);
+  InitMetadataStorage(&context, mdm, &arenas[kArenaType_MetaData], config);
 
   // NOTE(chogan): Store the metadata_manager_offset right after the
   // buffer_pool_offset so other processes can pick it up.

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -268,10 +268,14 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
                                            sleep_ms);
   }
 
+  WorldBarrier(&comm);
+
   api::Context::default_buffer_organizer_retries =
     config->num_buffer_organizer_retries;
 
-  WorldBarrier(&comm);
+  if (comm.proc_kind == ProcessKind::kApp) {
+    InitRpcClients(&result->rpc_);
+  }
 
   return result;
 }

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -50,12 +50,24 @@ bool Hermes::IsApplicationCore() {
   return result;
 }
 
+bool Hermes::IsFirstRankOnNode() {
+  bool result = comm_.first_on_node;
+
+  return result;
+}
+
 void Hermes::AppBarrier() {
   hermes::SubBarrier(&comm_);
 }
 
 int Hermes::GetProcessRank() {
   int result = comm_.sub_proc_id;
+
+  return result;
+}
+
+int Hermes::GetNodeId() {
+  int result = comm_.node_id;
 
   return result;
 }

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -51,6 +51,7 @@ class Hermes {
   void AppBarrier();
   int GetProcessRank();
   int GetNumProcesses();
+  void *GetAppCommunicator();
   void Finalize(bool force_rpc_shutdown = false);
 
   // MPI comms.
@@ -104,6 +105,8 @@ std::shared_ptr<api::Hermes> InitHermes(const char *config_file = NULL,
 
 }  // namespace api
 
+std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon = false,
+                                        bool is_adapter = false);
 std::shared_ptr<api::Hermes> InitHermesDaemon(char *config_file = NULL);
 std::shared_ptr<api::Hermes> InitHermesDaemon(Config *config);
 std::shared_ptr<api::Hermes> InitHermesClient(const char *config_file = NULL);

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -48,8 +48,10 @@ class Hermes {
   }
 
   bool IsApplicationCore();
+  bool IsFirstRankOnNode();
   void AppBarrier();
   int GetProcessRank();
+  int GetNodeId();
   int GetNumProcesses();
   void *GetAppCommunicator();
   void Finalize(bool force_rpc_shutdown = false);

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -21,6 +21,8 @@ class Hermes {
  public:
   std::set<std::string> bucket_list_;
   std::set<std::string> vbucket_list_;
+
+  // TODO(chogan): Temporarily public to facilitate iterative development.
   hermes::SharedMemoryContext context_;
   hermes::CommunicationContext comm_;
   hermes::RpcContext rpc_;

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -17,6 +17,10 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
     blob.data = blob_mem.data();
     blob.size = blob_mem.size();
     size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
+    if (bytes_read != swap_blob.size) {
+      // TODO(chogan): @errorhandling
+      result = 1;
+    }
 
     ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
                     swap_blob.bucket_id);
@@ -30,6 +34,10 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
 
 int MoveToTarget(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id,
                  TargetID dest) {
+  (void)(context);
+  (void)(rpc);
+  (void)(blob_id);
+  (void)(dest);
 // TODO(chogan): Move blob from current location to Target dest
   HERMES_NOT_IMPLEMENTED_YET;
   int result = 0;

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -374,6 +374,7 @@ static std::atomic<u32> *GetAvailableBuffersArray(SharedMemoryContext *context,
   return result;
 }
 
+#if 0
 static u32 GetNumBuffersAvailable(SharedMemoryContext *context,
                                   DeviceID device_id, int slab_index) {
   std::atomic<u32> *buffers_available = GetAvailableBuffersArray(context,
@@ -404,6 +405,7 @@ static u64 GetNumBytesRemaining(SharedMemoryContext *context, DeviceID id) {
 
   return result;
 }
+#endif
 
 static void DecrementAvailableBuffers(SharedMemoryContext *context,
                                       DeviceID device_id, int slab_index) {
@@ -1465,11 +1467,12 @@ SwapBlob WriteToSwap(SharedMemoryContext *context, Blob blob, u32 node_id,
       HERMES_NOT_IMPLEMENTED_YET;
     }
 
-    result.offset = ftell(context->swap_file);
-    if (result.offset == -1) {
+    long int file_position = ftell(context->swap_file);
+    if (file_position == -1) {
       // TODO(chogan): @errorhandling
       HERMES_NOT_IMPLEMENTED_YET;
     }
+    result.offset = file_position;
 
     if (fwrite(blob.data, 1, blob.size, context->swap_file) != blob.size) {
       // TODO(chogan): @errorhandling

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -70,6 +70,7 @@ void Finalize(SharedMemoryContext *context, CommunicationContext *comm,
               bool is_application_core, bool force_rpc_shutdown) {
   WorldBarrier(comm);
   if (is_application_core) {
+    ShutdownRpcClients(rpc);
     ReleaseSharedMemoryContext(context);
     HERMES_DEBUG_CLIENT_CLOSE();
   }

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1000,19 +1000,18 @@ ptrdiff_t InitBufferPool(u8 *shmem_base, Arena *buffer_pool_arena,
   int *num_buffers = PushArray<int>(scratch_arena, config->num_devices);
   int total_buffers = 0;
   for (int device = 0; device < config->num_devices; ++device) {
-    fprintf(stderr, "Device %d:\n", device);
+    DLOG(INFO) << "Device: " << device << std::endl;
     num_buffers[device] = 0;
     for (int slab = 0; slab < config->num_slabs[device]; ++slab) {
-      // TODO(chogan): @logging Switch to DLOG
-      fprintf(stderr, "    %d-Buffers: %d\n", slab,
-              buffer_counts[device][slab]);
+      DLOG(INFO) << "    " << slab << "-Buffers: "
+                 << buffer_counts[device][slab] << std::endl;
       num_buffers[device] += buffer_counts[device][slab];
     }
     total_buffers += num_buffers[device];
-    fprintf(stderr, "    Num Headers: %d\n", header_counts[device]);
-    fprintf(stderr, "    Num Buffers: %d\n", num_buffers[device]);
+    DLOG(INFO) << "    Num Headers: " << header_counts[device] << std::endl;
+    DLOG(INFO) << "    Num Buffers: " << num_buffers[device] << std::endl;
   }
-  fprintf(stderr, "Total Buffers: %d\n", total_buffers);
+  DLOG(INFO) << "Total Buffers: " << total_buffers << std::endl;;
 
   // Build RAM buffers.
 

--- a/src/communication.h
+++ b/src/communication.h
@@ -60,6 +60,8 @@ inline void SubBarrier(CommunicationContext *comm) {
   comm->sub_barrier(comm->state);
 }
 
+void *GetAppCommunicator(CommunicationContext *comm);
+
 }  // namespace hermes
 
 #endif  // HERMES_COMMUNICATION_H_

--- a/src/communication_mpi.cc
+++ b/src/communication_mpi.cc
@@ -17,6 +17,12 @@ struct MPIState {
   MPI_Comm sub_comm;
 };
 
+void *GetAppCommunicator(CommunicationContext *comm) {
+  MPIState *mpi_state = (MPIState *)comm->state;
+
+  return &mpi_state->sub_comm;
+}
+
 inline int MpiGetProcId(MPI_Comm comm) {
   int result;
   MPI_Comm_rank(comm, &result);

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -21,6 +21,7 @@ using hermes::api::Status;
 Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
                         std::vector<size_t> blob_sizes,
                         std::vector<PlacementSchema> &output) {
+  (void)rpc;
   HERMES_NOT_IMPLEMENTED_YET;
 
   Status result = 0;
@@ -157,6 +158,7 @@ Status RoundRobinPlacement(SharedMemoryContext *context, RpcContext *rpc,
 Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
                        std::vector<size_t> &blob_sizes,
                        std::vector<PlacementSchema> &output) {
+  (void)rpc;
   // TODO(chogan): For now we just look at the node level. Eventually we will
   // need the ability to escalate to neighborhoods, and the entire cluster.
   std::vector<u64> node_state = GetRemainingNodeCapacities(context);
@@ -262,6 +264,7 @@ Status RandomPlacement(SharedMemoryContext *context, RpcContext *rpc,
 Status MinimizeIoTimePlacement(SharedMemoryContext *context, RpcContext *rpc,
                             std::vector<size_t> &blob_sizes,
                             std::vector<PlacementSchema> &output) {
+  (void)rpc;
   using operations_research::MPSolver;
   using operations_research::MPVariable;
   using operations_research::MPConstraint;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -234,6 +234,8 @@ VBucketInfo *GetVBucketInfoByIndex(MetadataManager *mdm, u32 index);
 u32 AllocateBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
                          u32 target_node,
                          const std::vector<BufferID> &buffer_ids);
+std::vector<BufferID> GetBufferIdList(SharedMemoryContext *context,
+                                      RpcContext *rpc, BlobID blob_id);
 void FreeBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
                       BlobID blob_id);
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -231,6 +231,11 @@ u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);
 MetadataManager *GetMetadataManagerFromContext(SharedMemoryContext *context);
 BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index);
 VBucketInfo *GetVBucketInfoByIndex(MetadataManager *mdm, u32 index);
+u32 AllocateBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
+                         u32 target_node,
+                         const std::vector<BufferID> &buffer_ids);
+void FreeBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
+                      BlobID blob_id);
 
 void LocalAddBlobIdToBucket(MetadataManager *mdm, BucketID bucket_id,
                             BlobID blob_id);

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -279,7 +279,7 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
                                             double slepp_ms);
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
-                         Arena *arena, Config *config, i32 node_id);
+                         Arena *arena, Config *config);
 
 std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
 std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -380,8 +380,7 @@ void SeedHashForStorage(size_t seed) {
   stbds_rand_seed(seed);
 }
 
-void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
-                           Arena *arena, Config *config) {
+void InitSwapSpaceFilename(MetadataManager *mdm, Arena *arena, Config *config) {
   std::string swap_filename_prefix("swap");
   size_t swap_mount_length = config->swap_mount.size();
   bool ends_in_slash = config->swap_mount[swap_mount_length - 1] == '/';
@@ -405,8 +404,8 @@ void InitSwapSpaceFilename(SharedMemoryContext *context, MetadataManager *mdm,
 }
 
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
-                         Arena *arena, Config *config, i32 node_id) {
-  InitSwapSpaceFilename(context, mdm, arena, config);
+                         Arena *arena, Config *config) {
+  InitSwapSpaceFilename(mdm, arena, config);
 
   // Heaps
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -155,7 +155,8 @@ IdList *AllocateIdList(MetadataManager *mdm, u32 length) {
   IdList *result = (IdList *)id_list_memory;
   result->length = length;
   result->head_offset = GetHeapOffset(id_heap, (u8 *)(result + 1));
-  CheckHeapOverlap(mdm);
+  // TEMP(chogan):
+  // CheckHeapOverlap(mdm);
 
   return result;
 }

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -210,7 +210,8 @@ void LocalFreeBufferIdList(SharedMemoryContext *context, BlobID blob_id) {
   u8 *to_free = HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
 
   HeapFree(id_heap, to_free);
-  CheckHeapOverlap(mdm);
+  // TEMP(chogan):
+  // CheckHeapOverlap(mdm);
 }
 
 void LocalRemoveBlobFromBucketInfo(SharedMemoryContext *context,

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -155,8 +155,7 @@ IdList *AllocateIdList(MetadataManager *mdm, u32 length) {
   IdList *result = (IdList *)id_list_memory;
   result->length = length;
   result->head_offset = GetHeapOffset(id_heap, (u8 *)(result + 1));
-  // TEMP(chogan):
-  // CheckHeapOverlap(mdm);
+  CheckHeapOverlap(mdm);
 
   return result;
 }
@@ -210,8 +209,7 @@ void LocalFreeBufferIdList(SharedMemoryContext *context, BlobID blob_id) {
   u8 *to_free = HeapOffsetToPtr(id_heap, blob_id.bits.buffer_ids_offset);
 
   HeapFree(id_heap, to_free);
-  // TEMP(chogan):
-  // CheckHeapOverlap(mdm);
+  CheckHeapOverlap(mdm);
 }
 
 void LocalRemoveBlobFromBucketInfo(SharedMemoryContext *context,

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -47,6 +47,9 @@ struct RpcContext {
 void InitRpcContext(RpcContext *rpc, u32 num_nodes, u32 node_id,
                     Config *config);
 void *CreateRpcState(Arena *arena);
+void InitRpcClients(RpcContext *rpc);
+void ShutdownRpcClients(RpcContext *rpc);
+
 void FinalizeRpcContext(RpcContext *rpc, bool is_daemon);
 std::string GetHostNumberAsString(RpcContext *rpc, u32 node_id);
 std::string GetServerName(RpcContext *rpc, u32 node_id,

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -17,7 +17,13 @@ const int kMaxServerSuffixSize = 16;
 typedef void (*StartFunc)(SharedMemoryContext*, RpcContext*, Arena*,
                           const char*, int);
 
+struct ClientRpcContext {
+  void *state;
+  size_t state_size;
+};
+
 struct RpcContext {
+  ClientRpcContext client_rpc;
   void *state;
   /** The size of the internal rpc state. */
   size_t state_size;

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -392,6 +392,8 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
                                            SwapBlob swap_blob,
                                            TargetID target_id, int retries) {
     (void)req;
+    (void)swap_blob;
+    (void)target_id;
     for (int i = 0; i < retries; ++i) {
       // TODO(chogan): MoveToTarget(context, rpc, target_id, swap_blob);
       HERMES_NOT_IMPLEMENTED_YET;

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -301,7 +301,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
     };
 
   function<void(const request&, int)> rpc_test =
-    [](const reqeust &req, int val) {
+    [](const request &req, int val) {
       req.respond(val + 1);
   };
 

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -300,10 +300,16 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       state->engine->finalize();
     };
 
+  function<void(const request&, int)> rpc_test =
+    [](const reqeust &req, int val) {
+      req.respond(val + 1);
+  };
+
   // TODO(chogan): Currently these three are only used for testing.
   rpc_server->define("GetBuffers", rpc_get_buffers);
   rpc_server->define("SplitBuffers", rpc_split_buffers).disable_response();
   rpc_server->define("MergeBuffers", rpc_merge_buffers).disable_response();
+  rpc_server->define("RpcTest", rpc_test);
   //
 
   rpc_server->define("RemoteReleaseBuffer",

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -480,6 +480,28 @@ void *CreateRpcState(Arena *arena) {
   return result;
 }
 
+std::string GetProtocol(RpcContext *rpc) {
+  ThalliumState *tl_state = GetThalliumState(rpc);
+
+  std::string prefix = std::string(tl_state->server_name_prefix);
+  // NOTE(chogan): Chop "://" off the end of the server_name_prefix to get the
+  // protocol
+  std::string result = prefix.substr(0, prefix.length() - 3);
+
+  return result;
+}
+
+void InitRpcClients(RpcContext *rpc) {
+  ThalliumState *state = GetThalliumState(rpc);
+  std::string protocol = GetProtocol(rpc);
+  state->client_engine = new tl::engine(protocol, THALLIUM_CLIENT_MODE, true);
+}
+
+void ShutdownRpcClients(RpcContext *rpc) {
+  ThalliumState *state = GetThalliumState(rpc);
+  delete state->client_engine;
+}
+
 void FinalizeRpcContext(RpcContext *rpc, bool is_daemon) {
   ThalliumState *state = GetThalliumState(rpc);
   state->kill_requested.store(true);
@@ -537,17 +559,6 @@ std::string GetServerName(RpcContext *rpc, u32 node_id,
   } else {
     result += std::string(tl_state->server_name_postfix);
   }
-
-  return result;
-}
-
-std::string GetProtocol(RpcContext *rpc) {
-  ThalliumState *tl_state = GetThalliumState(rpc);
-
-  std::string prefix = std::string(tl_state->server_name_prefix);
-  // NOTE(chogan): Chop "://" off the end of the server_name_prefix to get the
-  // protocol
-  std::string result = prefix.substr(0, prefix.length() - 3);
 
   return result;
 }

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -300,16 +300,10 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       state->engine->finalize();
     };
 
-  function<void(const request&, int)> rpc_test =
-    [](const request &req, int val) {
-      req.respond(val + 1);
-  };
-
   // TODO(chogan): Currently these three are only used for testing.
   rpc_server->define("GetBuffers", rpc_get_buffers);
   rpc_server->define("SplitBuffers", rpc_split_buffers).disable_response();
   rpc_server->define("MergeBuffers", rpc_merge_buffers).disable_response();
-  rpc_server->define("RpcTest", rpc_test);
   //
 
   rpc_server->define("RemoteReleaseBuffer",

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
   bool test_swap = false;
   bool start_server = false;
 
-  while ((option = getopt(argc, argv, "bf:s")) != -1) {
+  while ((option = getopt(argc, argv, "bf:sx")) != -1) {
     switch (option) {
       case 'b': {
         test_get_buffers = true;


### PR DESCRIPTION
* Added benchmark tool for the MDM.
* Added some new public APIs
    * Hermes::IsFirstRankOnNode();
    * Hermes::GetNodeId();
    * Hermes::GetAppCommunicator();
* Fixed several warnings
* Creating and saving a `thallium::engine` once per client instead of on each RPC (800x speedup!)
