### PR TITLE
Embed BucketID in internal representation of Blob names

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -169,7 +169,8 @@ Status Bucket::RenameBlob(const std::string &old_name,
     return ret;
   } else {
     LOG(INFO) << "Renaming Blob " << old_name << " to " << new_name << '\n';
-    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name, id_);
+    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name,
+                       new_name, id_);
   }
 
   return ret;

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -101,8 +101,8 @@ size_t Bucket::GetBlobSize(Arena *arena, const std::string &name,
   if (IsValid()) {
     LOG(INFO) << "Getting Blob " << name << " size from bucket "
               << name_ << '\n';
-    BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                     name.c_str());
+    BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_, name,
+                                     id_);
     if (!IsNullBlobId(blob_id)) {
       result = GetBlobSizeById(&hermes_->context_, &hermes_->rpc_, arena,
                                blob_id);
@@ -125,8 +125,8 @@ size_t Bucket::Get(const std::string &name, Blob &user_blob, Context &ctx) {
       ret = GetBlobSize(scratch, name, ctx);
     } else {
       LOG(INFO) << "Getting Blob " << name << " from bucket " << name_ << '\n';
-      BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                       name.c_str());
+      BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_,
+                                       name, id_);
       ret = ReadBlobById(&hermes_->context_, &hermes_->rpc_,
                          &hermes_->trans_arena_, user_blob, blob_id);
     }
@@ -169,7 +169,7 @@ Status Bucket::RenameBlob(const std::string &old_name,
     return ret;
   } else {
     LOG(INFO) << "Renaming Blob " << old_name << " to " << new_name << '\n';
-    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name);
+    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name, id_);
   }
 
   return ret;
@@ -183,8 +183,8 @@ bool Bucket::ContainsBlob(const std::string &name) {
 }
 
 bool Bucket::BlobIsInSwap(const std::string &name) {
-  BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                   name.c_str());
+  BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_, name,
+                                   id_);
   bool result = hermes::BlobIsInSwap(blob_id);
 
   return result;

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -75,7 +75,7 @@ void Hermes::AppBarrier() {
 
 bool Hermes::BucketContainsBlob(const std::string &bucket_name,
                                 const std::string &blob_name) {
-  BucketID bucket_id = GetBucketIdByName(&context_, &rpc_, bucket_name.c_str());
+  BucketID bucket_id = GetBucketId(&context_, &rpc_, bucket_name.c_str());
   bool result = hermes::ContainsBlob(&context_, &rpc_, bucket_id, blob_name);
 
   return result;

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -311,6 +311,12 @@ namespace api {
 
 std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
                                    bool is_adapter) {
+  u16 endian_test = 0x1;
+  char *endian_ptr = (char *)&endian_test;
+  if (endian_ptr[0] != 1) {
+    LOG(FATAL) << "Big endian machines not supported yet." << std::endl;
+  }
+
   hermes::Config config = {};
   const size_t kConfigMemorySize = KILOBYTES(16);
   hermes::u8 config_memory[kConfigMemorySize];

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -254,8 +254,9 @@ Status VBucket::Delete(Context& ctx) {
                   BucketID bucket_id =
                     GetBucketId(&hermes_->context_, &hermes_->rpc_,
                                       ci->first.c_str());
-                  auto blob_id = GetBlobId(
-                    &hermes_->context_, &hermes_->rpc_, ci->second, bucket_id);
+                  auto blob_id =
+                    GetBlobId(&hermes_->context_, &hermes_->rpc_, ci->second,
+                              bucket_id);
                   // TODO(hari): @errorhandling check return of StdIoPersistBlob
                   ret = StdIoPersistBlob(&hermes_->context_, &hermes_->rpc_,
                                          &hermes_->trans_arena_, blob_id, file,

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -251,8 +251,11 @@ Status VBucket::Delete(Context& ctx) {
               if (!fileBackedTrait->offset_map.empty()) {
                 auto iter = fileBackedTrait->offset_map.find(ci->second);
                 if (iter != fileBackedTrait->offset_map.end()) {
-                  auto blob_id = GetBlobIdByName(
-                      &hermes_->context_, &hermes_->rpc_, ci->second.c_str());
+                  BucketID bucket_id =
+                    GetBucketId(&hermes_->context_, &hermes_->rpc_,
+                                      ci->first.c_str());
+                  auto blob_id = GetBlobId(
+                    &hermes_->context_, &hermes_->rpc_, ci->second, bucket_id);
                   // TODO(hari): @errorhandling check return of StdIoPersistBlob
                   ret = StdIoPersistBlob(&hermes_->context_, &hermes_->rpc_,
                                          &hermes_->trans_arena_, blob_id, file,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -176,8 +176,9 @@ union BucketID {
   u64 as_int;
 };
 
-// NOTE(chogan): We reserve sizeof(BucketID) bytes in order to embed the
-// BucketID into the Blob name.
+// NOTE(chogan): We reserve sizeof(BucketID) * 2 bytes in order to embed the
+// BucketID into the Blob name. See MakeInternalBlobName() for a description of
+// why we need double the bytes of a BucketID.
 constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
 
 union VBucketID {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -53,7 +53,6 @@ constexpr int kMaxPathLength = 256;
 constexpr int kMaxBufferPoolShmemNameLength = 64;
 constexpr int kMaxDevices = 8;
 constexpr int kMaxBucketNameSize = 256;
-constexpr int kMaxBlobNameSize = 64;
 constexpr int kMaxVBucketNameSize = 256;
 
 constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
@@ -176,6 +175,10 @@ union BucketID {
 
   u64 as_int;
 };
+
+// NOTE(chogan): We reserve sizeof(BucketID) bytes in order to embed the
+// BucketID into the Blob name.
+constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
 
 union VBucketID {
   struct {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -179,7 +179,8 @@ union BucketID {
 // NOTE(chogan): We reserve sizeof(BucketID) * 2 bytes in order to embed the
 // BucketID into the Blob name. See MakeInternalBlobName() for a description of
 // why we need double the bytes of a BucketID.
-constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
+constexpr int kBucketIdStringSize = sizeof(BucketID) * 2;
+constexpr int kMaxBlobNameSize = 64 - kBucketIdStringSize;
 
 union VBucketID {
   struct {

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -218,8 +218,8 @@ void DeleteVBucketId(MetadataManager *mdm, RpcContext *rpc,
   DeleteId(mdm, rpc, name, kMapType_VBucket);
 }
 
-void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-                  BucketID bucket_id) {
+void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc,
+                  const std::string &name, BucketID bucket_id) {
   std::string internal_name = MakeInternalBlobName(name, bucket_id);
   DeleteId(mdm, rpc, internal_name, kMapType_Blob);
 }
@@ -235,7 +235,8 @@ BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
 std::string GetBlobNameFromId(MetadataManager *mdm, BlobID blob_id) {
   std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
                                                 kMapType_Blob);
-  std::string result = blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
+  std::string result =
+    blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
 
   return result;
 }
@@ -250,7 +251,6 @@ BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
   result.as_int = (u64)std::stoull(blob_name, nullptr, base);
 
   return result;
-  
 }
 
 BucketInfo *LocalGetBucketInfoById(MetadataManager *mdm, BucketID id) {

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -77,6 +77,12 @@ bool IsNullTargetId(TargetID id) {
   return result;
 }
 
+u32 GetBlobNodeId(BlobID id) {
+  u32 result = (u32)abs(id.bits.node_id);
+
+  return result;
+}
+
 void LocalPut(MetadataManager *mdm, const char *key, u64 val,
               MapType map_type) {
   PutToStorage(mdm, key, val, map_type);
@@ -150,10 +156,15 @@ std::string MakeInternalBlobName(const std::string &name, BucketID id) {
   unsigned long long id_as_uint = id.as_int;
   std::stringstream ss;
 
-  // NOTE(chogan): Store the bytes of the blob_id at the beginning of the name
+  // NOTE(chogan): Store the bytes of the blob_id at the beginning of the name.
+  // We can't just stick the raw bytes in there because the Blob name will
+  // eventually treated as a C string, which means a null byte will be treated
+  // as a null terminator. Instead, we store the string representation of each
+  // byte, which means we need two bytes to represent one byte.
   for (int i = sizeof(unsigned long long) - 1; i >= 0 ; --i) {
+    // TODO(chogan): May require an endian swap
     u8 *byte = (u8 *)&id_as_uint + i;
-    ss << std::hex << std::setw(2) << std::setfill('0') << (int)*byte;
+    ss << std::hex << std::setw(2) << std::setfill('0') << (int)(*byte);
   }
   ss << name;
 
@@ -231,8 +242,9 @@ BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
   return result;
 }
 
-// TODO(chogan): Need RPC
-std::string GetBlobNameFromId(MetadataManager *mdm, BlobID blob_id) {
+std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
+                                   BlobID blob_id) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
   std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
                                                 kMapType_Blob);
   std::string result =
@@ -241,14 +253,41 @@ std::string GetBlobNameFromId(MetadataManager *mdm, BlobID blob_id) {
   return result;
 }
 
-// TODO(chogan): RPC
-BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
-                               BlobID id) {
+std::string GetBlobNameFromId(SharedMemoryContext *context, RpcContext *rpc,
+                              BlobID blob_id) {
+  u32 target_node = GetBlobNodeId(blob_id);
+  std::string result;
+  if (target_node == rpc->node_id) {
+    result = LocalGetBlobNameFromId(context, blob_id);
+  } else {
+    result = RpcCall<std::string>(rpc, target_node, "RemoteGetBlobNameFromId",
+                                  blob_id);
+  }
+
+  return result;
+}
+
+BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  std::string blob_name = GetBlobNameFromId(mdm, id);
+  std::string internal_name = ReverseGetFromStorage(mdm, id.as_int,
+                                                    kMapType_Blob);
   BucketID result = {};
   int base = 16;
-  result.as_int = (u64)std::stoull(blob_name, nullptr, base);
+  result.as_int = (u64)std::stoull(internal_name, nullptr, base);
+
+  return result;
+}
+
+BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                               BlobID id) {
+  BucketID result = {};
+  u32 target_node = GetBlobNodeId(id);
+  if (target_node == rpc->node_id) {
+    result = LocalGetBucketIdFromBlobId(context, id);
+  } else {
+    result = RpcCall<BucketID>(rpc, target_node, "RemoteGetBucketIdFromBlobId",
+                               id);
+  }
 
   return result;
 }
@@ -446,12 +485,6 @@ u32 AllocateBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
   return result;
 }
 
-u32 GetBlobNodeId(BlobID id) {
-  u32 result = (u32)abs(id.bits.node_id);
-
-  return result;
-}
-
 bool BlobIsInSwap(BlobID id) {
   bool result = id.bits.node_id < 0;
 
@@ -511,18 +544,6 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
   return result;
 }
 
-// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-//                                        SharedMemoryContext *context,
-//                                        RpcContext *rpc,
-//                                        const char *blob_name,
-//                                        u32 **sizes) {
-//   BlobID blob_id = GetBlobId(context, rpc, blob_name);
-//   BufferIdArray result = GetBufferIdsFromBlobId(arena, context, rpc, blob_id,
-//                                                 sizes);
-
-//   return result;
-// }
-
 void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
                         const char *blob_name, BucketID bucket_id,
                         const std::vector<BufferID> &buffer_ids,
@@ -577,10 +598,10 @@ void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
 
   FreeBufferIdList(context, rpc, blob_id);
 
-  MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  std::string blob_name = GetBlobNameFromId(mdm, blob_id);
+  std::string blob_name = LocalGetBlobNameFromId(context, blob_id);
 
   if (blob_name.size() > 0) {
+    MetadataManager *mdm = GetMetadataManagerFromContext(context);
     DeleteBlobId(mdm, rpc, blob_name.c_str(), bucket_id);
   } else {
     // TODO(chogan): @errorhandling

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -14,6 +14,7 @@
 
 #include <string.h>
 
+#include <iomanip>
 #include <string>
 
 #include "memory_management.h"
@@ -110,21 +111,8 @@ u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str) {
   return result;
 }
 
-BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
-  BucketInfo *info_array = (BucketInfo *)((u8 *)mdm + mdm->bucket_info_offset);
-  BucketInfo *result = info_array + index;
-
-  return result;
-}
-
-BucketInfo *LocalGetBucketInfoById(MetadataManager *mdm, BucketID id) {
-  BucketInfo *result = LocalGetBucketInfoByIndex(mdm, id.bits.index);
-
-  return result;
-}
-
-u64 GetIdByName(SharedMemoryContext *context, RpcContext *rpc, const char *name,
-                MapType map_type) {
+u64 GetId(SharedMemoryContext *context, RpcContext *rpc, const char *name,
+          MapType map_type) {
   u64 result = 0;
 
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
@@ -140,26 +128,133 @@ u64 GetIdByName(SharedMemoryContext *context, RpcContext *rpc, const char *name,
   return result;
 }
 
-BucketID GetBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
-                           const char *name) {
+BucketID GetBucketId(SharedMemoryContext *context, RpcContext *rpc,
+                     const char *name) {
   BucketID result = {};
-  result.as_int = GetIdByName(context, rpc, name, kMapType_Bucket);
+  result.as_int = GetId(context, rpc, name, kMapType_Bucket);
 
   return result;
 }
 
-VBucketID GetVBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
-                             const char *name) {
-  VBucketID result = {};
-  result.as_int = GetIdByName(context, rpc, name, kMapType_VBucket);
-
-  return result;
-}
-
-BlobID GetBlobIdByName(SharedMemoryContext *context, RpcContext *rpc,
+VBucketID GetVBucketId(SharedMemoryContext *context, RpcContext *rpc,
                        const char *name) {
+  VBucketID result = {};
+  result.as_int = GetId(context, rpc, name, kMapType_VBucket);
+
+  return result;
+}
+
+std::string MakeInternalBlobName(const std::string &name, BucketID id) {
+  static_assert(sizeof(BucketID) <= sizeof(unsigned long long));
+
+  unsigned long long id_as_uint = id.as_int;
+  std::stringstream ss;
+
+  // NOTE(chogan): Store the bytes of the blob_id at the beginning of the name
+  for (int i = sizeof(unsigned long long) - 1; i >= 0 ; --i) {
+    u8 *byte = (u8 *)&id_as_uint + i;
+    ss << std::hex << std::setw(2) << std::setfill('0') << (int)*byte;
+  }
+  ss << name;
+
+  std::string result = ss.str();
+
+  return result;
+}
+
+BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                 const std::string &name, BucketID bucket_id) {
+  std::string internal_name = MakeInternalBlobName(name, bucket_id);
   BlobID result = {};
-  result.as_int = GetIdByName(context, rpc, name, kMapType_Blob);
+  result.as_int = GetId(context, rpc, internal_name.c_str(), kMapType_Blob);
+
+  return result;
+}
+
+void PutId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
+           u64 id, MapType map_type) {
+  u32 target_node = HashString(mdm, rpc, name.c_str());
+  if (target_node == rpc->node_id) {
+    LocalPut(mdm, name.c_str(), id, map_type);
+  } else {
+    RpcCall<bool>(rpc, target_node, "RemotePut", name, id, map_type);
+  }
+}
+
+void PutBucketId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
+                 BucketID id) {
+  PutId(mdm, rpc, name, id.as_int, kMapType_Bucket);
+}
+
+void PutVBucketId(MetadataManager *mdm, RpcContext *rpc,
+                  const std::string &name, VBucketID id) {
+  PutId(mdm, rpc, name, id.as_int, kMapType_VBucket);
+}
+
+void PutBlobId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
+               BlobID id, BucketID bucket_id) {
+  std::string internal_name = MakeInternalBlobName(name, bucket_id);
+  PutId(mdm, rpc, internal_name, id.as_int, kMapType_Blob);
+}
+
+void DeleteId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
+              MapType map_type) {
+  u32 target_node = HashString(mdm, rpc, name.c_str());
+
+  if (target_node == rpc->node_id) {
+    LocalDelete(mdm, name.c_str(), map_type);
+  } else {
+    RpcCall<bool>(rpc, target_node, "RemoteDelete", name, map_type);
+  }
+}
+
+void DeleteBucketId(MetadataManager *mdm, RpcContext *rpc,
+                    const std::string &name) {
+  DeleteId(mdm, rpc, name, kMapType_Bucket);
+}
+
+void DeleteVBucketId(MetadataManager *mdm, RpcContext *rpc,
+                     const std::string &name) {
+  DeleteId(mdm, rpc, name, kMapType_VBucket);
+}
+
+void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
+                  BucketID bucket_id) {
+  std::string internal_name = MakeInternalBlobName(name, bucket_id);
+  DeleteId(mdm, rpc, internal_name, kMapType_Blob);
+}
+
+BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
+  BucketInfo *info_array = (BucketInfo *)((u8 *)mdm + mdm->bucket_info_offset);
+  BucketInfo *result = info_array + index;
+
+  return result;
+}
+
+// TODO(chogan): Need RPC
+std::string GetBlobNameFromId(MetadataManager *mdm, BlobID blob_id) {
+  std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
+                                                kMapType_Blob);
+  std::string result = blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
+
+  return result;
+}
+
+// TODO(chogan): RPC
+BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                               BlobID id) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  std::string blob_name = GetBlobNameFromId(mdm, id);
+  BucketID result = {};
+  int base = 16;
+  result.as_int = (u64)std::stoull(blob_name, nullptr, base);
+
+  return result;
+  
+}
+
+BucketInfo *LocalGetBucketInfoById(MetadataManager *mdm, BucketID id) {
+  BucketInfo *result = LocalGetBucketInfoByIndex(mdm, id.bits.index);
 
   return result;
 }
@@ -176,42 +271,6 @@ std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
   }
 
   return result;
-}
-
-void PutId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-           u64 id, MapType map_type) {
-  u32 target_node = HashString(mdm, rpc, name.c_str());
-  if (target_node == rpc->node_id) {
-    LocalPut(mdm, name.c_str(), id, map_type);
-  } else {
-    RpcCall<bool>(rpc, target_node, "RemotePut", name, id, map_type);
-  }
-}
-
-void DeleteId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-              MapType map_type) {
-  u32 target_node = HashString(mdm, rpc, name.c_str());
-
-  if (target_node == rpc->node_id) {
-    LocalDelete(mdm, name.c_str(), map_type);
-  } else {
-    RpcCall<bool>(rpc, target_node, "RemoteDelete", name, map_type);
-  }
-}
-
-void PutBucketId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-                 BucketID id) {
-  PutId(mdm, rpc, name, id.as_int, kMapType_Bucket);
-}
-
-void PutVBucketId(MetadataManager *mdm, RpcContext *rpc,
-                  const std::string &name, VBucketID id) {
-  PutId(mdm, rpc, name, id.as_int, kMapType_VBucket);
-}
-
-void PutBlobId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-               BlobID id) {
-  PutId(mdm, rpc, name, id.as_int, kMapType_Blob);
 }
 
 VBucketInfo *GetVBucketInfoByIndex(MetadataManager *mdm, u32 index) {
@@ -276,7 +335,7 @@ BucketID GetOrCreateBucketId(SharedMemoryContext *context, RpcContext *rpc,
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
 
   BeginTicketMutex(&mdm->bucket_mutex);
-  BucketID result = GetBucketIdByName(context, rpc, name.c_str());
+  BucketID result = GetBucketId(context, rpc, name.c_str());
 
   if (result.as_int != 0) {
     LOG(INFO) << "Opening Bucket '" << name << "'" << std::endl;
@@ -327,7 +386,7 @@ VBucketID GetOrCreateVBucketId(SharedMemoryContext *context, RpcContext *rpc,
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
 
   BeginTicketMutex(&mdm->vbucket_mutex);
-  VBucketID result = GetVBucketIdByName(context, rpc, name.c_str());
+  VBucketID result = GetVBucketId(context, rpc, name.c_str());
 
   if (result.as_int != 0) {
     LOG(INFO) << "Opening VBucket '" << name << "'" << std::endl;
@@ -452,17 +511,17 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
   return result;
 }
 
-BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-                                       SharedMemoryContext *context,
-                                       RpcContext *rpc,
-                                       const char *blob_name,
-                                       u32 **sizes) {
-  BlobID blob_id = GetBlobIdByName(context, rpc, blob_name);
-  BufferIdArray result = GetBufferIdsFromBlobId(arena, context, rpc, blob_id,
-                                                sizes);
+// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
+//                                        SharedMemoryContext *context,
+//                                        RpcContext *rpc,
+//                                        const char *blob_name,
+//                                        u32 **sizes) {
+//   BlobID blob_id = GetBlobId(context, rpc, blob_name);
+//   BufferIdArray result = GetBufferIdsFromBlobId(arena, context, rpc, blob_id,
+//                                                 sizes);
 
-  return result;
-}
+//   return result;
+// }
 
 void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
                         const char *blob_name, BucketID bucket_id,
@@ -477,7 +536,7 @@ void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
   blob_id.bits.buffer_ids_offset = AllocateBufferIdList(context, rpc,
                                                         target_node,
                                                         buffer_ids);
-  PutBlobId(mdm, rpc, blob_name, blob_id);
+  PutBlobId(mdm, rpc, blob_name, blob_id, bucket_id);
   AddBlobIdToBucket(mdm, rpc, blob_id, bucket_id);
 }
 
@@ -492,7 +551,8 @@ void FreeBufferIdList(SharedMemoryContext *context, RpcContext *rpc,
 }
 
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
-                            const char *blob_name, BlobID blob_id) {
+                            const char *blob_name, BlobID blob_id,
+                            BucketID bucket_id) {
   if (!BlobIsInSwap(blob_id)) {
     std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
     ReleaseBuffers(context, rpc, buffer_ids);
@@ -503,11 +563,11 @@ void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
   FreeBufferIdList(context, rpc, blob_id);
 
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  DeleteId(mdm, rpc, blob_name, kMapType_Blob);
+  DeleteBlobId(mdm, rpc, blob_name, bucket_id);
 }
 
 void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
-                          BlobID blob_id) {
+                          BlobID blob_id, BucketID bucket_id) {
   if (!BlobIsInSwap(blob_id)) {
     std::vector<BufferID> buffer_ids = GetBufferIdList(context, rpc, blob_id);
     ReleaseBuffers(context, rpc, buffer_ids);
@@ -518,11 +578,10 @@ void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
   FreeBufferIdList(context, rpc, blob_id);
 
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
-                                                kMapType_Blob);
+  std::string blob_name = GetBlobNameFromId(mdm, blob_id);
 
   if (blob_name.size() > 0) {
-    DeleteId(mdm, rpc, blob_name.c_str(), kMapType_Blob);
+    DeleteBlobId(mdm, rpc, blob_name.c_str(), bucket_id);
   } else {
     // TODO(chogan): @errorhandling
     DLOG(INFO) << "Expected to find blob_id " << blob_id.as_int
@@ -543,27 +602,29 @@ void RemoveBlobFromBucketInfo(SharedMemoryContext *context, RpcContext *rpc,
 
 void DestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID bucket_id, const std::string &blob_name) {
-  BlobID blob_id = GetBlobIdByName(context, rpc, blob_name.c_str());
+  BlobID blob_id = GetBlobId(context, rpc, blob_name, bucket_id);
   if (!IsNullBlobId(blob_id)) {
     u32 blob_id_target_node = GetBlobNodeId(blob_id);
 
     if (blob_id_target_node == rpc->node_id) {
-      LocalDestroyBlobByName(context, rpc, blob_name.c_str(), blob_id);
+      LocalDestroyBlobByName(context, rpc, blob_name.c_str(), blob_id,
+                             bucket_id);
     } else {
       RpcCall<bool>(rpc, blob_id_target_node, "RemoteDestroyBlobByName",
-                    blob_name, blob_id);
+                    blob_name, blob_id, bucket_id);
     }
     RemoveBlobFromBucketInfo(context, rpc, bucket_id, blob_id);
   }
 }
 
 void RenameBlob(SharedMemoryContext *context, RpcContext *rpc,
-                const std::string &old_name, const std::string &new_name) {
+                const std::string &old_name, const std::string &new_name,
+                BucketID bucket_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  BlobID blob_id = GetBlobIdByName(context, rpc, old_name.c_str());
+  BlobID blob_id = GetBlobId(context, rpc, old_name, bucket_id);
   if (!IsNullBlobId(blob_id)) {
-    DeleteId(mdm, rpc, old_name, kMapType_Blob);
-    PutBlobId(mdm, rpc, new_name, blob_id);
+    DeleteBlobId(mdm, rpc, old_name, bucket_id);
+    PutBlobId(mdm, rpc, new_name, blob_id, bucket_id);
   } else {
     // TODO(chogan): @errorhandling
   }
@@ -571,7 +632,7 @@ void RenameBlob(SharedMemoryContext *context, RpcContext *rpc,
 
 bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
                   BucketID bucket_id, const std::string &blob_name) {
-  BlobID blob_id = GetBlobIdByName(context, rpc, blob_name.c_str());
+  BlobID blob_id = GetBlobId(context, rpc, blob_name, bucket_id);
   bool result = false;
 
   if (!IsNullBlobId(blob_id)) {
@@ -587,12 +648,13 @@ bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
   return result;
 }
 
-void DestroyBlobById(SharedMemoryContext *context, RpcContext *rpc, BlobID id) {
+void DestroyBlobById(SharedMemoryContext *context, RpcContext *rpc, BlobID id,
+                     BucketID bucket_id) {
   u32 target_node = GetBlobNodeId(id);
   if (target_node == rpc->node_id) {
-    LocalDestroyBlobById(context, rpc, id);
+    LocalDestroyBlobById(context, rpc, id, bucket_id);
   } else {
-    RpcCall<bool>(rpc, target_node, "RemoteDestroyBlobById", id);
+    RpcCall<bool>(rpc, target_node, "RemoteDestroyBlobById", id, bucket_id);
   }
 }
 
@@ -614,7 +676,7 @@ void LocalRenameBucket(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID id, const std::string &old_name,
                        const std::string &new_name) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  DeleteId(mdm, rpc, old_name, kMapType_Bucket);
+  DeleteBucketId(mdm, rpc, old_name);
   PutBucketId(mdm, rpc, new_name, id);
 }
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -161,7 +161,8 @@ void DestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
  *
  */
 void RenameBlob(SharedMemoryContext *context, RpcContext *rpc,
-                const std::string &old_name, const std::string &new_name);
+                const std::string &old_name, const std::string &new_name,
+                BucketID bucket_id);
 
 /**
  *
@@ -185,16 +186,16 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
 /**
  *
  */
-BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-                                       SharedMemoryContext *context,
-                                       RpcContext *rpc, const char *blob_name,
-                                       u32 **sizes);
+// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
+//                                        SharedMemoryContext *context,
+//                                        RpcContext *rpc, const char *blob_name,
+//                                        u32 **sizes);
 
 /**
  *
  */
-BlobID GetBlobIdByName(SharedMemoryContext *context, RpcContext *rpc,
-                       const char *name);
+BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                       const std::string &name, BucketID bucket_id);
 
 /**
  *
@@ -277,7 +278,7 @@ std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
 /**
  *
  */
-BucketID GetBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
+BucketID GetBucketId(SharedMemoryContext *context, RpcContext *rpc,
                            const char *name);
 /**
  *

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -188,7 +188,8 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
  */
 // BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
 //                                        SharedMemoryContext *context,
-//                                        RpcContext *rpc, const char *blob_name,
+//                                        RpcContext *rpc,
+//                                        const char *blob_name,
 //                                        u32 **sizes);
 
 /**

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -183,20 +183,20 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
                                      SharedMemoryContext *context,
                                      RpcContext *rpc, BlobID blob_id,
                                      u32 **sizes);
-/**
- *
- */
-// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-//                                        SharedMemoryContext *context,
-//                                        RpcContext *rpc,
-//                                        const char *blob_name,
-//                                        u32 **sizes);
 
 /**
  *
  */
 BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
                        const std::string &name, BucketID bucket_id);
+
+
+
+/**
+ *
+ */
+std::string GetBlobNameFromId(MetadataManager *mdm, RpcContext *rpc,
+                              BlobID blob_id);
 
 /**
  *
@@ -276,11 +276,19 @@ TargetID FindTargetIdFromDeviceId(const std::vector<TargetID> &targets,
  */
 std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
                                BucketID bucket_id);
+
 /**
  *
  */
 BucketID GetBucketId(SharedMemoryContext *context, RpcContext *rpc,
                            const char *name);
+
+/**
+ *
+ */
+BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                               BlobID blob_id);
+
 /**
  *
  */

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -103,5 +103,26 @@ BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id);
 std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
                                    BlobID blob_id);
 
+/**
+ * Faster version of std::stoull.
+ *
+ * This is 4.1x faster than std::stoull. Since we generate all the numbers that
+ * we use this function on, we can guarantee the following:
+ *   - The size will always be kBucketIdStringSize.
+ *   - The number will always be unsigned and within the range of a u64.
+ *   - There will never be invalid characters passed in (only 0-9 and a-f).
+ *
+ * Avoiding all this input sanitization and error checking is how we can get a
+ * 4.1x speedup.
+ *
+ * \param s A string with size at least kBucketIdStringSize, where the first
+ *          kBucketIdStringSize characters consist only of 0-9 and a-f.
+ *
+ * \return The u64 representation of the first kBucketIdStringSize characters of
+ *         \p s.
+ */
+u64 HexStringToU64(const std::string &s);
+std::string MakeInternalBlobName(const std::string &name, BucketID id);
+
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -99,6 +99,9 @@ std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
 std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
 u32 GetNextNode(RpcContext *rpc);
 u32 GetPreviousNode(RpcContext *rpc);
+BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id);
+std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
+                                   BlobID blob_id);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -22,7 +22,7 @@ bool IsNullVBucketId(VBucketID id);
 bool IsNullBlobId(BlobID id);
 bool IsNullTargetId(TargetID id);
 TicketMutex *GetMapMutex(MetadataManager *mdm, MapType map_type);
-VBucketID GetVBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
+VBucketID GetVBucketId(SharedMemoryContext *context, RpcContext *rpc,
                              const char *name);
 u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);
 MetadataManager *GetMetadataManagerFromContext(SharedMemoryContext *context);
@@ -48,9 +48,10 @@ void LocalFreeBufferIdList(SharedMemoryContext *context, BlobID blob_id);
 bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
                                const char *bucket_name, BucketID bucket_id);
 void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
-                          BlobID blob_id);
+                          BlobID blob_id, BucketID bucket_id);
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
-                            const char *blob_name, BlobID blob_id);
+                            const char *blob_name, BlobID blob_id,
+                            BucketID bucket_id);
 BucketID LocalGetNextFreeBucketId(SharedMemoryContext *context, RpcContext *rpc,
                                   const std::string &name);
 u32 LocalAllocateBufferIdList(MetadataManager *mdm,

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -462,7 +462,7 @@ bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
       ReleaseIdsPtr(mdm);
 
       for (auto blob_id : blobs_to_destroy) {
-        DestroyBlobById(context, rpc, blob_id);
+        DestroyBlobById(context, rpc, blob_id, bucket_id);
       }
       // Delete BlobId list
       FreeIdList(mdm, info->blobs);

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -252,16 +252,18 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       req.respond(true);
     };
 
-  function<void(const request&, const string&, BlobID)>
+  function<void(const request&, const string&, BlobID, BucketID)>
     rpc_destroy_blob_by_name =
-    [context, rpc](const request &req, const string &name, BlobID id) {
-      LocalDestroyBlobByName(context, rpc, name.c_str(), id);
-        req.respond(true);
+    [context, rpc](const request &req, const string &name, BlobID id,
+                   BucketID bucket_id) {
+      LocalDestroyBlobByName(context, rpc, name.c_str(), id, bucket_id);
+      req.respond(true);
     };
 
-  function<void(const request&, BlobID)>
-    rpc_destroy_blob_by_id = [context, rpc](const request &req, BlobID id) {
-      LocalDestroyBlobById(context, rpc, id);
+  function<void(const request&, BlobID, BucketID)>
+    rpc_destroy_blob_by_id = [context, rpc](const request &req, BlobID id,
+                                            BucketID bucket_id) {
+      LocalDestroyBlobById(context, rpc, id, bucket_id);
       req.respond(true);
     };
 

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -341,6 +341,19 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
 
       req.respond(result);
     };
+  auto rpc_get_bucket_id_from_blob_id = [context](const request &req,
+                                                  BlobID id) {
+    BucketID result = LocalGetBucketIdFromBlobId(context, id);
+
+    req.respond(result);
+  };
+
+  auto rpc_get_blob_name_from_id = [context](const request &req, BlobID
+                                             blob_id) {
+    std::string result = LocalGetBlobNameFromId(context, blob_id);
+
+    req.respond(result);
+  };
 
   function<void(const request&)> rpc_finalize =
     [rpc](const request &req) {
@@ -391,6 +404,9 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_global_device_capacities);
   rpc_server->define("RemoteGetBlobIds", rpc_get_blob_ids);
   rpc_server->define("RemoteGetNodeTargets", rpc_get_node_targets);
+  rpc_server->define("RemoteGetBucketIdFromBlobId",
+                     rpc_get_bucket_id_from_blob_id);
+  rpc_server->define("RemoteGetBlobNameFromId", rpc_get_blob_name_from_id);
   rpc_server->define("RemoteFinalize", rpc_finalize).disable_response();
 }
 

--- a/test/mdm_test.cc
+++ b/test/mdm_test.cc
@@ -215,6 +215,31 @@ void TestGetRelativeNodeId() {
   Assert(GetPreviousNode(&rpc) == 9);
 }
 
+void TestDuplicateBlobNames(HermesPtr hermes) {
+  hapi::Context ctx;
+  const size_t blob_size = 8;
+  hapi::Bucket b1("b1", hermes, ctx);
+  hapi::Bucket b2("b2", hermes, ctx);
+  std::string blob_name("duplicate");
+  hapi::Blob blob1(blob_size, 'x');
+  hapi::Blob blob2(blob_size, 'z');
+
+  Assert(b1.Put(blob_name, blob1, ctx).Succeeded());
+  Assert(b2.Put(blob_name, blob2, ctx).Succeeded());
+
+  Assert(b1.ContainsBlob(blob_name));
+  Assert(b2.ContainsBlob(blob_name));
+
+  hapi::Blob result(blob_size, '0');
+  Assert(b1.Get(blob_name, result, ctx) == blob_size);
+  Assert(result == blob1);
+  Assert(b2.Get(blob_name, result, ctx) == blob_size);
+  Assert(result == blob2);
+
+  Assert(b1.Destroy(ctx).Succeeded());
+  Assert(b2.Destroy(ctx).Succeeded());
+}
+
 int main(int argc, char **argv) {
   int mpi_threads_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);


### PR DESCRIPTION
Fixes #88.

Prepends a `Blob`'s `BucketID` onto the internal representation of the `Blob` name. This allows each `Bucket` to have its own "namespace" in the MDM for `Blob` names. When the name is retrieved, the `BucketID` portion is discarded. I originally planned to stuff the raw bytes of the `BucketID` at the beginning of the name, but that causes null bytes to be interpreted as null terminators when the names are eventually treated as C strings in `stb_ds.h`. To get around this, I'm storing the hex representation of the `BucketID` as `char`s.  Luckily, since we generate all the numbers we have to convert from a hex string to a `u64`, we can get a 4.1x speedup over `std::stoull` by avoiding input sanitization and error checking.

* Renamed functions:
  * `GetBlobIdByName` -> `GetBlobId`
  * `GetBucketIdByName` -> `GetBucketId`
  * `GetVBucketdByName` -> `GetVBucketId`
* Adds `GetBucketIdFromBlobId()` needed for the adapter.