### PR TITLE
Handle swap blob metadata correctly

### DIFF
--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -1670,7 +1670,8 @@ api::Status PlaceBlob(SharedMemoryContext *context, RpcContext *rpc,
     HERMES_END_TIMED_BLOCK();
 
     // NOTE(chogan): Update all metadata associated with this Put
-    AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids);
+    AttachBlobToBucket(context, rpc, name.c_str(), bucket_id, buffer_ids,
+                       false, called_from_buffer_organizer);
   } else {
     if (called_from_buffer_organizer) {
       result = PLACE_SWAP_BLOB_TO_BUF_FAILED;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -223,7 +223,8 @@ VBucketID GetOrCreateVBucketId(SharedMemoryContext *context, RpcContext *rpc,
 void AttachBlobToBucket(SharedMemoryContext *context, RpcContext *rpc,
                         const char *blob_name, BucketID bucket_id,
                         const std::vector<BufferID> &buffer_ids,
-                        bool is_swap_blob = false);
+                        bool is_swap_blob = false,
+                        bool called_from_buffer_organizer = false);
 
 /**
  *
@@ -342,6 +343,12 @@ void LocalEndGlobalTicketMutex(MetadataManager *mdm);
 void AttachBlobToVBucket(SharedMemoryContext *context, RpcContext *rpc,
                          const char *blob_name, const char *bucket_name,
                          VBucketID vbucket_id);
+
+/**
+ *
+ */
+void RemoveBlobFromBucketInfo(SharedMemoryContext *context, RpcContext *rpc,
+                              BucketID bucket_id, BlobID blob_id);
 
 /**
  *


### PR DESCRIPTION
* Fixes a memory leak when a `SwapBlob` is placed into the hierarchy. 
* Correctly removes a `SwapBlob` from a `Bucket`'s buffer ID list when it is placed into the hierarchy.
