### PR TITLE
Remove the global mutex

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -34,16 +34,14 @@ Bucket::Bucket(const std::string &initial_name,
                             std::to_string(kMaxBucketNameSize));
   } else {
     id_ = GetOrCreateBucketId(&hermes_->context_, &hermes_->rpc_, name_);
-    if (!Bucket::IsValid()) {
+    if (!IsValid()) {
       throw std::runtime_error("Bucket id is invalid.");
     }
   }
 }
 
 bool Bucket::IsValid() const {
-  bool result = id_.as_int != 0;
-
-  return result;
+  return !IsNullBucketId(id_);
 }
 
 Status Bucket::Put(const std::string &name, const u8 *data, size_t size,

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -23,6 +23,10 @@ namespace hermes {
 
 namespace api {
 
+bool VBucket::IsValid() const {
+  return !IsNullVBucketId(id_);
+}
+
 Status VBucket::Link(std::string blob_name, std::string bucket_name,
                      Context& ctx) {
   (void)ctx;

--- a/src/api/vbucket.h
+++ b/src/api/vbucket.h
@@ -35,10 +35,10 @@ class VBucket {
   std::list<Trait *> attached_traits_;
   Blob local_blob;
   bool persist;
+  /** internal Hermes object owned by vbucket */
   std::shared_ptr<Hermes> hermes_;
 
  public:
-  /** internal Hermes object owned by vbucket */
   VBucket(std::string initial_name, std::shared_ptr<Hermes> const &h,
           bool persist, Context ctx)
       : name_(initial_name),
@@ -52,8 +52,13 @@ class VBucket {
     (void)ctx;
     if (IsVBucketNameTooLong(name_)) {
       id_.as_int = 0;
+      throw std::length_error("VBucket name exceeds maximum size of " +
+                              std::to_string(kMaxVBucketNameSize));
     } else {
       id_ = GetOrCreateVBucketId(&hermes_->context_, &hermes_->rpc_, name_);
+      if (!IsValid()) {
+        throw std::runtime_error("Could not open or create VBucket");
+      }
     }
   }
 
@@ -61,6 +66,8 @@ class VBucket {
     name_.clear();
     linked_blobs_.clear();
   }
+
+  bool IsValid() const;
 
   /** get the name of vbucket */
   std::string GetName() const { return this->name_; }

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -105,15 +105,6 @@ struct MetadataManager {
   // TODO(chogan): @optimization Should the TicketMutexes here be reader/writer
   // locks?
 
-  // TODO(chogan): @optimization Hopefully this is used rarely. If it becomes
-  // something that's commonly used, we need to come up with something smarter.
-  /** Mutex shared by all nodes for operations that require synchronization.
-   *
-   *  Should only be accessed via BeginGlobalTicketMutex() and
-   *  EndGlobalTicketMutex().
-   */
-  TicketMutex global_mutex;
-
   /** Lock for accessing `BucketInfo` structures located at
    * `bucket_info_offset` */
   TicketMutex bucket_mutex;
@@ -237,12 +228,6 @@ void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
 /**
  *
  */
-void IncrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
-                       BucketID id);
-
-/**
- *
- */
 void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
                        BucketID id);
 
@@ -303,14 +288,17 @@ BucketID GetBucketIdFromBlobId(SharedMemoryContext *context, RpcContext *rpc,
 /**
  *
  */
-void IncrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
+void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
                        VBucketID id);
+/**
+ *
+ */
+bool IsNullBucketId(BucketID id);
 
 /**
  *
  */
-void DecrementRefcount(SharedMemoryContext *context, RpcContext *rpc,
-                       VBucketID id);
+bool IsNullVBucketId(VBucketID id);
 
 /**
  *

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -52,7 +52,7 @@ void LocalDestroyBlobById(SharedMemoryContext *context, RpcContext *rpc,
 void LocalDestroyBlobByName(SharedMemoryContext *context, RpcContext *rpc,
                             const char *blob_name, BlobID blob_id,
                             BucketID bucket_id);
-BucketID LocalGetNextFreeBucketId(SharedMemoryContext *context, RpcContext *rpc,
+BucketID LocalGetNextFreeBucketId(SharedMemoryContext *context,
                                   const std::string &name);
 u32 LocalAllocateBufferIdList(MetadataManager *mdm,
                               const std::vector<BufferID> &buffer_ids);
@@ -102,6 +102,10 @@ u32 GetPreviousNode(RpcContext *rpc);
 BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id);
 std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
                                    BlobID blob_id);
+BucketID LocalGetOrCreateBucketId(SharedMemoryContext *context,
+                                  const std::string &name);
+VBucketID LocalGetOrCreateVBucketId(SharedMemoryContext *context,
+                                    const std::string &name);
 
 /**
  * Faster version of std::stoull.


### PR DESCRIPTION
Rather than performing  a potential RPC for every metadata operation in `GetOrCreateBucketId`, we combine all the functionality into a single RPC. This improves performance by reducing the number of RPCs, and guarantees correctness because the whole function will be protected by a mutex (without requiring a global mutex).
  
* Add `IsNullId` instead of repeating `id_.as_int != 0;`
* Add some missing error handling for `VBucket`s.
* Remove the global mutex
* Combine all RPCs in `GetOrCreate[V]BucketId` into one.
* Replace type of RPC definitions in `rpc_thallium.cc` with `auto` to reduce the clutter.