### PR TITLE
Fix false positives in CI and add warning flags

### DIFF
--- a/ci/install_hermes.sh
+++ b/ci/install_hermes.sh
@@ -9,7 +9,7 @@ pushd build
 
 INSTALL_PREFIX="${HOME}/${LOCAL}"
 
-export CXXFLAGS="${CXXFLAGS} -std=c++17"
+export CXXFLAGS="${CXXFLAGS} -std=c++17 -Werror -Wall -Wextra"
 cmake                                                      \
     -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}               \
     -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}                  \
@@ -29,6 +29,7 @@ cmake                                                      \
     -DHERMES_DEBUG_HEAP=OFF                                \
     ..
 
-cmake --build . -- -j4 && ctest -VV
+cmake --build . -- -j4
+ctest -VV
 
 popd


### PR DESCRIPTION
* In bash, `set -e` doesn't apply to compound statements that use `&&`, so if compilation failed, the job would still succeed because the last command in the script (`popd`) succeeded.
* Add `-Werror -Wall -Wextra` to the CI builds.