### PR TITLE
Send Blobs to swap space on GetBuffers failure

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -55,15 +55,10 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
       for (size_t i = 0; i < size; ++i) {
         blobs[0][i] = data[i];
       }
-      ret = PlaceBlobs(schemas, blobs, names);
+      ret = PlaceBlobs(schemas, blobs, names, ctx.buffer_organizer_retries);
     } else {
-      SwapBlob swap_blob = PutToSwap(&hermes_->context_, &hermes_->rpc_, name,
-                                     id_, data, size);
-      TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, name, swap_blob,
-                             ctx.buffer_organizer_retries);
-      ret = 0;
-      // TODO(chogan): @errorhandling Signify in Status that the Blob went to
-      // swap space
+      // TODO(chogan): @errorhandling No space left or contraints unsatisfiable.
+      ret = 1;
     }
   }
 

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -72,7 +72,7 @@ class Bucket {
   template<typename T>
   Status PlaceBlobs(std::vector<PlacementSchema> &schemas,
                     const std::vector<std::vector<T>> &blobs,
-                    const std::vector<std::string> &names);
+                    const std::vector<std::string> &names, int retries);
 
   /**
    *
@@ -144,7 +144,7 @@ Status Bucket::Put(const std::string &name, const std::vector<T> &data,
 template<typename T>
 Status Bucket::PlaceBlobs(std::vector<PlacementSchema> &schemas,
                           const std::vector<std::vector<T>> &blobs,
-                          const std::vector<std::string> &names) {
+                          const std::vector<std::string> &names, int retries) {
   Status result = 0;
 
   for (size_t i = 0; i < schemas.size(); ++i) {
@@ -154,9 +154,8 @@ Status Bucket::PlaceBlobs(std::vector<PlacementSchema> &schemas,
     blob.size = blobs[i].size() * sizeof(T);
     LOG(INFO) << "Attaching blob '" << names[i] << "' to Bucket '" << name_
               << "'" << std::endl;
-    // TODO(chogan): @errorhandling What about partial failure?
     result = PlaceBlob(&hermes_->context_, &hermes_->rpc_, schema, blob,
-                       names[i].c_str(), id_);
+                       names[i].c_str(), id_, retries);
   }
 
   return result;
@@ -188,18 +187,10 @@ Status Bucket::Put(std::vector<std::string> &names,
     HERMES_END_TIMED_BLOCK();
 
     if (ret == 0) {
-      ret = PlaceBlobs(schemas, blobs, names);
+      ret = PlaceBlobs(schemas, blobs, names, ctx.buffer_organizer_retries);
     } else {
-      std::vector<SwapBlob> swapped_blobs =
-        PutToSwap(&hermes_->context_, &hermes_->rpc_, id_, blobs, names);
-
-      for (size_t i = 0; i < swapped_blobs.size(); ++i) {
-        TriggerBufferOrganizer(&hermes_->rpc_, kPlaceInHierarchy, names[i],
-                               swapped_blobs[i], ctx.buffer_organizer_retries);
-      }
-      ret = 0;
-      // TODO(chogan): @errorhandling Signify in Status that the Blobs went to
-      // swap space
+      // TODO(chogan): @errorhandling No space left or contraints unsatisfiable.
+      ret = 1;
     }
   } else {
     // TODO(chogan): @errorhandling

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -23,7 +23,7 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
     }
 
     ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
-                    swap_blob.bucket_id);
+                    swap_blob.bucket_id, 0, true);
   } else {
     // TODO(chogan): @errorhandling
     result = 1;

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -473,7 +473,8 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                      SwapBlob swap_blob, const std::string &blob_name);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob, const char *name,
-                      BucketID bucket_id);
+                      BucketID bucket_id, int retries,
+                      bool called_from_buffer_organizer = false);
 api::Status StdIoPersistBucket(SharedMemoryContext *context, RpcContext *rpc,
                                Arena *arena, BucketID bucket_id,
                                const std::string &file_name,


### PR DESCRIPTION
The old behavior sent `Blob`s to swap space when `CalculatePlacement` failed and returned an error when `GetBuffers` failed. Now we do the opposite. Return an error when `CalculatePlacement` fails and send the `Blob` to swap space when `GetBuffers` fails. I had to add a `ForceBlobToSwap` function to the tests because triggering a `Blob` to go to swap from the API would require getting lucky with race conditions.