### PR TITLE
Embed BucketID in internal representation of Blob names

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -169,7 +169,8 @@ Status Bucket::RenameBlob(const std::string &old_name,
     return ret;
   } else {
     LOG(INFO) << "Renaming Blob " << old_name << " to " << new_name << '\n';
-    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name, id_);
+    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name,
+                       new_name, id_);
   }
 
   return ret;

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -101,8 +101,8 @@ size_t Bucket::GetBlobSize(Arena *arena, const std::string &name,
   if (IsValid()) {
     LOG(INFO) << "Getting Blob " << name << " size from bucket "
               << name_ << '\n';
-    BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                     name.c_str());
+    BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_, name,
+                                     id_);
     if (!IsNullBlobId(blob_id)) {
       result = GetBlobSizeById(&hermes_->context_, &hermes_->rpc_, arena,
                                blob_id);
@@ -125,8 +125,8 @@ size_t Bucket::Get(const std::string &name, Blob &user_blob, Context &ctx) {
       ret = GetBlobSize(scratch, name, ctx);
     } else {
       LOG(INFO) << "Getting Blob " << name << " from bucket " << name_ << '\n';
-      BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                       name.c_str());
+      BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_,
+                                       name, id_);
       ret = ReadBlobById(&hermes_->context_, &hermes_->rpc_,
                          &hermes_->trans_arena_, user_blob, blob_id);
     }
@@ -169,7 +169,7 @@ Status Bucket::RenameBlob(const std::string &old_name,
     return ret;
   } else {
     LOG(INFO) << "Renaming Blob " << old_name << " to " << new_name << '\n';
-    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name);
+    hermes::RenameBlob(&hermes_->context_, &hermes_->rpc_, old_name, new_name, id_);
   }
 
   return ret;
@@ -183,8 +183,8 @@ bool Bucket::ContainsBlob(const std::string &name) {
 }
 
 bool Bucket::BlobIsInSwap(const std::string &name) {
-  BlobID blob_id = GetBlobIdByName(&hermes_->context_, &hermes_->rpc_,
-                                   name.c_str());
+  BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_, name,
+                                   id_);
   bool result = hermes::BlobIsInSwap(blob_id);
 
   return result;

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -75,7 +75,7 @@ void Hermes::AppBarrier() {
 
 bool Hermes::BucketContainsBlob(const std::string &bucket_name,
                                 const std::string &blob_name) {
-  BucketID bucket_id = GetBucketIdByName(&context_, &rpc_, bucket_name.c_str());
+  BucketID bucket_id = GetBucketId(&context_, &rpc_, bucket_name.c_str());
   bool result = hermes::ContainsBlob(&context_, &rpc_, bucket_id, blob_name);
 
   return result;

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -311,6 +311,12 @@ namespace api {
 
 std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
                                    bool is_adapter) {
+  u16 endian_test = 0x1;
+  char *endian_ptr = (char *)&endian_test;
+  if (endian_ptr[0] != 1) {
+    LOG(FATAL) << "Big endian machines not supported yet." << std::endl;
+  }
+
   hermes::Config config = {};
   const size_t kConfigMemorySize = KILOBYTES(16);
   hermes::u8 config_memory[kConfigMemorySize];

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -254,8 +254,9 @@ Status VBucket::Delete(Context& ctx) {
                   BucketID bucket_id =
                     GetBucketId(&hermes_->context_, &hermes_->rpc_,
                                       ci->first.c_str());
-                  auto blob_id = GetBlobId(
-                    &hermes_->context_, &hermes_->rpc_, ci->second, bucket_id);
+                  auto blob_id =
+                    GetBlobId(&hermes_->context_, &hermes_->rpc_, ci->second,
+                              bucket_id);
                   // TODO(hari): @errorhandling check return of StdIoPersistBlob
                   ret = StdIoPersistBlob(&hermes_->context_, &hermes_->rpc_,
                                          &hermes_->trans_arena_, blob_id, file,

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -251,8 +251,11 @@ Status VBucket::Delete(Context& ctx) {
               if (!fileBackedTrait->offset_map.empty()) {
                 auto iter = fileBackedTrait->offset_map.find(ci->second);
                 if (iter != fileBackedTrait->offset_map.end()) {
-                  auto blob_id = GetBlobIdByName(
-                      &hermes_->context_, &hermes_->rpc_, ci->second.c_str());
+                  BucketID bucket_id =
+                    GetBucketId(&hermes_->context_, &hermes_->rpc_,
+                                      ci->first.c_str());
+                  auto blob_id = GetBlobId(
+                    &hermes_->context_, &hermes_->rpc_, ci->second, bucket_id);
                   // TODO(hari): @errorhandling check return of StdIoPersistBlob
                   ret = StdIoPersistBlob(&hermes_->context_, &hermes_->rpc_,
                                          &hermes_->trans_arena_, blob_id, file,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -176,8 +176,9 @@ union BucketID {
   u64 as_int;
 };
 
-// NOTE(chogan): We reserve sizeof(BucketID) bytes in order to embed the
-// BucketID into the Blob name.
+// NOTE(chogan): We reserve sizeof(BucketID) * 2 bytes in order to embed the
+// BucketID into the Blob name. See MakeInternalBlobName() for a description of
+// why we need double the bytes of a BucketID.
 constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
 
 union VBucketID {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -53,7 +53,6 @@ constexpr int kMaxPathLength = 256;
 constexpr int kMaxBufferPoolShmemNameLength = 64;
 constexpr int kMaxDevices = 8;
 constexpr int kMaxBucketNameSize = 256;
-constexpr int kMaxBlobNameSize = 64;
 constexpr int kMaxVBucketNameSize = 256;
 
 constexpr char kPlaceInHierarchy[] = "PlaceInHierarchy";
@@ -176,6 +175,10 @@ union BucketID {
 
   u64 as_int;
 };
+
+// NOTE(chogan): We reserve sizeof(BucketID) bytes in order to embed the
+// BucketID into the Blob name.
+constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
 
 union VBucketID {
   struct {

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -179,7 +179,8 @@ union BucketID {
 // NOTE(chogan): We reserve sizeof(BucketID) * 2 bytes in order to embed the
 // BucketID into the Blob name. See MakeInternalBlobName() for a description of
 // why we need double the bytes of a BucketID.
-constexpr int kMaxBlobNameSize = 64 - (sizeof(BucketID) * 2);
+constexpr int kBucketIdStringSize = sizeof(BucketID) * 2;
+constexpr int kMaxBlobNameSize = 64 - kBucketIdStringSize;
 
 union VBucketID {
   struct {

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -218,8 +218,8 @@ void DeleteVBucketId(MetadataManager *mdm, RpcContext *rpc,
   DeleteId(mdm, rpc, name, kMapType_VBucket);
 }
 
-void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc, const std::string &name,
-                  BucketID bucket_id) {
+void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc,
+                  const std::string &name, BucketID bucket_id) {
   std::string internal_name = MakeInternalBlobName(name, bucket_id);
   DeleteId(mdm, rpc, internal_name, kMapType_Blob);
 }
@@ -235,7 +235,8 @@ BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
 std::string GetBlobNameFromId(MetadataManager *mdm, BlobID blob_id) {
   std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
                                                 kMapType_Blob);
-  std::string result = blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
+  std::string result =
+    blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
 
   return result;
 }
@@ -250,7 +251,6 @@ BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
   result.as_int = (u64)std::stoull(blob_name, nullptr, base);
 
   return result;
-  
 }
 
 BucketInfo *LocalGetBucketInfoById(MetadataManager *mdm, BucketID id) {

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -245,8 +245,11 @@ std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
                                                 kMapType_Blob);
-  std::string result =
-    blob_name.substr(sizeof(BucketID) * 2, std::string::npos);
+
+  std::string result;
+  if (blob_name.size() > kBucketIdStringSize) {
+    result = blob_name.substr(kBucketIdStringSize, std::string::npos);
+  }
 
   return result;
 }
@@ -688,7 +691,7 @@ bool ContainsBlob(SharedMemoryContext *context, RpcContext *rpc,
       result = LocalContainsBlob(context, bucket_id, blob_id);
     } else {
       result = RpcCall<bool>(rpc, target_node, "RemoteContainsBlob", bucket_id,
-                             blob_name);
+                             blob_id);
     }
   }
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -172,7 +172,8 @@ void DestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
  *
  */
 void RenameBlob(SharedMemoryContext *context, RpcContext *rpc,
-                const std::string &old_name, const std::string &new_name);
+                const std::string &old_name, const std::string &new_name,
+                BucketID bucket_id);
 
 /**
  *
@@ -196,16 +197,16 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
 /**
  *
  */
-BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-                                       SharedMemoryContext *context,
-                                       RpcContext *rpc, const char *blob_name,
-                                       u32 **sizes);
+// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
+//                                        SharedMemoryContext *context,
+//                                        RpcContext *rpc, const char *blob_name,
+//                                        u32 **sizes);
 
 /**
  *
  */
-BlobID GetBlobIdByName(SharedMemoryContext *context, RpcContext *rpc,
-                       const char *name);
+BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                       const std::string &name, BucketID bucket_id);
 
 /**
  *
@@ -288,7 +289,7 @@ std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
 /**
  *
  */
-BucketID GetBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
+BucketID GetBucketId(SharedMemoryContext *context, RpcContext *rpc,
                            const char *name);
 /**
  *

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -199,7 +199,8 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
  */
 // BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
 //                                        SharedMemoryContext *context,
-//                                        RpcContext *rpc, const char *blob_name,
+//                                        RpcContext *rpc,
+//                                        const char *blob_name,
 //                                        u32 **sizes);
 
 /**

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -194,20 +194,20 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
                                      SharedMemoryContext *context,
                                      RpcContext *rpc, BlobID blob_id,
                                      u32 **sizes);
-/**
- *
- */
-// BufferIdArray GetBufferIdsFromBlobName(Arena *arena,
-//                                        SharedMemoryContext *context,
-//                                        RpcContext *rpc,
-//                                        const char *blob_name,
-//                                        u32 **sizes);
 
 /**
  *
  */
 BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
                        const std::string &name, BucketID bucket_id);
+
+
+
+/**
+ *
+ */
+std::string GetBlobNameFromId(MetadataManager *mdm, RpcContext *rpc,
+                              BlobID blob_id);
 
 /**
  *
@@ -287,11 +287,19 @@ TargetID FindTargetIdFromDeviceId(const std::vector<TargetID> &targets,
  */
 std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
                                BucketID bucket_id);
+
 /**
  *
  */
 BucketID GetBucketId(SharedMemoryContext *context, RpcContext *rpc,
                            const char *name);
+
+/**
+ *
+ */
+BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
+                               BlobID blob_id);
+
 /**
  *
  */

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -103,5 +103,26 @@ BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id);
 std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
                                    BlobID blob_id);
 
+/**
+ * Faster version of std::stoull.
+ *
+ * This is 4.1x faster than std::stoull. Since we generate all the numbers that
+ * we use this function on, we can guarantee the following:
+ *   - The size will always be kBucketIdStringSize.
+ *   - The number will always be unsigned and within the range of a u64.
+ *   - There will never be invalid characters passed in (only 0-9 and a-f).
+ *
+ * Avoiding all this input sanitization and error checking is how we can get a
+ * 4.1x speedup.
+ *
+ * \param s A string with size at least kBucketIdStringSize, where the first
+ *          kBucketIdStringSize characters consist only of 0-9 and a-f.
+ *
+ * \return The u64 representation of the first kBucketIdStringSize characters of
+ *         \p s.
+ */
+u64 HexStringToU64(const std::string &s);
+std::string MakeInternalBlobName(const std::string &name, BucketID id);
+
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -99,6 +99,9 @@ std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
 std::vector<TargetID> LocalGetNodeTargets(SharedMemoryContext *context);
 u32 GetNextNode(RpcContext *rpc);
 u32 GetPreviousNode(RpcContext *rpc);
+BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id);
+std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
+                                   BlobID blob_id);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -22,7 +22,7 @@ bool IsNullVBucketId(VBucketID id);
 bool IsNullBlobId(BlobID id);
 bool IsNullTargetId(TargetID id);
 TicketMutex *GetMapMutex(MetadataManager *mdm, MapType map_type);
-VBucketID GetVBucketIdByName(SharedMemoryContext *context, RpcContext *rpc,
+VBucketID GetVBucketId(SharedMemoryContext *context, RpcContext *rpc,
                              const char *name);
 u32 HashString(MetadataManager *mdm, RpcContext *rpc, const char *str);
 MetadataManager *GetMetadataManagerFromContext(SharedMemoryContext *context);
@@ -48,9 +48,10 @@ void LocalFreeBufferIdList(SharedMemoryContext *context, BlobID blob_id);
 bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
                                const char *bucket_name, BucketID bucket_id);
 void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
-                          BlobID blob_id);
+                          BlobID blob_id, BucketID bucket_id);
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
-                            const char *blob_name, BlobID blob_id);
+                            const char *blob_name, BlobID blob_id,
+                            BucketID bucket_id);
 BucketID LocalGetNextFreeBucketId(SharedMemoryContext *context, RpcContext *rpc,
                                   const std::string &name);
 u32 LocalAllocateBufferIdList(MetadataManager *mdm,

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -462,7 +462,7 @@ bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
       ReleaseIdsPtr(mdm);
 
       for (auto blob_id : blobs_to_destroy) {
-        DestroyBlobById(context, rpc, blob_id);
+        DestroyBlobById(context, rpc, blob_id, bucket_id);
       }
       // Delete BlobId list
       FreeIdList(mdm, info->blobs);

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -252,16 +252,18 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       req.respond(true);
     };
 
-  function<void(const request&, const string&, BlobID)>
+  function<void(const request&, const string&, BlobID, BucketID)>
     rpc_destroy_blob_by_name =
-    [context, rpc](const request &req, const string &name, BlobID id) {
-      LocalDestroyBlobByName(context, rpc, name.c_str(), id);
-        req.respond(true);
+    [context, rpc](const request &req, const string &name, BlobID id,
+                   BucketID bucket_id) {
+      LocalDestroyBlobByName(context, rpc, name.c_str(), id, bucket_id);
+      req.respond(true);
     };
 
-  function<void(const request&, BlobID)>
-    rpc_destroy_blob_by_id = [context, rpc](const request &req, BlobID id) {
-      LocalDestroyBlobById(context, rpc, id);
+  function<void(const request&, BlobID, BucketID)>
+    rpc_destroy_blob_by_id = [context, rpc](const request &req, BlobID id,
+                                            BucketID bucket_id) {
+      LocalDestroyBlobById(context, rpc, id, bucket_id);
       req.respond(true);
     };
 

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -341,6 +341,19 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
 
       req.respond(result);
     };
+  auto rpc_get_bucket_id_from_blob_id = [context](const request &req,
+                                                  BlobID id) {
+    BucketID result = LocalGetBucketIdFromBlobId(context, id);
+
+    req.respond(result);
+  };
+
+  auto rpc_get_blob_name_from_id = [context](const request &req, BlobID
+                                             blob_id) {
+    std::string result = LocalGetBlobNameFromId(context, blob_id);
+
+    req.respond(result);
+  };
 
   function<void(const request&)> rpc_finalize =
     [rpc](const request &req) {
@@ -413,6 +426,9 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_global_device_capacities);
   rpc_server->define("RemoteGetBlobIds", rpc_get_blob_ids);
   rpc_server->define("RemoteGetNodeTargets", rpc_get_node_targets);
+  rpc_server->define("RemoteGetBucketIdFromBlobId",
+                     rpc_get_bucket_id_from_blob_id);
+  rpc_server->define("RemoteGetBlobNameFromId", rpc_get_blob_name_from_id);
   rpc_server->define("RemoteFinalize", rpc_finalize).disable_response();
 }
 

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -348,9 +348,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
     req.respond(result);
   };
 
-  auto rpc_get_blob_name_from_id = [context](const request &req, BlobID
-                                             blob_id) {
-    std::string result = LocalGetBlobNameFromId(context, blob_id);
+  auto rpc_get_blob_name_from_id = [context](const request &req, BlobID id) {
+    std::string result = LocalGetBlobNameFromId(context, id);
 
     req.respond(result);
   };

--- a/test/mdm_test.cc
+++ b/test/mdm_test.cc
@@ -215,6 +215,31 @@ void TestGetRelativeNodeId() {
   Assert(GetPreviousNode(&rpc) == 9);
 }
 
+void TestDuplicateBlobNames(HermesPtr hermes) {
+  hapi::Context ctx;
+  const size_t blob_size = 8;
+  hapi::Bucket b1("b1", hermes, ctx);
+  hapi::Bucket b2("b2", hermes, ctx);
+  std::string blob_name("duplicate");
+  hapi::Blob blob1(blob_size, 'x');
+  hapi::Blob blob2(blob_size, 'z');
+
+  Assert(b1.Put(blob_name, blob1, ctx).Succeeded());
+  Assert(b2.Put(blob_name, blob2, ctx).Succeeded());
+
+  Assert(b1.ContainsBlob(blob_name));
+  Assert(b2.ContainsBlob(blob_name));
+
+  hapi::Blob result(blob_size, '0');
+  Assert(b1.Get(blob_name, result, ctx) == blob_size);
+  Assert(result == blob1);
+  Assert(b2.Get(blob_name, result, ctx) == blob_size);
+  Assert(result == blob2);
+
+  Assert(b1.Destroy(ctx).Succeeded());
+  Assert(b2.Destroy(ctx).Succeeded());
+}
+
 int main(int argc, char **argv) {
   int mpi_threads_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);


### PR DESCRIPTION
Fixes #88.
Replaces #149.

Prepends a `Blob`'s `BucketID` onto the internal representation of the `Blob` name. This allows each `Bucket` to have its own "namespace" in the MDM for `Blob` names. When the name is retrieved, the `BucketID` portion is discarded. I originally planned to stuff the raw bytes of the `BucketID` at the beginning of the name, but that causes null bytes to be interpreted as null terminators when the names are eventually treated as C strings in `stb_ds.h`. To get around this, I'm storing the hex representation of the `BucketID` as `char`s.  Luckily, since we generate all the numbers we have to convert from a hex string to a `u64`, we can get a 4.1x speedup over `std::stoull` by avoiding input sanitization and error checking.

* Renamed functions:
  * `GetBlobIdByName` -> `GetBlobId`
  * `GetBucketIdByName` -> `GetBucketId`
  * `GetVBucketdByName` -> `GetVBucketId`
* Adds `GetBucketIdFromBlobId()` needed for the adapter.