### PR TITLE
add code coverage for hermes library for local usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,10 @@ option(HERMES_ENABLE_TIMING "Turn on timing of selected functions." OFF)
 option(HERMES_ENABLE_COVERAGE "Enable codecode  coverage." OFF)
 # Calculate code coverage with debug mode
 if(HERMES_ENABLE_COVERAGE)
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "Use code coverage with debug mode")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,11 @@ option(HERMES_MDM_STORAGE_STBDS
 option(HERMES_DEBUG_HEAP "Store Heap debug information for visualization." OFF)
 option(HERMES_BUILD_BENCHMARKS "Build the Hermes benchmark suite." OFF)
 option(HERMES_ENABLE_TIMING "Turn on timing of selected functions." OFF)
+option(HERMES_ENABLE_COVERAGE "Enable codecode  coverage." OFF)
+# Calculate code coverage with debug mode
+if(HERMES_ENABLE_COVERAGE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+endif()
 
 if(BUILD_SHARED_LIBS)
   set(HERMES_BUILD_SHARED_LIBS 1)
@@ -295,6 +300,24 @@ if(HERMES_BUILD_BUFFER_POOL_VISUALIZER)
   if(SDL2_FOUND)
     message(STATUS "found SDL2 at ${SDL2_DIR}")
   endif()
+endif()
+
+#-----------------------------------------------------------------------------
+# Coverage
+#-----------------------------------------------------------------------------
+if(HERMES_ENABLE_COVERAGE)
+  set(COVERAGE_FLAGS "-fprofile-arcs -ftest-coverage" CACHE STRING
+    "Flags to the coverage program to perform coverage inspection"
+  )
+  mark_as_advanced(COVERAGE_FLAGS)
+
+  macro(set_coverage_flags target)
+    set_target_properties(${target}
+      PROPERTIES
+        COMPILE_FLAGS ${COVERAGE_FLAGS}
+        LINK_FLAGS ${COVERAGE_FLAGS}
+    )
+  endmacro()
 endif()
 
 #-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,9 @@ target_compile_definitions(hermes
 
 hermes_set_lib_options(hermes "hermes" ${HERMES_LIBTYPE})
 
-set_coverage_flags(hermes)
+if(HERMES_ENABLE_COVERAGE)
+  set_coverage_flags(hermes)
+endif()
 
 set(HERMES_EXPORTED_LIBS hermes ${HERMES_EXPORTED_LIBS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,8 @@ target_compile_definitions(hermes
 
 hermes_set_lib_options(hermes "hermes" ${HERMES_LIBTYPE})
 
+set_coverage_flags(hermes)
+
 set(HERMES_EXPORTED_LIBS hermes ${HERMES_EXPORTED_LIBS})
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
It is for for local code coverage. `lcov` and `genhtml` are required tools.
Follow the steps after ctest in build directory:
  1. cd src/CMakeFiles/hermes.dir
  2. lcov --capture --directory . --output-file coverage.info
  3. genhtml coverage.info --output-directory coverage

View index.html for results in generated coverage folder.

