### PR TITLE
DPE related bug fixes and refactoring

### DIFF
--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -64,11 +64,9 @@ std::vector<int> GetValidSplitChoices(size_t blob_size) {
   // Split the blob if size is greater than 64KB
   if (blob_size > KILOBYTES(64) && blob_size <= KILOBYTES(256)) {
     split_option = 2;
-  }
-  else if (blob_size > KILOBYTES(256) && blob_size <= MEGABYTES(1)) {
+  } else if (blob_size > KILOBYTES(256) && blob_size <= MEGABYTES(1)) {
     split_option = 5;
-  }
-  else if (blob_size > MEGABYTES(1) && blob_size <= MEGABYTES(4)) {
+  } else if (blob_size > MEGABYTES(1) && blob_size <= MEGABYTES(4)) {
     split_option = 8;
   }
 

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -60,7 +60,7 @@ Status TopDownPlacement(SharedMemoryContext *context, RpcContext *rpc,
 }
 
 std::vector<int> GetValidSplitChoices(size_t blob_size) {
-  int split_option {1};
+  int split_option = 10;
   // Split the blob if size is greater than 64KB
   if (blob_size > KILOBYTES(64) && blob_size <= KILOBYTES(256)) {
     split_option = 2;
@@ -70,9 +70,6 @@ std::vector<int> GetValidSplitChoices(size_t blob_size) {
   }
   else if (blob_size > MEGABYTES(1) && blob_size <= MEGABYTES(4)) {
     split_option = 8;
-  }
-  else {
-    split_option = 10;
   }
 
   constexpr int split_range[] = { 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 };

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -1,6 +1,8 @@
 #ifndef HERMES_DATA_PLACEMENT_ENGINE_H_
 #define HERMES_DATA_PLACEMENT_ENGINE_H_
 
+#include <map>
+
 #include "hermes_types.h"
 #include "hermes.h"
 

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -23,5 +23,8 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
                           std::vector<PlacementSchema> &output,
                           const api::Context &api_context);
 
+// internal
+std::vector<int> GetValidSplitChoices(size_t blob_size);
+
 }  // namespace hermes
 #endif  // HERMES_DATA_PLACEMENT_ENGINE_H_

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -28,7 +28,8 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
 // internal
 std::vector<int> GetValidSplitChoices(size_t blob_size);
 Status AddRandomSchema(std::multimap<u64, size_t> &ordered_cap,
-                       size_t blob_size, std::vector<PlacementSchema> &output);
+                       size_t blob_size, std::vector<PlacementSchema> &output,
+                       std::vector<u64> &node_state);
 
 }  // namespace hermes
 #endif  // HERMES_DATA_PLACEMENT_ENGINE_H_

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -25,6 +25,8 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
 
 // internal
 std::vector<int> GetValidSplitChoices(size_t blob_size);
+Status AddRandomSchema(std::multimap<u64, size_t> &ordered_cap,
+                       size_t blob_size, std::vector<PlacementSchema> &output);
 
 }  // namespace hermes
 #endif  // HERMES_DATA_PLACEMENT_ENGINE_H_

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
     config.arena_percentages[hermes::kArenaType_MetaData] = 0.5;
 
     std::shared_ptr<Hermes> hermes = hermes::InitHermesDaemon(&config);
-    // TestSwap(hermes);
+    TestSwap(hermes);
     TestBufferOrganizer(hermes);
     hermes->Finalize(true);
   }

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -8,6 +8,7 @@
 #include "data_placement_engine.h"
 
 using namespace hermes;  // NOLINT(*)
+namespace hapi = hermes::api;
 
 namespace hermes {
 namespace testing {
@@ -63,7 +64,7 @@ void UpdateSystemViewState(PlacementSchema schema) {
   }
 }
 
-std::vector<PlacementSchema> RandomPlacement(std::vector<hermes::api::Blob> blobs) {
+std::vector<PlacementSchema> RandomPlacement(std::vector<hapi::Blob> blobs) {
   std::vector<PlacementSchema> result;
   // TODO(KIMMY): use kernel function of system view
   testing::SystemViewState state {GetSystemViewState()};

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -68,10 +68,13 @@ std::vector<PlacementSchema> RandomPlacement(std::vector<hapi::Blob> blobs) {
   std::vector<PlacementSchema> result;
   // TODO(KIMMY): use kernel function of system view
   testing::SystemViewState state {GetSystemViewState()};
+  std::vector<u64> node_state(state.num_devices);
   std::multimap<u64, size_t> ordered_cap;
+
 
   for (int j {0}; j < state.num_devices; ++j) {
     ordered_cap.insert(std::pair<u64, size_t>(state.bytes_available[j], j));
+    node_state[j] = state.bytes_available[j];
   }
 
   for (size_t i {0}; i < blobs.size(); ++i) {
@@ -109,12 +112,12 @@ std::vector<PlacementSchema> RandomPlacement(std::vector<hapi::Blob> blobs) {
                               blob_each_portion*(split_num-1));
 
       for (size_t k {0}; k < new_blob_size.size(); ++k) {
-        AddRandomSchema(ordered_cap, new_blob_size[k], result);
+        AddRandomSchema(ordered_cap, new_blob_size[k], result, node_state);
       }
     } else {
       // Blob size is less than 64KB or do not split
       std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
-      AddRandomSchema(ordered_cap, blobs[i].size(), result);
+      AddRandomSchema(ordered_cap, blobs[i].size(), result, node_state);
     }
   }
 

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -5,6 +5,7 @@
 #include "ortools/linear_solver/linear_solver.h"
 
 #include "hermes.h"
+#include "data_placement_engine.h"
 
 using namespace hermes;  // NOLINT(*)
 
@@ -88,22 +89,8 @@ PlacementSchema RandomPlacement(std::vector<hermes::api::Blob> blobs) {
 
     // Split the blob
     if (number) {
-      int split_option {1};
       std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
-      // Not split the blob if size is less than 64KB
-      if (blobs[i].size() > KILOBYTES(64) && blobs[i].size() <= KILOBYTES(256))
-        split_option = 2;
-      else if (blobs[i].size() > KILOBYTES(256) &&
-               blobs[i].size() <= MEGABYTES(1))
-        split_option = 5;
-      else if (blobs[i].size() > MEGABYTES(1) &&
-               blobs[i].size() <= MEGABYTES(4))
-        split_option = 8;
-      else
-        split_option = 10;
-
-      int split_range[] = { 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
-      std::vector<int> split_choice(split_range, split_range+split_option-1);
+      std::vector<int> split_choice = GetValidSplitChoices(blobs[i].size());
 
       // Random pickup a number from split_choice to split the blob
       std::uniform_int_distribution<std::mt19937::result_type>

--- a/test/dpe_roundrobin_test.cc
+++ b/test/dpe_roundrobin_test.cc
@@ -5,6 +5,7 @@
 #include "ortools/linear_solver/linear_solver.h"
 
 #include "hermes.h"
+#include "data_placement_engine.h"
 
 using namespace hermes;  // NOLINT(*)
 
@@ -86,22 +87,8 @@ PlacementSchema RoundRobinPlacement(std::vector<hermes::api::Blob> blobs) {
 
     // Split the blob
     if (number) {
-      int split_option {1};
       std::cout << "blob size is " << blobs[i].size() << '\n' << std::flush;
-      // Not split the blob if size is less than 64KB
-      if (blobs[i].size() > KILOBYTES(64) && blobs[i].size() <= KILOBYTES(256))
-        split_option = 2;
-      else if (blobs[i].size() > KILOBYTES(256) &&
-               blobs[i].size() <= MEGABYTES(1))
-        split_option = 5;
-      else if (blobs[i].size() > MEGABYTES(1) &&
-               blobs[i].size() <= MEGABYTES(4))
-        split_option = 8;
-      else
-        split_option = 10;
-
-      int split_range[] = { 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
-      std::vector<int> split_choice(split_range, split_range+split_option-1);
+      std::vector<int> split_choice = GetValidSplitChoices(blobs[i].size());
 
      // Random pickup a number from split_choice to split the blob
      std::uniform_int_distribution<std::mt19937::result_type>


### PR DESCRIPTION
Replaces #43.
* Added a single function (`UpdateBufferingCapacities`) that handles all capacity updates. We currently update a global system view state and node level capacities, but the two will likely merge into one once we have topologies and targets worked out.
* Factored `GetValidSplitChoices` and `AddRandomSchema` out of `RandomPlacement` (in the library and in the tests) to eliminate code duplication.
* Corrected behavior of `AddRandomSchema`.
* `RoundRobinPlacement` operates on node state instead of global state.
* Properly initialize `ordered_cap` in `RandomPlacement`.
* `RandomPlacement` updates its local copy of `node_state` (working on outdated information or course).
