### PR TITLE
Fix two bugs and a warning

### DIFF
--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -161,12 +161,12 @@ Status Bucket::Put(std::vector<std::string> &names,
 
   if (IsValid()) {
     size_t num_blobs = blobs.size();
-    std::vector<size_t> sizes(num_blobs);
+    std::vector<size_t> sizes_in_bytes(num_blobs);
     for (size_t i = 0; i < num_blobs; ++i) {
-      sizes[i] = blobs[i].size();
+      sizes_in_bytes[i] = blobs[i].size() * sizeof(T);
     }
     std::vector<PlacementSchema> schemas;
-    ret = CalculatePlacement(&hermes_->context_, &hermes_->rpc_, sizes,
+    ret = CalculatePlacement(&hermes_->context_, &hermes_->rpc_, sizes_in_bytes,
                              schemas, ctx);
 
     if (ret == 0) {
@@ -175,7 +175,7 @@ Status Bucket::Put(std::vector<std::string> &names,
       std::vector<SwapBlob> swapped_blobs =
         PutToSwap(&hermes_->context_, &hermes_->rpc_, id_, blobs, names);
 
-      for (int i = 0; i < swapped_blobs.size(); ++i) {
+      for (size_t i = 0; i < swapped_blobs.size(); ++i) {
         TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, names[i],
                                swapped_blobs[i], ctx.buffer_organizer_retries);
       }

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1036,7 +1036,7 @@ ptrdiff_t InitBufferPool(u8 *shmem_base, Arena *buffer_pool_arena,
   // TODO(chogan): @configuration Assumes the first Device is RAM
   for (int slab = 0; slab < config->num_slabs[0]; ++slab) {
     PartitionRamBuffers(buffer_pool_arena, slab_buffer_sizes[0][slab],
-                        buffer_counts[0][slab], config->block_sizes[slab]);
+                        buffer_counts[0][slab], config->block_sizes[0]);
   }
 
   // Init Devices and Targets


### PR DESCRIPTION
* Any sizes passed to `CaclulatePlacement` should be in bytes.
* When partitioning RAM buffers, we always want the block size of the RAM tier.
* Fix an unsigned/signed comparison warning.