### PR TITLE
Control PlacementPolicy at global, Bucket, and Put granularity

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -25,7 +25,7 @@ namespace api {
 
 Bucket::Bucket(const std::string &initial_name,
                const std::shared_ptr<Hermes> &h, Context ctx)
-  : name_(initial_name), hermes_(h), placement_policy(ctx.policy) {
+  : name_(initial_name), hermes_(h), ctx_(ctx) {
 
   if (IsBucketNameTooLong(name_)) {
     id_.as_int = 0;
@@ -59,6 +59,12 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
     std::vector<Blob> blobs{Blob{data, data + size}};
     result = Put(names, blobs, ctx);
   }
+
+  return result;
+}
+
+Status Bucket::Put(const std::string &name, const u8 *data, size_t size) {
+  Status result = Put(name, data, size, ctx_);
 
   return result;
 }

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -25,8 +25,7 @@ namespace api {
 
 Bucket::Bucket(const std::string &initial_name,
                const std::shared_ptr<Hermes> &h, Context ctx)
-    : name_(initial_name), hermes_(h) {
-  (void)ctx;
+  : name_(initial_name), hermes_(h), placement_policy(ctx.policy) {
 
   if (IsBucketNameTooLong(name_)) {
     id_.as_int = 0;

--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -26,7 +26,6 @@ namespace api {
 Bucket::Bucket(const std::string &initial_name,
                const std::shared_ptr<Hermes> &h, Context ctx)
   : name_(initial_name), hermes_(h), ctx_(ctx) {
-
   if (IsBucketNameTooLong(name_)) {
     id_.as_int = 0;
     throw std::length_error("Bucket name is too long: " +

--- a/src/api/bucket.h
+++ b/src/api/bucket.h
@@ -38,6 +38,12 @@ class Bucket {
   /** internal Hermes object owned by Bucket */
   std::shared_ptr<Hermes> hermes_;
 
+  /**
+   * The data PlacementPolicy this Bucket will use. Defaults to the value set in
+   * the default_placement_policy parameter of the configuration file.
+   */
+  PlacementPolicy placement_policy;
+
   // TODO(chogan): Think about the Big Three
   Bucket() : name_(""), id_{0, 0}, hermes_(nullptr) {
     LOG(INFO) << "Create NULL Bucket " << std::endl;

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -297,6 +297,7 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
 
   api::Context::default_buffer_organizer_retries =
     config->num_buffer_organizer_retries;
+  api::Context::default_placement_policy = config->default_placement_policy;
 
   InitRpcClients(&result->rpc_);
 

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -28,6 +28,7 @@ namespace hermes {
 namespace api {
 
 int Context::default_buffer_organizer_retries;
+PlacementPolicy Context::default_placement_policy;
 
 Status RenameBucket(const std::string &old_name,
                     const std::string &new_name,

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -83,23 +83,6 @@ class VBucket;
 
 class Bucket;
 
-struct Context {
-  static int default_buffer_organizer_retries;
-  static PlacementPolicy default_placement_policy;
-
-  PlacementPolicy policy;
-  int buffer_organizer_retries;
-
-  Context() : policy(default_placement_policy),
-              buffer_organizer_retries(default_buffer_organizer_retries) {}
-};
-
-struct TraitTag{};
-typedef ID<TraitTag, int64_t, -1> THnd;
-
-struct BucketTag{};
-typedef ID<BucketTag, int64_t, -1> BHnd;
-
 /** rename a bucket referred to by name only */
 Status RenameBucket(const std::string &old_name,
                     const std::string &new_name,

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -83,12 +83,6 @@ class VBucket;
 
 class Bucket;
 
-enum class PlacementPolicy {
-  kRandom,
-  kRoundRobin,
-  kMinimizeIoTime,
-};
-
 struct Context {
   static int default_buffer_organizer_retries;
 

--- a/src/api/hermes.h
+++ b/src/api/hermes.h
@@ -85,11 +85,12 @@ class Bucket;
 
 struct Context {
   static int default_buffer_organizer_retries;
+  static PlacementPolicy default_placement_policy;
 
   PlacementPolicy policy;
   int buffer_organizer_retries;
 
-  Context() : policy(PlacementPolicy::kRoundRobin),
+  Context() : policy(default_placement_policy),
               buffer_organizer_retries(default_buffer_organizer_retries) {}
 };
 

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -16,11 +16,11 @@
 namespace hermes {
 
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                     SwapBlob swap_blob, const std::string &name) {
+                     SwapBlob swap_blob, const std::string &name,
+                     api::Context &ctx) {
   int result = 0;
   std::vector<PlacementSchema> schemas;
   std::vector<size_t> sizes(1, swap_blob.size);
-  api::Context ctx;
   Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
 
   if (ret.Succeeded()) {
@@ -35,7 +35,7 @@ int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
     }
 
     ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
-                    swap_blob.bucket_id, 0, true);
+                    swap_blob.bucket_id, ctx, true);
   } else {
     // TODO(chogan): @errorhandling
     result = 1;

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -15,30 +15,23 @@
 
 namespace hermes {
 
-int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                     SwapBlob swap_blob, const std::string &name,
-                     api::Context &ctx) {
-  int result = 0;
+Status PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
+                        SwapBlob swap_blob, const std::string &name,
+                        api::Context &ctx) {
   std::vector<PlacementSchema> schemas;
   std::vector<size_t> sizes(1, swap_blob.size);
-  Status ret = CalculatePlacement(context, rpc, sizes, schemas, ctx);
+  Status result = CalculatePlacement(context, rpc, sizes, schemas, ctx);
 
-  if (ret.Succeeded()) {
+  if (result.Succeeded()) {
     std::vector<u8> blob_mem(swap_blob.size);
     Blob blob = {};
     blob.data = blob_mem.data();
     blob.size = blob_mem.size();
-    size_t bytes_read = ReadFromSwap(context, blob, swap_blob);
-    if (bytes_read != swap_blob.size) {
-      // TODO(chogan): @errorhandling
-      result = 1;
-    }
-
-    ret = PlaceBlob(context, rpc, schemas[0], blob, name.c_str(),
-                    swap_blob.bucket_id, ctx, true);
+    ReadFromSwap(context, blob, swap_blob);
+    result = PlaceBlob(context, rpc, schemas[0], blob, name,
+                       swap_blob.bucket_id, ctx, true);
   } else {
-    // TODO(chogan): @errorhandling
-    result = 1;
+    LOG(ERROR) << result.Msg();
   }
 
   return result;

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1645,9 +1645,9 @@ size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
 }
 
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
-                 PlacementSchema &schema, Blob blob, const std::string &name,
-                 BucketID bucket_id, int retries,
-                 bool called_from_buffer_organizer) {
+                      PlacementSchema &schema, Blob blob,
+                      const std::string &name, BucketID bucket_id,
+                      api::Context &ctx, bool called_from_buffer_organizer) {
   api::Status result;
 
   if (ContainsBlob(context, rpc, bucket_id, name)
@@ -1671,8 +1671,6 @@ api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
     AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids);
   } else {
     if (called_from_buffer_organizer) {
-      // TODO(chogan): @errorhandling The BufferOrganizer failed to place a blob
-      // from swap space into the hierarchy.
       result = PLACE_SWAP_BLOB_TO_BUF_FAILED;
       LOG(ERROR) << result.Msg();
     } else {
@@ -1680,7 +1678,7 @@ api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                                      blob.size);
       result = BLOB_IN_SWAP_PLACE;
       LOG(WARNING) << result.Msg();
-      TriggerBufferOrganizer(rpc, kPlaceInHierarchy, name, swap_blob, retries);
+      TriggerBufferOrganizer(rpc, kPlaceInHierarchy, name, swap_blob, ctx);
     }
   }
 

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -484,9 +484,9 @@ std::vector<f32> GetBandwidths(SharedMemoryContext *context);
 
 u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
-int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                     SwapBlob swap_blob, const std::string &blob_name,
-                     api::Context &ctx);
+api::Status PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
+                             SwapBlob swap_blob, const std::string &blob_name,
+                             api::Context &ctx);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob,
                       const std::string &name, BucketID bucket_id,

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -486,11 +486,11 @@ u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                      SwapBlob swap_blob, const std::string &blob_name,
-                     api::Context ctx);
+                     api::Context &ctx);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob,
                       const std::string &name, BucketID bucket_id,
-                      api::Context ctx,
+                      api::Context &ctx,
                       bool called_from_buffer_organizer = false);
 api::Status StdIoPersistBucket(SharedMemoryContext *context, RpcContext *rpc,
                                Arena *arena, BucketID bucket_id,

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -485,10 +485,12 @@ std::vector<f32> GetBandwidths(SharedMemoryContext *context);
 u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 int PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
-                     SwapBlob swap_blob, const std::string &blob_name);
+                     SwapBlob swap_blob, const std::string &blob_name,
+                     api::Context ctx);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob,
-                      const std::string &name, BucketID bucket_id, int retries,
+                      const std::string &name, BucketID bucket_id,
+                      api::Context ctx,
                       bool called_from_buffer_organizer = false);
 api::Status StdIoPersistBucket(SharedMemoryContext *context, RpcContext *rpc,
                                Arena *arena, BucketID bucket_id,

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -116,7 +116,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "buffer_organizer_port",
   "rpc_host_number_range",
   "rpc_num_threads",
-  "placement_policy",
+  "default_placement_policy",
 };
 
 struct Token {

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -80,6 +80,7 @@ enum ConfigVariable {
   ConfigVariable_BufferOrganizerPort,
   ConfigVariable_RpcHostNumberRange,
   ConfigVariable_RpcNumThreads,
+  ConfigVariable_PlacementPolicy,
 
   ConfigVariable_Count
 };
@@ -115,6 +116,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "buffer_organizer_port",
   "rpc_host_number_range",
   "rpc_num_threads",
+  "placement_policy",
 };
 
 struct Token {
@@ -815,6 +817,22 @@ void ParseTokens(TokenList *tokens, Config *config) {
       }
       case ConfigVariable_RpcNumThreads: {
         config->rpc_num_threads = ParseInt(&tok);
+        break;
+      }
+      case ConfigVariable_PlacementPolicy: {
+        std::string policy = ParseString(&tok);
+
+        if (policy == "MinimizeIoTime") {
+          config->default_placement_policy =
+            api::PlacementPolicy::kMinimizeIoTime;
+        } else if (policy == "Random") {
+          config->default_placement_policy = api::PlacementPolicy::kRandom;
+        } else if (policy == "RoundRobin") {
+          config->default_placement_policy = api::PlacementPolicy::kRoundRobin;
+        } else {
+          LOG(FATAL) << "Unknown default_placement_policy: '" << policy << "'"
+                     << std::endl;
+        }
         break;
       }
       default: {

--- a/src/data_placement_engine.cc
+++ b/src/data_placement_engine.cc
@@ -398,6 +398,10 @@ Status CalculatePlacement(SharedMemoryContext *context, RpcContext *rpc,
       }
     }
 
+    if (targets.size() == 0) {
+      continue;
+    }
+
     std::vector<u64> node_state =
       GetRemainingTargetCapacities(context, rpc, targets);
 

--- a/src/hermes_status.h
+++ b/src/hermes_status.h
@@ -5,29 +5,29 @@
 namespace hermes {
 
 #define RETURN_CODES(X)                                          \
-  X(2,   HERMES_OK_MAX,              R"(Maximum supported HERMES success with \
-                                      caveat.)") \
+  X(2,   HERMES_OK_MAX,              "Maximum supported HERMES success with " \
+                                     "caveat.") \
   X(1,   BLOB_IN_SWAP_PLACE,         "Blob is placed into swap place.") \
   X(0,   HERMES_SUCCESS,             "No error!")         \
   X(-1,  INVALID_BUCKET,             "Bucket ID is invalid.") \
   X(-2,  BUCKET_NAME_TOO_LONG,       "Bucket name exceeds max length (256).") \
   X(-3,  VBUCKET_NAME_TOO_LONG,      "VBucket name exceeds max length (256).") \
   X(-4,  BLOB_NAME_TOO_LONG,         "Blob name exceeds max length (64).") \
-  X(-5,  INVALID_BLOB,               R"(Blob data is invalid. Please check \
-                                      address and size.)") \
+  X(-5,  INVALID_BLOB,               "Blob data is invalid. Please check " \
+                                     "address and size.") \
   X(-6,  BLOB_NOT_IN_BUCKET,         "Blob is not in this bucket.") \
   X(-7,  BLOB_NOT_LINKED_TO_VBUCKET, "Blob is not linked to this vbucket.") \
   X(-8,  TRAIT_NOT_VALID,            "Selected trait is not valid.") \
   X(-9,  TRAIT_EXISTS_ALREADY,       "Selected trait already exists.") \
   X(-10, OFFSET_MAP_EMPTY,           "Offset_map is empty.") \
   X(-11, BLOB_NOT_LINKED_IN_MAP,     "Map doesnt have the blob linked.") \
-  X(-12, BUCKET_IN_USE,              R"(Bucket cannot be destroyed because its \
-                                      reference count is greater than 1.)") \
-  X(-13, DPE_RANDOM_FOUND_NO_TGT,    R"(DPE random found no target with enough \
-                                      space for blob.)") \
+  X(-12, BUCKET_IN_USE,              "Bucket cannot be destroyed because its "\
+                                     "reference count is greater than 1.") \
+  X(-13, DPE_RANDOM_FOUND_NO_TGT,    "DPE random found no target with enough " \
+                                     "space for blob.") \
   X(-14, DPE_GET_INVALID_TGT,        "DPE got an invalid target ID.") \
-  X(-15, DPE_ORTOOLS_NO_SOLUTION,    R"(DPE or-tools does not find a solution \
-                                      with provided constraints.)") \
+  X(-15, DPE_ORTOOLS_NO_SOLUTION,    "DPE or-tools does not find a solution" \
+                                     "with provided constraints.") \
   X(-16, DPE_PLACEMENTSCHEMA_EMPTY,  "DPE PlacementSchema is empty.") \
   X(-17, READ_BLOB_FAILED,           "Read blob from its id failed.") \
   X(-18, STDIO_OFFSET_ERROR,         "Offset invalid or fseek() failed.") \
@@ -36,10 +36,10 @@ namespace hermes {
   X(-21, STDIO_FCLOSE_FAILED,        "Func fclose failed. System err msg: ") \
   X(-22, FCLOSE_FAILED,              "Func fclose failed. System err msg: ") \
   X(-23, INVALID_FILE,               "File is not valid.") \
-  X(-24, PLACE_SWAP_BLOB_TO_BUF_FAILED, R"(Place blob from swap space into \
-                                      buffering system failed.)") \
-  X(-25, DPE_RR_FIND_TGT_FAILED,     R"(DPE round-robin failed to find \
-                                      proper target for blob.)") \
+  X(-24, PLACE_SWAP_BLOB_TO_BUF_FAILED, "Place blob from swap space into " \
+                                     "buffering system failed.") \
+  X(-25, DPE_RR_FIND_TGT_FAILED,     "DPE round-robin failed to find " \
+                                     "proper target for blob.") \
   X(-26, HERMES_ERROR_MAX,           "Maximum supported HERMES errors.") \
 
 #define RETURN_ENUM(ID, NAME, TEXT) NAME = ID,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -43,6 +43,13 @@ typedef u16 DeviceID;
 
 namespace api {
 typedef std::vector<unsigned char> Blob;
+
+enum class PlacementPolicy {
+  kRandom,
+  kRoundRobin,
+  kMinimizeIoTime,
+};
+
 }  // namespace api
 
 // TODO(chogan): These constants impose limits on the number of slabs, devices,
@@ -160,6 +167,7 @@ struct Config {
   int buffer_organizer_port;
   int rpc_host_number_range[2];
   int rpc_num_threads;
+  api::PlacementPolicy default_placement_policy;
 
   /** A base name for the BufferPool shared memory segement. Hermes appends the
    * value of the USER environment variable to this string.

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -50,6 +50,17 @@ enum class PlacementPolicy {
   kMinimizeIoTime,
 };
 
+struct Context {
+  static int default_buffer_organizer_retries;
+  static PlacementPolicy default_placement_policy;
+
+  PlacementPolicy policy;
+  int buffer_organizer_retries;
+
+  Context() : policy(default_placement_policy),
+              buffer_organizer_retries(default_buffer_organizer_retries) {}
+};
+
 }  // namespace api
 
 // TODO(chogan): These constants impose limits on the number of slabs, devices,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -404,7 +404,7 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
   auto rpc_place_in_hierarchy = [context, rpc](const tl::request &req,
                                                SwapBlob swap_blob,
                                                const std::string name,
-                                               api::Context &ctx) {
+                                               api::Context ctx) {
     (void)req;
     for (int i = 0; i < ctx.buffer_organizer_retries; ++i) {
       LOG(INFO) << "Buffer Organizer placing blob '" << name

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -245,7 +245,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   auto rpc_rename_bucket =
     [context, rpc](const request &req, BucketID id, const string &old_name,
                    const string &new_name) {
-      LocalRenameBucket(context, rpc, id, old_name.c_str(), new_name.c_str());
+      LocalRenameBucket(context, rpc, id, old_name, new_name);
       req.respond(true);
     };
 
@@ -410,16 +410,16 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
       LOG(INFO) << "Buffer Organizer placing blob '" << name
                 << "' in hierarchy. Attempt " << i + 1 << " of "
                 << ctx.buffer_organizer_retries << std::endl;
-      int result = PlaceInHierarchy(context, rpc, swap_blob, name, ctx);
-      if (result == 0) {
+      api::Status result = PlaceInHierarchy(context, rpc, swap_blob, name, ctx);
+      if (result.Succeeded()) {
         break;
       } else {
-        // TODO(chogan): We probably don't want to sleep here, but for now this
-        // enables testing.
-        double sleep_ms = 2000;
         ThalliumState *state = GetThalliumState(rpc);
 
         if (state && state->bo_engine) {
+          // TODO(chogan): We probably don't want to sleep here, but for now
+          // this enables testing.
+          double sleep_ms = 2000;
           tl::thread::self().sleep(*state->bo_engine, sleep_ms);
         }
       }
@@ -435,10 +435,6 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
     for (int i = 0; i < retries; ++i) {
       // TODO(chogan): MoveToTarget(context, rpc, target_id, swap_blob);
       HERMES_NOT_IMPLEMENTED_YET;
-      int result = 0;
-      if (result == 0) {
-        break;
-      }
     }
   };
 

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -117,12 +117,6 @@ void serialize(A &ar, SwapBlob &swap_blob) {
   ar & swap_blob.bucket_id;
 }
 
-template<typename A>
-void serialize(A &ar, api::Context &ctx) {
-  ar & ctx.buffer_organizer_retries;
-  ar & (int)ctx.policy;
-}
-
 #ifndef THALLIUM_USE_CEREAL
 /**
  *  Lets Thallium know how to serialize a MapType.
@@ -152,7 +146,24 @@ void load(A &ar, MapType &map_type) {
   ar.read(&val, 1);
   map_type = (MapType)val;
 }
-#endif
+#endif  // #ifndef THALLIUM_USE_CEREAL
+
+namespace api {
+template<typename A>
+void save(A &ar, api::Context &ctx) {
+  ar.write(&ctx.buffer_organizer_retries, 1);
+  int val = (int)ctx.policy;
+  ar.write(&val, 1);
+}
+
+template<typename A>
+void load(A &ar, api::Context &ctx) {
+  int val = 0;
+  ar.read(&ctx.buffer_organizer_retries, 1);
+  ar.read(&val, 1);
+  ctx.policy = (PlacementPolicy)val;
+}
+}  // namespace api
 
 std::string GetRpcAddress(Config *config, const std::string &host_number,
                           int port);

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -117,6 +117,12 @@ void serialize(A &ar, SwapBlob &swap_blob) {
   ar & swap_blob.bucket_id;
 }
 
+template<typename A>
+void serialize(A &ar, api::Context &ctx) {
+  ar & ctx.buffer_organizer_retries;
+  ar & (int)ctx.policy;
+}
+
 #ifndef THALLIUM_USE_CEREAL
 /**
  *  Lets Thallium know how to serialize a MapType.

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -110,6 +110,8 @@ void InitDefaultConfig(Config *config) {
     config->buffer_pool_shmem_name[i] = buffer_pool_shmem_name[i];
   }
   config->buffer_pool_shmem_name[shmem_name_size] = '\0';
+
+  config->default_placement_policy = api::PlacementPolicy::kMinimizeIoTime;
 }
 
 namespace testing {

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -114,7 +114,8 @@ static void TestGetBandwidths() {
 }
 
 static hapi::Status ForceBlobToSwap(hapi::Hermes *hermes, hermes::u64 id,
-                                    hapi::Blob &blob, const char *blob_name) {
+                                    hapi::Blob &blob, const char *blob_name,
+                                    hapi::Context ctx) {
   using namespace hermes;  // NOLINT(*)
   PlacementSchema schema;
   schema.push_back({blob.size(), testing::DefaultRamTargetId()});
@@ -123,9 +124,8 @@ static hapi::Status ForceBlobToSwap(hapi::Hermes *hermes, hermes::u64 id,
   internal_blob.size = blob.size();
   hermes::BucketID bucket_id = {};
   bucket_id.as_int = id;
-  int retries = 3;
   hapi::Status result = PlaceBlob(&hermes->context_, &hermes->rpc_, schema,
-                                  internal_blob, blob_name, bucket_id, retries);
+                                  internal_blob, blob_name, bucket_id, ctx);
 
   return result;
 }
@@ -191,7 +191,7 @@ static void TestSwap() {
   hapi::Blob data(data_size, 'x');
   std::string blob_name("swap_blob");
   hapi::Status status = ForceBlobToSwap(hermes.get(), bucket.GetId(), data,
-                                        blob_name.c_str());
+                                        blob_name.c_str(), ctx);
   Assert(status == hermes::BLOB_IN_SWAP_PLACE);
   // NOTE(chogan): The Blob is in the swap space, but the API behaves as normal.
   Assert(bucket.ContainsBlob(blob_name));
@@ -228,7 +228,7 @@ static void TestBufferOrganizer() {
   hapi::Blob data2(KILOBYTES(4), 'y');
   std::string blob2_name("bo_blob2");
   status = ForceBlobToSwap(hermes.get(), bucket.GetId(), data2,
-                           blob2_name.c_str());
+                           blob2_name.c_str(), ctx);
   Assert(status == hermes::BLOB_IN_SWAP_PLACE);
   Assert(bucket.BlobIsInSwap(blob2_name));
 
@@ -318,14 +318,12 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-#define TEST(name) LOG(INFO) << "Running " << #name << std::endl; name();
-
-  // TEST(TestGetBuffers);
-  // TEST(TestGetBandwidths);
-  // TEST(TestBlobOverwrite);
-  TEST(TestSwap);
-  // TEST(TestBufferOrganizer);
-  // TEST(TestBufferingFileCorrectness);
+  TestGetBuffers;
+  TestGetBandwidths;
+  TestBlobOverwrite;
+  TestSwap;
+  TestBufferOrganizer;
+  TestBufferingFileCorrectness;
 
   MPI_Finalize();
 

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -172,7 +172,7 @@ static void TestBlobOverwrite() {
 
   // NOTE(chogan): Overwrite the data
   hapi::Blob new_blob(blob_size, '2');
-  status = bucket.Put(blob_name, new_blob, ctx);
+  Assert(bucket.Put(blob_name, new_blob, ctx).Succeeded());
 
   Assert(buffers_available[slab_index] == 1);
 

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -318,12 +318,12 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  TestGetBuffers;
-  TestGetBandwidths;
-  TestBlobOverwrite;
-  TestSwap;
-  TestBufferOrganizer;
-  TestBufferingFileCorrectness;
+  TestGetBuffers();
+  TestGetBandwidths();
+  TestBlobOverwrite();
+  TestSwap();
+  TestBufferOrganizer();
+  TestBufferingFileCorrectness();
 
   MPI_Finalize();
 

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -318,12 +318,14 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  TestGetBuffers();
-  TestGetBandwidths();
-  TestBlobOverwrite();
-  TestSwap();
-  TestBufferOrganizer();
-  TestBufferingFileCorrectness();
+#define TEST(name) LOG(INFO) << "Running " << #name << std::endl; name();
+
+  // TEST(TestGetBuffers);
+  // TEST(TestGetBandwidths);
+  // TEST(TestBlobOverwrite);
+  TEST(TestSwap);
+  // TEST(TestBufferOrganizer);
+  // TEST(TestBufferingFileCorrectness);
 
   MPI_Finalize();
 

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -93,5 +93,8 @@ int main(int argc, char **argv) {
   Assert(strncmp(config.buffer_pool_shmem_name, expected_shm_name,
                  sizeof(expected_shm_name)) == 0);
 
+  Assert(config.default_placement_policy ==
+         hermes::api::PlacementPolicy::kMinimizeIoTime);
+
   return 0;
 }

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -98,3 +98,6 @@ rpc_num_threads = 1;
 # The shared memory prefix for the hermes shared memory segment. A user name
 # will be automatically appended.
 buffer_pool_shmem_name = "/hermes_buffer_pool_";
+
+# Choose Random, RoundRobin, or MinimizeIotime
+default_placement_policy = "MinimizeIoTime";

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -99,5 +99,5 @@ rpc_num_threads = 1;
 # will be automatically appended.
 buffer_pool_shmem_name = "/hermes_buffer_pool_";
 
-# Choose Random, RoundRobin, or MinimizeIotime
+# Choose Random, RoundRobin, or MinimizeIoTime
 default_placement_policy = "MinimizeIoTime";


### PR DESCRIPTION
Closes #162.

* Adds a `default_placement_policy` option to the configuration file. This becomes the default `policy` value for all instances of `api::Context`.
* Save the `Context` passed to a `Bucket`. The `Context::policy` in the `Bucket` overrides the global default.
* Add overloads of `Put` that don't take a `Context` argument. These versions simply use the `Context` stored in the `Bucket`.
* Passing a `Context` to a `Put` overrides the `Bucket`'s default `policy`.
* The full `Context` is preserved on swap blobs when the BO attempts to place them back into the hierarchy. Previously it used a default `Context`.