### PR TITLE
Free buffers when overwriting a blob

### DIFF
--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -155,7 +155,7 @@ Status Bucket::PlaceBlobs(std::vector<PlacementSchema> &schemas,
     LOG(INFO) << "Attaching blob '" << names[i] << "' to Bucket '" << name_
               << "'" << std::endl;
     result = PlaceBlob(&hermes_->context_, &hermes_->rpc_, schema, blob,
-                       names[i].c_str(), id_, retries);
+                       names[i], id_, retries);
   }
 
   return result;

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -373,7 +373,7 @@ void SetFirstFreeBufferId(SharedMemoryContext *context, DeviceID device_id,
 }
 
 std::atomic<u32> *GetAvailableBuffersArray(SharedMemoryContext *context,
-                                                  DeviceID device_id) {
+                                           DeviceID device_id) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   std::atomic<u32> *result =
     (std::atomic<u32> *)(context->shm_base +

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -372,7 +372,7 @@ void SetFirstFreeBufferId(SharedMemoryContext *context, DeviceID device_id,
   }
 }
 
-static std::atomic<u32> *GetAvailableBuffersArray(SharedMemoryContext *context,
+std::atomic<u32> *GetAvailableBuffersArray(SharedMemoryContext *context,
                                                   DeviceID device_id) {
   BufferPool *pool = GetBufferPoolFromContext(context);
   std::atomic<u32> *result =
@@ -1594,10 +1594,18 @@ size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
 }
 
 Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
-                 PlacementSchema &schema, Blob blob, const char *name,
+                 PlacementSchema &schema, Blob blob, const std::string &name,
                  BucketID bucket_id, int retries,
                  bool called_from_buffer_organizer) {
   Status result = 0;
+
+  if (ContainsBlob(context, rpc, bucket_id, name)) {
+    // TODO(chogan) @optimization If the existing buffers are already large
+    // enough to hold the new Blob, then we don't need to release them.
+    // Additionally, no metadata operations would be required.
+    DestroyBlobByName(context, rpc, bucket_id, name);
+  }
+
   HERMES_BEGIN_TIMED_BLOCK("GetBuffers");
   std::vector<BufferID> buffer_ids = GetBuffers(context, schema);
   HERMES_END_TIMED_BLOCK();
@@ -1608,7 +1616,7 @@ Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
     HERMES_END_TIMED_BLOCK();
 
     // NOTE(chogan): Update all metadata associated with this Put
-    AttachBlobToBucket(context, rpc, name, bucket_id, buffer_ids);
+    AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids);
   } else {
     if (called_from_buffer_organizer) {
       // TODO(chogan): @errorhandling The BufferOrganizer failed to place a blob

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -472,8 +472,8 @@ bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                      SwapBlob swap_blob, const std::string &blob_name);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
-                      PlacementSchema &schema, Blob blob, const char *name,
-                      BucketID bucket_id, int retries,
+                      PlacementSchema &schema, Blob blob,
+                      const std::string &name, BucketID bucket_id, int retries,
                       bool called_from_buffer_organizer = false);
 api::Status StdIoPersistBucket(SharedMemoryContext *context, RpcContext *rpc,
                                Arena *arena, BucketID bucket_id,

--- a/src/buffer_pool_internal.h
+++ b/src/buffer_pool_internal.h
@@ -201,6 +201,11 @@ Target *GetTarget(SharedMemoryContext *context, int index);
  */
 Target *GetTargetFromId(SharedMemoryContext *context, TargetID id);
 
+/**
+ *
+ */
+std::atomic<u32> *GetAvailableBuffersArray(SharedMemoryContext *context,
+                                           DeviceID device_id);
 }  // namespace hermes
 
 #endif  // HERMES_BUFFER_POOL_INTERNAL_H_

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -562,12 +562,14 @@ bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
   BlobID blob_id = GetBlobIdByName(context, rpc, blob_name.c_str());
   bool result = false;
 
-  u32 target_node = bucket_id.bits.node_id;
-  if (target_node == rpc->node_id) {
-    result = LocalContainsBlob(context, bucket_id, blob_id);
-  } else {
-    result = RpcCall<bool>(rpc, target_node, "RemoteContainsBlob", bucket_id,
-                           blob_name);
+  if (!IsNullBlobId(blob_id)) {
+    u32 target_node = bucket_id.bits.node_id;
+    if (target_node == rpc->node_id) {
+      result = LocalContainsBlob(context, bucket_id, blob_id);
+    } else {
+      result = RpcCall<bool>(rpc, target_node, "RemoteContainsBlob", bucket_id,
+                             blob_name);
+    }
   }
 
   return result;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,21 +81,29 @@ target_compile_definitions(bp_test
 #------------------------------------------------------------------------------
 
 add_executable(config_parser_test config_parser_test.cc)
-target_link_libraries(config_parser_test hermes)
+target_link_libraries(config_parser_test hermes
+  $<$<BOOL:${HERMES_RPC_THALLIUM}>:thallium>)
 
 add_test(NAME TestConfigParser
   COMMAND config_parser_test ${CMAKE_CURRENT_SOURCE_DIR}/data/hermes.conf)
+target_compile_definitions(config_parser_test
+  PRIVATE $<$<BOOL:${HERMES_RPC_THALLIUM}>:HERMES_RPC_THALLIUM>)
 
 #------------------------------------------------------------------------------
 # Memory Management tests
 #------------------------------------------------------------------------------
 
 add_executable(mem memory_test.cc)
-target_link_libraries(mem hermes)
+target_link_libraries(mem hermes $<$<BOOL:${HERMES_RPC_THALLIUM}>:thallium>)
 add_test(NAME TestMemoryManagement COMMAND mem)
+target_compile_definitions(mem
+  PRIVATE $<$<BOOL:${HERMES_RPC_THALLIUM}>:HERMES_RPC_THALLIUM>)
 
 add_executable(stb_map stb_map_test.cc)
-target_link_libraries(stb_map hermes ${LIBRT} MPI::MPI_CXX)
+target_link_libraries(stb_map hermes ${LIBRT}
+  $<$<BOOL:${HERMES_RPC_THALLIUM}>:thallium> MPI::MPI_CXX)
+target_compile_definitions(stb_map
+  PRIVATE $<$<BOOL:${HERMES_RPC_THALLIUM}>:HERMES_RPC_THALLIUM>)
 add_test(NAME TestSTBMapWithHeap COMMAND stb_map)
 
 #------------------------------------------------------------------------------

--- a/test/bucket_test.cc
+++ b/test/bucket_test.cc
@@ -133,27 +133,14 @@ void TestPutOverwrite(std::shared_ptr<hapi::Hermes> hermes) {
   hapi::Status status = bucket.Put(blob_name, blob, ctx);
   Assert(status == 0);
 
-  hapi::Blob retrieved_blob;
-  size_t retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
-  Assert(blob_size == retrieved_size);
-  retrieved_blob.resize(retrieved_size);
-  retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
-  Assert(blob_size == retrieved_size);
-  Assert(retrieved_blob == blob);
-
-  retrieved_blob.clear();
+  hermes::testing::GetAndVerifyBlob(bucket, blob_name, blob);
 
   // NOTE(chogan): Overwrite the data
   size_t new_size = KILOBYTES(9);
   hapi::Blob new_blob(new_size, 'z');
   status = bucket.Put(blob_name, new_blob, ctx);
 
-  retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
-  Assert(retrieved_size == new_size);
-  retrieved_blob.resize(retrieved_size);
-  retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
-  Assert(retrieved_size == new_size);
-  Assert(retrieved_blob == new_blob);
+  hermes::testing::GetAndVerifyBlob(bucket, blob_name, new_blob);
 
   bucket.Destroy(ctx);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -10,6 +10,7 @@
 #include <map>
 
 #include "hermes_types.h"
+#include "bucket.h"
 
 namespace hermes {
 namespace testing {
@@ -42,6 +43,8 @@ void Assert(bool expr, const char *file, int lineno, const char *message) {
     exit(-1);
   }
 }
+
+#define Assert(expr) hermes::testing::Assert((expr), __FILE__, __LINE__, #expr)
 
 struct TargetViewState {
   std::vector<hermes::u64> bytes_capacity;
@@ -143,9 +146,20 @@ void PrintNodeState(TargetViewState &node_state) {
   }
 }
 
+void GetAndVerifyBlob(api::Bucket &bucket, const std::string &blob_name,
+                      const api::Blob &expected) {
+  api::Context ctx;
+  api::Blob retrieved_blob;
+  size_t expected_size = expected.size();
+  size_t retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
+  Assert(expected_size == retrieved_size);
+  retrieved_blob.resize(retrieved_size);
+  retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
+  Assert(expected_size == retrieved_size);
+  Assert(retrieved_blob == expected);
+}
+
 }  // namespace testing
 }  // namespace hermes
-
-#define Assert(expr) hermes::testing::Assert((expr), __FILE__, __LINE__, #expr)
 
 #endif  // HERMES_TEST_UTILS_H_


### PR DESCRIPTION
* On a `Put`, we first need to check if the `Bucket` already contains the `Blob` and if so, delete it before replacing it.
* I added a helper function to `test_utils.h` that required including `bucket.h`, so I had to make Thallium available to the tests in `test/CMakeList.txt`.
* In `ContainsBlob` we can return `false` if the `BlobID` is `NULL`.