### PR TITLE
Move from DeviceID to TargetID in data placement

### DIFF
--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -71,7 +71,6 @@ typedef std::vector<unsigned char> Blob;
 enum class PlacementPolicy {
   kRandom,
   kRoundRobin,
-  kTopDown,
   kMinimizeIoTime,
 };
 

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -149,6 +149,12 @@ Device *GetDeviceById(SharedMemoryContext *context, DeviceID device_id) {
   return result;
 }
 
+DeviceID GetDeviceIdFromTargetId(TargetID target_id) {
+  DeviceID result = target_id.bits.device_id;
+
+  return result;
+}
+
 BufferHeader *GetHeadersBase(SharedMemoryContext *context) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   BufferHeader *result = (BufferHeader *)(context->shm_base +
@@ -519,10 +525,8 @@ std::vector<BufferID> GetBuffers(SharedMemoryContext *context,
 
   bool failed = false;
   std::vector<BufferID> result;
-  for (auto &size_and_device : schema) {
-    DeviceID device_id = size_and_device.second;
-
-    size_t size_left = size_and_device.first;
+  for (auto [size_left, target] : schema) {
+    DeviceID device_id = GetDeviceIdFromTargetId(target);
     std::vector<size_t> num_buffers(pool->num_slabs[device_id], 0);
 
     // NOTE(chogan): naive buffer selection algorithm: fill with largest

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -54,16 +54,6 @@ struct Device {
   char mount_point[kMaxPathLength];
 };
 
-union TargetID {
-  struct {
-    u32 node_id;
-    u16 device_id;
-    u16 index;
-  } bits;
-
-  u64 as_int;
-};
-
 struct Target {
   TargetID id;
   /** The total capacity of the Target. */

--- a/src/data_placement_engine.h
+++ b/src/data_placement_engine.h
@@ -22,15 +22,17 @@ class DataPlacementEngine {
 
 Status RoundRobinPlacement(std::vector<size_t> &blob_sizes,
                         std::vector<u64> &node_state,
-                        std::vector<PlacementSchema> &output);
+                           std::vector<PlacementSchema> &output,
+                           const std::vector<TargetID> &targets);
 
 Status RandomPlacement(std::vector<size_t> &blob_sizes,
-                       std::multimap<u64, size_t> &ordered_cap,
+                       std::multimap<u64, TargetID> &ordered_cap,
                        std::vector<PlacementSchema> &output);
 
-Status MinimizeIoTimePlacement(std::vector<size_t> &blob_sizes,
-                               std::vector<u64> &node_state,
-                               std::vector<f32> &bandwidths,
+Status MinimizeIoTimePlacement(const std::vector<size_t> &blob_sizes,
+                               const std::vector<u64> &node_state,
+                               const std::vector<f32> &bandwidths,
+                               const std::vector<TargetID> &targets,
                                std::vector<PlacementSchema> &output);
 
 Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
@@ -38,7 +40,7 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
                           std::vector<PlacementSchema> &output,
                           const api::Context &api_context);
 
-PlacementSchema AggregateBlobSchema(size_t num_target, PlacementSchema &schema);
+PlacementSchema AggregateBlobSchema(PlacementSchema &schema);
 
 // internal
 std::vector<int> GetValidSplitChoices(size_t blob_size);

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -46,11 +46,22 @@ constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
 #define HERMES_NOT_IMPLEMENTED_YET \
   LOG(FATAL) << __func__ << " not implemented yet\n"
 
+union TargetID {
+  struct {
+    u32 node_id;
+    u16 device_id;
+    u16 index;
+  } bits;
+
+  u64 as_int;
+};
+
 /**
- * A PlacementSchema is a vector of (size, device) pairs where size is the number of
- * bytes to buffer and device is the Device ID where to buffer those bytes.
+ * A PlacementSchema is a vector of (size, target) pairs where size is the
+ * number of bytes to buffer and target is the TargetID where to buffer those
+ * bytes.
  */
-using PlacementSchema = std::vector<std::pair<size_t, DeviceID>>;
+using PlacementSchema = std::vector<std::pair<size_t, TargetID>>;
 
 /**
  * Distinguishes whether the process (or rank) is part of the application cores

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -46,10 +46,17 @@ constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
 #define HERMES_NOT_IMPLEMENTED_YET \
   LOG(FATAL) << __func__ << " not implemented yet\n"
 
+/** A TargetID uniquely identifies a buffering target within the system. */
 union TargetID {
   struct {
+    /** The ID of the node in charge of this target. */
     u32 node_id;
+    /** The ID of the virtual device that backs this target. It is an index into
+     * the Device array starting at BufferPool::devices_offset (on the node with
+     * ID node_id). */
     u16 device_id;
+    /** The index into the Target array starting at BufferPool::targets_offset
+     * (on the node with ID node_id). */
     u16 index;
   } bits;
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -41,6 +41,12 @@ bool IsNullBlobId(BlobID id) {
   return result;
 }
 
+bool IsNullTargetId(TargetID id) {
+  bool result = id.as_int == 0;
+
+  return result;
+}
+
 TicketMutex *GetMapMutex(MetadataManager *mdm, MapType map_type) {
   TicketMutex *mutex = 0;
   switch (map_type) {
@@ -602,17 +608,6 @@ u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id) {
   return result;
 }
 
-std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context) {
-  std::vector<TargetID> targets = GetNodeTargets(context);
-  std::vector<u64> result(targets.size());
-
-  for (size_t i = 0; i < targets.size(); ++i) {
-    result[i] = LocalGetRemainingCapacity(context, targets[i]);
-  }
-
-  return result;
-}
-
 u64 GetRemainingCapacity(SharedMemoryContext *context, RpcContext *rpc,
                          TargetID id) {
   u32 target_node = id.bits.node_id;
@@ -713,6 +708,22 @@ void UpdateGlobalSystemViewState(SharedMemoryContext *context,
                     adjustments);
     }
   }
+}
+
+TargetID FindTargetIdFromDeviceId(const std::vector<TargetID> &targets,
+                                  DeviceID device_id) {
+  TargetID result = {};
+  // TODO(chogan): @optimization Inefficient O(n)
+  for (size_t target_index = 0;
+       target_index < targets.size();
+       ++target_index) {
+    if (targets[target_index].bits.device_id == device_id) {
+      result = targets[target_index];
+      break;
+    }
+  }
+
+  return result;
 }
 
 static ptrdiff_t GetOffsetFromMdm(MetadataManager *mdm, void *ptr) {

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -233,6 +233,12 @@ SwapBlob IdArrayToSwapBlob(BufferIdArray ids);
  */
 bool IsNameTooLong(const std::string &name);
 
+/**
+ *
+ */
+TargetID FindTargetIdFromDeviceId(const std::vector<TargetID> &targets,
+                                  DeviceID device_id);
+
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -8,6 +8,7 @@ namespace hermes {
 bool IsNullBucketId(BucketID id);
 bool IsNullVBucketId(VBucketID id);
 bool IsNullBlobId(BlobID id);
+bool IsNullTargetId(TargetID id);
 TicketMutex *GetMapMutex(MetadataManager *mdm, MapType map_type);
 VBucketID GetVBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
                              const char *name);
@@ -72,7 +73,9 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config);
 
-std::vector<u64> GetRemainingNodeCapacities(SharedMemoryContext *context);
+std::vector<u64>
+GetRemainingNodeCapacities(SharedMemoryContext *context,
+                           const std::vector<TargetID> &targets);
 std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
 
 }  // namespace hermes

--- a/test/buffer_pool_client_test.cc
+++ b/test/buffer_pool_client_test.cc
@@ -27,6 +27,7 @@
 using namespace hermes;  // NOLINT(*)
 using hermes::testing::Timer;
 namespace hapi = hermes::api;
+const size_t kFourKiB = KILOBYTES(4);
 
 struct TimingResult {
   double get_buffers_time;
@@ -35,7 +36,8 @@ struct TimingResult {
 
 TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
   TimingResult result = {};
-  PlacementSchema schema{std::make_pair(4096, 0)};
+  TargetID ram_target = testing::DefaultRamTargetId();
+  PlacementSchema schema{std::make_pair(kFourKiB, ram_target)};
 
   Timer get_timer;
   Timer release_timer;
@@ -65,7 +67,8 @@ TimingResult TestGetBuffersRpc(RpcContext *rpc, int iters) {
 
 TimingResult TestGetBuffers(SharedMemoryContext *context, int iters) {
   TimingResult result = {};
-  PlacementSchema schema{std::make_pair(4096, 0)};
+  TargetID ram_target = testing::DefaultRamTargetId();
+  PlacementSchema schema{std::make_pair(kFourKiB, ram_target)};
 
   Timer get_timer;
   Timer release_timer;
@@ -150,15 +153,14 @@ void TestFileBuffering(std::shared_ptr<hapi::Hermes> hermes, int rank,
                        const char *test_file) {
   SharedMemoryContext *context = &hermes->context_;
   RpcContext *rpc = &hermes->rpc_;
-  DeviceID device_id = 1;
-
+  TargetID file_target = testing::DefaultFileTargetId();
   ScopedTemporaryMemory scratch(&hermes->trans_arena_);
 
   FileMapper mapper(test_file);
   Blob blob = mapper.blob;
 
   if (blob.data) {
-    PlacementSchema schema{std::make_pair(blob.size, device_id)};
+    PlacementSchema schema{std::make_pair(blob.size, file_target)};
     std::vector<BufferID> buffer_ids(0);
 
     while (buffer_ids.size() == 0) {

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -26,12 +26,12 @@ void TestGetBuffers(Hermes *hermes) {
   using namespace hermes;  // NOLINT(*)
   SharedMemoryContext *context = &hermes->context_;
   BufferPool *pool = GetBufferPoolFromContext(context);
-  DeviceID device_id = 0;
-  i32 block_size = pool->block_sizes[device_id];
+  TargetID ram_target = testing::DefaultRamTargetId();
+  i32 block_size = pool->block_sizes[ram_target.bits.device_id];
 
   {
     // A request smaller than the block size should return 1 buffer
-    PlacementSchema schema{std::make_pair(block_size / 2, device_id)};
+    PlacementSchema schema{std::make_pair(block_size / 2, ram_target)};
     std::vector<BufferID> ret = GetBuffers(context, schema);
     Assert(ret.size() == 1);
     LocalReleaseBuffers(context, ret);
@@ -39,7 +39,7 @@ void TestGetBuffers(Hermes *hermes) {
 
   {
     // A request larger than the available space should return no buffers
-    PlacementSchema schema{std::make_pair(GIGABYTES(3), device_id)};
+    PlacementSchema schema{std::make_pair(GIGABYTES(3), ram_target)};
     std::vector<BufferID> ret = GetBuffers(context, schema);
     Assert(ret.size() == 0);
   }
@@ -49,11 +49,12 @@ void TestGetBuffers(Hermes *hermes) {
     UpdateGlobalSystemViewState(context, &hermes->rpc_);
     std::vector<u64> global_state = GetGlobalDeviceCapacities(context,
                                                               &hermes->rpc_);
-    PlacementSchema schema{std::make_pair(global_state[device_id], device_id)};
+    PlacementSchema schema{
+      std::make_pair(global_state[ram_target.bits.device_id], ram_target)};
     std::vector<BufferID> ret = GetBuffers(context, schema);
     Assert(ret.size());
     // The next request should fail
-    PlacementSchema failed_schema{std::make_pair(1, device_id)};
+    PlacementSchema failed_schema{std::make_pair(1, ram_target)};
     std::vector<BufferID> failed_request = GetBuffers(context, failed_schema);
     Assert(failed_request.size() == 0);
     LocalReleaseBuffers(context, ret);

--- a/test/dpe_random_test.cc
+++ b/test/dpe_random_test.cc
@@ -8,17 +8,18 @@
 
 using namespace hermes;  // NOLINT(*)
 
-static hermes::testing::TargetViewState node_state {InitDeviceState()};
+static hermes::testing::TargetViewState node_state {testing::InitDeviceState()};
 
 u64 UpdateDeviceState(PlacementSchema schema) {
   u64 result {0};
   node_state.ordered_cap.clear();
 
-  for (auto [size, device] : schema) {
+  for (auto [size, target] : schema) {
     result += size;
-    node_state.bytes_available[device] -= size;
-    node_state.ordered_cap.insert(std::pair<u64, size_t>
-                              (node_state.bytes_available[device], device));
+    node_state.bytes_available[target.bits.device_id] -= size;
+    node_state.ordered_cap.insert(
+      std::pair<u64, TargetID>(
+        node_state.bytes_available[target.bits.device_id], target));
   }
 
   return result;
@@ -42,6 +43,9 @@ void RandomPlaceBlob(std::vector<size_t> &blob_sizes,
 
   std::cout << "\nRandomPlacement to place blob of size " << blob_sizes[0]
             << " to targets\n" << std::flush;
+
+  std::vector<TargetID> targets =
+    testing::GetDefaultTargets(node_state.num_devices);
   Status result = RandomPlacement(blob_sizes, node_state.ordered_cap,
                                   schemas_tmp);
   if (result) {
@@ -50,7 +54,7 @@ void RandomPlaceBlob(std::vector<size_t> &blob_sizes,
   }
 
   for (auto it = schemas_tmp.begin(); it != schemas_tmp.end(); ++it) {
-    PlacementSchema schema = AggregateBlobSchema(node_state.num_devices, (*it));
+    PlacementSchema schema = AggregateBlobSchema((*it));
     Assert(schemas.size() <= static_cast<size_t>(node_state.num_devices));
     schemas.push_back(schema);
   }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -46,15 +46,43 @@ struct TargetViewState {
   std::vector<hermes::u64> bytes_capacity;
   std::vector<hermes::u64> bytes_available;
   std::vector<hermes::f32> bandwidth;
-  std::multimap<hermes::u64, size_t> ordered_cap;
+  std::multimap<hermes::u64, TargetID> ordered_cap;
   int num_devices;
 };
 
-}  // namespace testing
-}  // namespace hermes
+TargetID DefaultRamTargetId() {
+  TargetID result = {};
+  result.bits.node_id = 1;
+  result.bits.device_id = 0;
+  result.bits.index = 0;
 
-hermes::testing::TargetViewState InitDeviceState() {
-  hermes::testing::TargetViewState result = {};
+  return result;
+}
+
+TargetID DefaultFileTargetId() {
+  TargetID result = {};
+  result.bits.node_id = 1;
+  result.bits.device_id = 1;
+  result.bits.index = 1;
+
+  return result;
+}
+
+std::vector<TargetID> GetDefaultTargets(size_t n) {
+  std::vector<TargetID> result(n);
+  for (size_t i = 0; i < n; ++i) {
+    TargetID id = {};
+    id.bits.node_id = 1;
+    id.bits.device_id = (DeviceID)i;
+    id.bits.index = i;
+    result[i] = id;
+  }
+
+  return result;
+}
+
+TargetViewState InitDeviceState() {
+  TargetViewState result = {};
   result.num_devices = 4;
 
   result.bytes_available.push_back(MEGABYTES(5));
@@ -72,13 +100,22 @@ hermes::testing::TargetViewState InitDeviceState() {
   result.bandwidth.push_back(150);
   result.bandwidth.push_back(70);
 
-  result.ordered_cap.insert(std::pair<hermes::u64, size_t>(MEGABYTES(5), 0));
-  result.ordered_cap.insert(std::pair<hermes::u64, size_t>(MEGABYTES(20), 1));
-  result.ordered_cap.insert(std::pair<hermes::u64, size_t>(MEGABYTES(50), 2));
-  result.ordered_cap.insert(std::pair<hermes::u64, size_t>(MEGABYTES(200), 3));
+  using hermes::TargetID;
+  std::vector<TargetID> targets = GetDefaultTargets(result.num_devices);
+  result.ordered_cap.insert(std::pair<hermes::u64, TargetID>(MEGABYTES(5),
+                                                             targets[0]));
+  result.ordered_cap.insert(std::pair<hermes::u64, TargetID>(MEGABYTES(20),
+                                                             targets[1]));
+  result.ordered_cap.insert(std::pair<hermes::u64, TargetID>(MEGABYTES(50),
+                                                             targets[2]));
+  result.ordered_cap.insert(std::pair<hermes::u64, TargetID>(MEGABYTES(200),
+                                                             targets[3]));
 
   return result;
 }
+
+}  // namespace testing
+}  // namespace hermes
 
 #define Assert(expr) hermes::testing::Assert((expr), __FILE__, __LINE__, #expr)
 


### PR DESCRIPTION
* Changed `PlacementSchema` from `std::vector<std::pair<size_t, DeviceID>>` to `std::vector<std::pair<size_t, TargetID>>`.
* All data placement now works with `TargetID`s instead of `DeviceID`s.
* I made some name changes in the DPE code to help improve my understanding. Let me know if I got anything wrong.
* We still only work with local targets, but this PR provides the infrastructure to support neighborhoods and global lists of targets.