### PR TITLE
Add pre-built list of neighborhood Targets to each node

### DIFF
--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -296,6 +296,10 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
 
   InitRpcClients(&result->rpc_);
 
+  // NOTE(chogan): Can only initialize the neighborhood Targets once the RPC
+  // clients have been initialized.
+  InitNeighborhoodTargets(&result->context_, &result->rpc_);
+
   return result;
 }
 

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -362,7 +362,7 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
   // TODO(chogan): @optimization We can avoid the copy here when getting local
   // targets by just getting a pointer and length. I went with a vector just to
   // make the interface nicer when we need neighborhood or global targets.
-  std::vector<TargetID> targets = GetNodeTargets(context);
+  std::vector<TargetID> targets = LocalGetNodeTargets(context);
   std::vector<u64> node_state = GetRemainingNodeCapacities(context, targets);
 
   switch (api_context.policy) {

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -977,8 +977,8 @@ void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
 
 u32 GetRelativeNodeId(RpcContext *rpc, int offset) {
   int result = rpc->node_id + offset;
-  CHECK_GE(result, 0);
-  CHECK_LE(result, rpc->num_nodes + 1);
+  assert(result >= 0);
+  assert(result <= (int)(rpc->num_nodes + 1));
 
   if (result > (int)rpc->num_nodes) {
     result = 1;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -1041,6 +1041,10 @@ std::vector<TargetID> GetNeighborhoodTargets(SharedMemoryContext *context,
       u32 prev_node = GetPreviousNode(rpc);
       std::vector<TargetID> prev_targets = GetNodeTargets(context, rpc,
                                                           prev_node);
+
+      result.reserve(next_targets.size() + prev_targets.size());
+      result.insert(result.end(), next_targets.begin(), next_targets.end());
+      result.insert(result.end(), prev_targets.begin(), prev_targets.end());
     }
   }
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -143,6 +143,11 @@ void InitMetadataManager(MetadataManager *mdm, Arena *arena, Config *config,
 /**
  *
  */
+void InitNeighborhoodTargets(SharedMemoryContext *context, RpcContext *rpc);
+
+/**
+ *
+ */
 bool DestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
                    const char *name, BucketID bucket_id);
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -122,6 +122,7 @@ struct MetadataManager {
   size_t map_seed;
 
   IdList node_targets;
+  IdList neighborhood_targets;
 
   u32 system_view_state_update_interval_ms;
   u32 global_system_view_state_node_id;

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -96,6 +96,8 @@ std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
 std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
                                     BucketID bucket_id);
 std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
+u32 GetNextNode(RpcContext *rpc);
+u32 GetPreviousNode(RpcContext *rpc);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -95,6 +95,7 @@ GetRemainingNodeCapacities(SharedMemoryContext *context,
 std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
 std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
                                     BucketID bucket_id);
+std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -61,6 +61,11 @@ std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
 /**
  *
  */
+std::vector<TargetID> LocalGetNeighborhoodTargets(SharedMemoryContext *context);
+
+/**
+ *
+ */
 std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
                                     BucketID bucket_id);
 }  // namespace hermes

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -56,7 +56,7 @@ size_t GetStoredMapSize(MetadataManager *mdm, MapType map_type);
 /**
  *
  */
-std::vector<TargetID> GetNodeTargets(SharedMemoryContext *context);
+std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
 
 /**
  *

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -493,16 +493,32 @@ bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
   return destroyed;
 }
 
-std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context) {
-  MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  u32 length = mdm->node_targets.length;
+std::vector<TargetID> LocalGetTargets(MetadataManager *mdm,
+                                      IdList target_list) {
+  u32 length = target_list.length;
   std::vector<TargetID> result(length);
 
-  u64 *target_ids = GetIdsPtr(mdm, mdm->node_targets);
+  u64 *target_ids = GetIdsPtr(mdm, target_list);
   for (u32 i = 0; i < length; ++i) {
     result[i].as_int = target_ids[i];
   }
   ReleaseIdsPtr(mdm);
+
+  return result;
+}
+
+std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  std::vector<TargetID> result = LocalGetTargets(mdm, mdm->node_targets);
+
+  return result;
+}
+
+std::vector<TargetID>
+LocalGetNeighborhoodTargets(SharedMemoryContext *context) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  std::vector<TargetID> result = LocalGetTargets(mdm,
+                                                 mdm->neighborhood_targets);
 
   return result;
 }

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -333,6 +333,13 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       req.respond(result);
     };
 
+  function<void(const request&)> rpc_get_node_targets =
+    [context](const request &req) {
+      std::vector<TargetID> result = LocalGetNodeTargets(context);
+
+      req.respond(result);
+    };
+
   function<void(const request&)> rpc_finalize =
     [rpc](const request &req) {
       (void)req;
@@ -381,6 +388,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   rpc_server->define("RemoteGetGlobalDeviceCapacities",
                      rpc_get_global_device_capacities);
   rpc_server->define("RemoteGetBlobIds", rpc_get_blob_ids);
+  rpc_server->define("RemoteGetNodeTargets", rpc_get_node_targets);
   rpc_server->define("RemoteFinalize", rpc_finalize).disable_response();
 }
 

--- a/test/mdm_test.cc
+++ b/test/mdm_test.cc
@@ -190,6 +190,19 @@ static void TestMaxNameLength(HermesPtr hermes) {
   bucket.Destroy(ctx);
 }
 
+// void TestGetRelativeNodeId() {
+//   RpcContext rpc = {};
+//   rpc.num_nodes = 10;
+//   rpc.node_id = 1;
+
+//   Assert(GetNextNode(&rpc) == 2);
+//   Assert(GetPreviousNode(&rpc) == 10);
+
+//   rpc.node_id = 10;
+//   Assert(GetNextNode(&rpc) == 1);
+//   Assert(GetPreviousNode(&rpc) == 9);
+// }
+
 int main(int argc, char **argv) {
   int mpi_threads_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
@@ -208,6 +221,7 @@ int main(int argc, char **argv) {
   TestRenameBucket(hermes);
   TestBucketRefCounting(hermes);
   TestMaxNameLength(hermes);
+  // TestGetRelativeNodeId();
 
   hermes->Finalize(true);
 

--- a/test/mdm_test.cc
+++ b/test/mdm_test.cc
@@ -190,18 +190,18 @@ static void TestMaxNameLength(HermesPtr hermes) {
   bucket.Destroy(ctx);
 }
 
-// void TestGetRelativeNodeId() {
-//   RpcContext rpc = {};
-//   rpc.num_nodes = 10;
-//   rpc.node_id = 1;
+void TestGetRelativeNodeId() {
+  RpcContext rpc = {};
+  rpc.num_nodes = 10;
+  rpc.node_id = 1;
 
-//   Assert(GetNextNode(&rpc) == 2);
-//   Assert(GetPreviousNode(&rpc) == 10);
+  Assert(GetNextNode(&rpc) == 2);
+  Assert(GetPreviousNode(&rpc) == 10);
 
-//   rpc.node_id = 10;
-//   Assert(GetNextNode(&rpc) == 1);
-//   Assert(GetPreviousNode(&rpc) == 9);
-// }
+  rpc.node_id = 10;
+  Assert(GetNextNode(&rpc) == 1);
+  Assert(GetPreviousNode(&rpc) == 9);
+}
 
 int main(int argc, char **argv) {
   int mpi_threads_provided;
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
   TestRenameBucket(hermes);
   TestBucketRefCounting(hermes);
   TestMaxNameLength(hermes);
-  // TestGetRelativeNodeId();
+  TestGetRelativeNodeId();
 
   hermes->Finalize(true);
 


### PR DESCRIPTION
Closes #76.

* Adds a list of neighborhood `Target`s to each node that consists of the local `Target`s from `node_id` - 1 and `node_id` + 1 (wrapping around). This is a temporary definition of a neighborhood. In the future a `TopologyManager` will decide how neighborhoods are built.
* The main interface is `LocalGetNeighborhoodTargets`. Unfortunately we can't create automated tests for it until we resolve #116.