### PR TITLE
Use neighborhood Targets if a Put fails to place to local Targets

### DIFF
--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -193,7 +193,6 @@ Status Bucket::Put(std::vector<std::string> &names,
 
   for (auto &name : names) {
     if (IsBlobNameTooLong(name)) {
-      // TODO(chogan): @errorhandling
       ret = BLOB_NAME_TOO_LONG;
       LOG(ERROR) << ret.Msg();
       return ret;
@@ -221,12 +220,10 @@ Status Bucket::Put(std::vector<std::string> &names,
     if (ret.Succeeded()) {
       ret = PlaceBlobs(schemas, blobs, names, ctx.buffer_organizer_retries);
     } else {
-      // TODO(chogan): @errorhandling No space left or contraints unsatisfiable.
       LOG(ERROR) << ret.Msg();
       return ret;
     }
   } else {
-    // TODO(chogan): @errorhandling
     ret = INVALID_BUCKET;
     LOG(ERROR) << ret.Msg();
     return ret;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -270,6 +270,17 @@ TargetID FindTargetIdFromDeviceId(const std::vector<TargetID> &targets,
 /**
  *
  */
+std::vector<TargetID> GetNeighborhoodTargets(SharedMemoryContext *context,
+                                             RpcContext *rpc);
+/**
+ *
+ */
+std::vector<u64>
+GetRemainingTargetCapacities(SharedMemoryContext *context, RpcContext *rpc,
+                             const std::vector<TargetID> &targets);
+/**
+ *
+ */
 std::vector<BlobID> GetBlobIds(SharedMemoryContext *context, RpcContext *rpc,
                                BucketID bucket_id);
 

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -72,7 +72,7 @@ u64 LocalGet(MetadataManager *mdm, const char *key, MapType map_type);
 void LocalPut(MetadataManager *mdm, const char *key, u64 val, MapType map_type);
 void LocalDelete(MetadataManager *mdm, const char *key, MapType map_type);
 
-u64 LocalGetRemainingCapacity(SharedMemoryContext *context, TargetID id);
+u64 LocalGetRemainingTargetCapacity(SharedMemoryContext *context, TargetID id);
 void LocalUpdateGlobalSystemViewState(SharedMemoryContext *context,
                                       std::vector<i64> adjustments);
 SystemViewState *GetLocalSystemViewState(SharedMemoryContext *context);
@@ -90,9 +90,6 @@ void StartGlobalSystemViewStateUpdateThread(SharedMemoryContext *context,
 void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
                          Arena *arena, Config *config);
 
-std::vector<u64>
-GetRemainingNodeCapacities(SharedMemoryContext *context,
-                           const std::vector<TargetID> &targets);
 std::string GetSwapFilename(MetadataManager *mdm, u32 node_id);
 std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
                                     BucketID bucket_id);

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -583,18 +583,6 @@ size_t GetStoredMapSize(MetadataManager *mdm, MapType map_type) {
   return result;
 }
 
-std::vector<u64>
-GetRemainingNodeCapacities(SharedMemoryContext *context,
-                           const std::vector<TargetID> &targets) {
-  std::vector<u64> result(targets.size());
-
-  for (size_t i = 0; i < targets.size(); ++i) {
-    result[i] = LocalGetRemainingCapacity(context, targets[i]);
-  }
-
-  return result;
-}
-
 u32 HashStringForStorage(MetadataManager *mdm, RpcContext *rpc,
                          const char *str) {
   int result =

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -293,7 +293,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   };
 
   auto rpc_get_remaining_capacity = [context](const request &req, TargetID id) {
-    u64 result = LocalGetRemainingCapacity(context, id);
+    u64 result = LocalGetRemainingTargetCapacity(context, id);
 
     req.respond(result);
   };
@@ -371,7 +371,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   rpc_server->define("RemoteDecrementRefcount", rpc_decrement_refcount_bucket);
   rpc_server->define("RemoteDecrementRefcountVBucket",
                      rpc_decrement_refcount_vbucket);
-  rpc_server->define("RemoteGetRemainingCapacity", rpc_get_remaining_capacity);
+  rpc_server->define("RemoteGetRemainingTargetCapacity",
+                     rpc_get_remaining_capacity);
   rpc_server->define("RemoteUpdateGlobalSystemViewState",
                      rpc_update_global_system_view_state);
   rpc_server->define("RemoteGetGlobalDeviceCapacities",


### PR DESCRIPTION
Closes #147 

We attempt a data placement three times: first with node-local targets, then with neighborhood targets, then with global targets (not implemented yet), only expanding the target list if the placement fails.

Also removes duplicated code from `Put`. Now all three `Put`s go through the "multi" or "vector" `Put`.