### PR TITLE
Fix bug in BlobID node assignment

### DIFF
--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -622,7 +622,8 @@ void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
                         bool is_swap_blob) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
 
-  int target_node = HashString(mdm, rpc, blob_name);
+  std::string internal_name = MakeInternalBlobName(blob_name, bucket_id);
+  int target_node = HashString(mdm, rpc, internal_name.c_str());
   BlobID blob_id = {};
   // NOTE(chogan): A negative node_id indicates a swap blob
   blob_id.bits.node_id = is_swap_blob ? -target_node : target_node;

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -546,8 +546,8 @@ u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type) {
 std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
                                   MapType map_type) {
   std::string result;
-  size_t map_size = GetStoredMapSize(mdm, map_type);
   IdMap *map = GetMap(mdm, map_type);
+  size_t map_size = shlen(map);
 
   // TODO(chogan): @optimization This could be more efficient if necessary
   for (size_t i = 0; i < map_size; ++i) {


### PR DESCRIPTION
* `BlobID`s were being assigned to nodes based on their user-facing name instead of their internal name. All library functions should only operate on the internal name.
* Fixed a possible race condition in map iteration. We should only get the number of elements when we already hold the lock.