### PR TITLE
Add API calls that use default Context

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -45,12 +45,20 @@ Bucket::~Bucket() {
   }
 }
 
+std::string Bucket::GetName() const {
+  return name_;
+}
+
+u64 Bucket::GetId() const {
+  return id_.as_int;
+}
+
 bool Bucket::IsValid() const {
   return !IsNullBucketId(id_);
 }
 
 Status Bucket::Put(const std::string &name, const u8 *data, size_t size,
-                   Context &ctx) {
+                   const Context &ctx) {
   Status result;
 
   if (size > 0 && nullptr == data) {
@@ -76,7 +84,7 @@ Status Bucket::Put(const std::string &name, const u8 *data, size_t size) {
 }
 
 size_t Bucket::GetBlobSize(Arena *arena, const std::string &name,
-                           Context &ctx) {
+                           const Context &ctx) {
   (void)ctx;
   size_t result = 0;
 
@@ -94,14 +102,21 @@ size_t Bucket::GetBlobSize(Arena *arena, const std::string &name,
   return result;
 }
 
-size_t Bucket::Get(const std::string &name, Blob &user_blob, Context &ctx) {
+size_t Bucket::Get(const std::string &name, Blob &user_blob,
+                   const Context &ctx) {
   size_t ret = Get(name, user_blob.data(), user_blob.size(), ctx);
 
   return ret;
 }
 
+size_t Bucket::Get(const std::string &name, Blob &user_blob) {
+  size_t result = Get(name, user_blob, ctx_);
+
+  return result;
+}
+
 size_t Bucket::Get(const std::string &name, void *user_blob, size_t blob_size,
-                   Context &ctx) {
+                   const Context &ctx) {
   (void)ctx;
 
   size_t ret = 0;
@@ -128,7 +143,7 @@ size_t Bucket::Get(const std::string &name, void *user_blob, size_t blob_size,
 }
 
 std::vector<size_t> Bucket::Get(const std::vector<std::string> &names,
-                                std::vector<Blob> &blobs, Context &ctx) {
+                                std::vector<Blob> &blobs, const Context &ctx) {
   std::vector<size_t> result(names.size(), 0);
   if (names.size() == blobs.size()) {
     for (size_t i = 0; i < result.size(); ++i) {
@@ -154,7 +169,13 @@ Status Bucket::GetV(void *user_blob, Predicate pred, Context &ctx) {
   return ret;
 }
 
-Status Bucket::DeleteBlob(const std::string &name, Context &ctx) {
+Status Bucket::DeleteBlob(const std::string &name) {
+  Status result = DeleteBlob(name, ctx_);
+
+  return result;
+}
+
+Status Bucket::DeleteBlob(const std::string &name, const Context &ctx) {
   (void)ctx;
   Status ret;
 
@@ -165,8 +186,15 @@ Status Bucket::DeleteBlob(const std::string &name, Context &ctx) {
 }
 
 Status Bucket::RenameBlob(const std::string &old_name,
+                          const std::string &new_name) {
+  Status result = RenameBlob(old_name, new_name, ctx_);
+
+  return result;
+}
+
+Status Bucket::RenameBlob(const std::string &old_name,
                           const std::string &new_name,
-                          Context &ctx) {
+                          const Context &ctx) {
   (void)ctx;
   Status ret;
 
@@ -209,16 +237,13 @@ std::vector<std::string> Bucket::GetBlobNames(Predicate pred,
   return std::vector<std::string>();
 }
 
-struct bkt_info * Bucket::GetInfo(Context &ctx) {
-  (void)ctx;
-  struct bkt_info *ret = nullptr;
+Status Bucket::Rename(const std::string &new_name) {
+  Status result = Rename(new_name, ctx_);
 
-  LOG(INFO) << "Getting bucket information from bucket " << name_ << '\n';
-
-  return ret;
+  return result;
 }
 
-Status Bucket::Rename(const std::string &new_name, Context &ctx) {
+Status Bucket::Rename(const std::string &new_name, const Context &ctx) {
   (void)ctx;
   Status ret;
 
@@ -235,7 +260,13 @@ Status Bucket::Rename(const std::string &new_name, Context &ctx) {
   return ret;
 }
 
-Status Bucket::Persist(const std::string &file_name, Context &ctx) {
+Status Bucket::Persist(const std::string &file_name) {
+  Status result = Persist(file_name, ctx_);
+
+  return result;
+}
+
+Status Bucket::Persist(const std::string &file_name, const Context &ctx) {
   (void)ctx;
   // TODO(chogan): Once we have Traits, we need to let users control the mode
   // when we're, for example, updating an existing file. For now we just assume
@@ -250,7 +281,13 @@ Status Bucket::Persist(const std::string &file_name, Context &ctx) {
   return result;
 }
 
-Status Bucket::Release(Context &ctx) {
+Status Bucket::Release() {
+  Status result = Release(ctx_);
+
+  return result;
+}
+
+Status Bucket::Release(const Context &ctx) {
   (void)ctx;
   Status ret;
 
@@ -263,7 +300,13 @@ Status Bucket::Release(Context &ctx) {
   return ret;
 }
 
-Status Bucket::Destroy(Context &ctx) {
+Status Bucket::Destroy() {
+  Status result = Destroy(ctx_);
+
+  return result;
+}
+
+Status Bucket::Destroy(const Context &ctx) {
   (void)ctx;
   Status result;
 

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -27,6 +27,12 @@ bool VBucket::IsValid() const {
   return !IsNullVBucketId(id_);
 }
 
+Status VBucket::Link(std::string blob_name, std::string bucket_name) {
+  Status result = Link(blob_name, bucket_name, ctx_);
+
+  return result;
+}
+
 Status VBucket::Link(std::string blob_name, std::string bucket_name,
                      Context& ctx) {
   (void)ctx;
@@ -55,6 +61,12 @@ Status VBucket::Link(std::string blob_name, std::string bucket_name,
   }
 
   return ret;
+}
+
+Status VBucket::Unlink(std::string blob_name, std::string bucket_name) {
+  Status result = Unlink(blob_name, bucket_name, ctx_);
+
+  return result;
 }
 
 Status VBucket::Unlink(std::string blob_name, std::string bucket_name,
@@ -90,7 +102,7 @@ Status VBucket::Unlink(std::string blob_name, std::string bucket_name,
   return ret;
 }
 
-bool VBucket::Contain_blob(std::string blob_name, std::string bucket_name) {
+bool VBucket::ContainsBlob(std::string blob_name, std::string bucket_name) {
   bool ret = false;
   std::string bk_tmp, blob_tmp;
 
@@ -126,6 +138,12 @@ std::vector<std::string> VBucket::GetLinks(Predicate pred, Context& ctx) {
   return std::vector<std::string>();
 }
 
+Status VBucket::Attach(Trait* trait) {
+  Status result = Attach(trait, ctx_);
+
+  return result;
+}
+
 Status VBucket::Attach(Trait* trait, Context& ctx) {
   (void)ctx;
   (void)trait;
@@ -158,6 +176,12 @@ Status VBucket::Attach(Trait* trait, Context& ctx) {
   }
 
   return ret;
+}
+
+Status VBucket::Detach(Trait* trait) {
+  Status result = Detach(trait, ctx_);
+
+  return result;
 }
 
 Status VBucket::Detach(Trait* trait, Context& ctx) {
@@ -212,6 +236,12 @@ std::vector<TraitID> VBucket::GetTraits(Predicate pred, Context& ctx) {
     attached_traits.push_back(t->id);
   }
   return attached_traits;
+}
+
+Status VBucket::Delete() {
+  Status result = Delete(ctx_);
+
+  return result;
 }
 
 Status VBucket::Delete(Context& ctx) {

--- a/src/api/vbucket.h
+++ b/src/api/vbucket.h
@@ -37,19 +37,21 @@ class VBucket {
   bool persist;
   /** internal Hermes object owned by vbucket */
   std::shared_ptr<Hermes> hermes_;
+  /** The Context for this VBucket. */
+  Context ctx_;
 
  public:
   VBucket(std::string initial_name, std::shared_ptr<Hermes> const &h,
-          bool persist, Context ctx)
+          bool persist, Context ctx = Context())
       : name_(initial_name),
         id_({0, 0}),
         linked_blobs_(),
         attached_traits_(),
         local_blob(),
         persist(persist),
-        hermes_(h) {
+        hermes_(h),
+        ctx_(ctx) {
     LOG(INFO) << "Create VBucket " << initial_name << std::endl;
-    (void)ctx;
     if (IsVBucketNameTooLong(name_)) {
       id_.as_int = 0;
       throw std::length_error("VBucket name exceeds maximum size of " +
@@ -74,12 +76,14 @@ class VBucket {
 
   /** link a blob to this vbucket */
   Status Link(std::string blob_name, std::string bucket_name, Context &ctx);
+  Status Link(std::string blob_name, std::string bucket_name);
 
   /** unlink a blob from this vbucket */
   Status Unlink(std::string blob_name, std::string bucket_name, Context &ctx);
+  Status Unlink(std::string blob_name, std::string bucket_name);
 
   /** check if blob is in this vbucket */
-  bool Contain_blob(std::string blob_name, std::string bucket_name);
+  bool ContainsBlob(std::string blob_name, std::string bucket_name);
 
   /** get a blob linked to this vbucket */
   Blob &GetBlob(std::string blob_name, std::string bucket_name);
@@ -91,9 +95,11 @@ class VBucket {
 
   /** attach a trait to this vbucket */
   Status Attach(Trait *trait, Context &ctx);
+  Status Attach(Trait *trait);
 
   /** detach a trait to this vbucket */
   Status Detach(Trait *trait, Context &ctx);
+  Status Detach(Trait *trait);
 
   /** retrieves the subset of attached traits satisfying pred */
   template <class Predicate>
@@ -102,6 +108,7 @@ class VBucket {
   /** delete a vBucket */
   /** decrements the links counts of blobs in buckets */
   Status Delete(Context &ctx);
+  Status Delete();
 };  // class VBucket
 
 }  // namespace api

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -17,7 +17,7 @@ namespace hermes {
 
 Status PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                         SwapBlob swap_blob, const std::string &name,
-                        api::Context &ctx) {
+                        const api::Context &ctx) {
   std::vector<PlacementSchema> schemas;
   std::vector<size_t> sizes(1, swap_blob.size);
   Status result = CalculatePlacement(context, rpc, sizes, schemas, ctx);

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1654,7 +1654,8 @@ size_t ReadFromSwap(SharedMemoryContext *context, Blob blob,
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob,
                       const std::string &name, BucketID bucket_id,
-                      api::Context &ctx, bool called_from_buffer_organizer) {
+                      const api::Context &ctx,
+                      bool called_from_buffer_organizer) {
   api::Status result;
 
   if (ContainsBlob(context, rpc, bucket_id, name)

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -489,11 +489,11 @@ u32 GetBufferSize(SharedMemoryContext *context, RpcContext *rpc, BufferID id);
 bool BufferIsByteAddressable(SharedMemoryContext *context, BufferID id);
 api::Status PlaceInHierarchy(SharedMemoryContext *context, RpcContext *rpc,
                              SwapBlob swap_blob, const std::string &blob_name,
-                             api::Context &ctx);
+                             const api::Context &ctx);
 api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
                       PlacementSchema &schema, Blob blob,
                       const std::string &name, BucketID bucket_id,
-                      api::Context &ctx,
+                      const api::Context &ctx,
                       bool called_from_buffer_organizer = false);
 api::Status StdIoPersistBucket(SharedMemoryContext *context, RpcContext *rpc,
                                Arena *arena, BucketID bucket_id,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -446,7 +446,7 @@ void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,
 
 void TriggerBufferOrganizer(RpcContext *rpc, const char *func_name,
                             const std::string &blob_name, SwapBlob swap_blob,
-                            api::Context &ctx) {
+                            const api::Context &ctx) {
   std::string server_name = GetServerName(rpc, rpc->node_id, true);
   std::string protocol = GetProtocol(rpc);
   tl::engine engine(protocol, THALLIUM_CLIENT_MODE, true);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -78,13 +78,12 @@ TargetID DefaultFileTargetId() {
 
 void GetAndVerifyBlob(api::Bucket &bucket, const std::string &blob_name,
                       const api::Blob &expected) {
-  api::Context ctx;
   api::Blob retrieved_blob;
   size_t expected_size = expected.size();
-  size_t retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
+  size_t retrieved_size = bucket.Get(blob_name, retrieved_blob);
   Assert(expected_size == retrieved_size);
   retrieved_blob.resize(retrieved_size);
-  retrieved_size = bucket.Get(blob_name, retrieved_blob, ctx);
+  retrieved_size = bucket.Get(blob_name, retrieved_blob);
   Assert(expected_size == retrieved_size);
   Assert(retrieved_blob == expected);
 }

--- a/test/trait_test.cc
+++ b/test/trait_test.cc
@@ -93,13 +93,12 @@ TEST_CASE("CustomTrait",
   // REQUIRE(info.comm_size > 1);
   std::shared_ptr<hermes::api::Hermes> hermes_app =
       hermes::api::InitHermes(args.config.c_str(), true);
-  hermes::api::Context ctx;
   fs::path fullpath = args.directory;
   fullpath /= args.filename;
   std::string fullpath_str = fullpath.string();
   SECTION("Basic") {
-    hermes::api::Bucket file_bucket(args.filename, hermes_app, ctx);
-    hermes::api::VBucket file_vbucket(args.filename, hermes_app, true, ctx);
+    hermes::api::Bucket file_bucket(args.filename, hermes_app);
+    hermes::api::VBucket file_vbucket(args.filename, hermes_app, true);
     auto offset_map = std::unordered_map<std::string, hermes::u64>();
     auto blob_cmp = [](std::string a, std::string b) {
       return std::stol(a) < std::stol(b);
@@ -108,21 +107,21 @@ TEST_CASE("CustomTrait",
     auto check_write = hermes::api::Blob();
     for (size_t i = 0; i < args.iterations; ++i) {
       hermes::api::Status status =
-        file_bucket.Put(std::to_string(i), info.write_blob, ctx);
+        file_bucket.Put(std::to_string(i), info.write_blob);
       Assert(status.Succeeded());
       blob_names.insert(std::to_string(i));
       check_write.insert(check_write.end(), info.write_blob.begin(),
                          info.write_blob.end());
     }
     for (const auto& blob_name : blob_names) {
-      file_vbucket.Link(blob_name, args.filename, ctx);
+      file_vbucket.Link(blob_name, args.filename);
       offset_map.emplace(blob_name, std::stol(blob_name) * info.FILE_PAGE);
     }
     auto trait = hermes::api::FileMappingTrait(fullpath_str, offset_map,
                                                nullptr, NULL, NULL);
-    file_vbucket.Attach(&trait, ctx);
-    file_vbucket.Delete(ctx);
-    file_bucket.Destroy(ctx);
+    file_vbucket.Attach(&trait);
+    file_vbucket.Delete();
+    file_bucket.Destroy();
     REQUIRE(fs::exists(fullpath_str));
     REQUIRE(fs::file_size(fullpath_str) == args.iterations * args.request_size);
     auto read_blob =


### PR DESCRIPTION
Fixes #130.

* Add overloads of `Bucket` and `VBucket` methods that use a stored default `Context` (set during the constructor) instead of requiring the user to always pass one in.
* Pass `Context`s by `const` reference.
* Simplify tests by removing all default `Context` instances.