### PR TITLE
Set upper limit to name lengths

### DIFF
--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -165,7 +165,15 @@ Status Bucket::Put(std::vector<std::string> &names,
                    std::vector<std::vector<T>> &blobs, Context &ctx) {
   Status ret = 0;
 
-  if (IsValid()) {
+  for (auto &name : names) {
+    if (IsNameTooLong(name)) {
+      // TODO(chogan): @errorhandling
+      ret = 1;
+      break;
+    }
+  }
+
+  if (IsValid() && ret == 0) {
     size_t num_blobs = blobs.size();
     std::vector<size_t> sizes_in_bytes(num_blobs);
     for (size_t i = 0; i < num_blobs; ++i) {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -39,6 +39,7 @@ static constexpr int kMaxBufferPoolSlabs = 8;
 constexpr int kMaxPathLength = 256;
 constexpr int kMaxBufferPoolShmemNameLength = 64;
 constexpr int kMaxDevices = 8;
+constexpr int kMaxNameSize = 128;
 
 constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -12,6 +12,17 @@
 
 namespace hermes {
 
+bool IsNameTooLong(const std::string &name) {
+  bool result = false;
+  if (name.size() + 1 >= kMaxNameSize) {
+    LOG(WARNING) << "Name '" << name << "' exceeds the maximum name size of "
+                 << kMaxNameSize << " bytes." << std::endl;
+    result = true;
+  }
+
+  return result;
+}
+
 bool IsNullBucketId(BucketID id) {
   bool result = id.as_int == 0;
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -228,6 +228,11 @@ SwapBlob VecToSwapBlob(std::vector<BufferID> &vec);
  */
 SwapBlob IdArrayToSwapBlob(BufferIdArray ids);
 
+/**
+ *
+ */
+bool IsNameTooLong(const std::string &name);
+
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_


### PR DESCRIPTION
Restricting bucket and blob names to 128 bytes so we can get an upper bound for our metadata size.