### PR TITLE
Basic Blob statistics and scoring

### DIFF
--- a/src/api/bucket.cc
+++ b/src/api/bucket.cc
@@ -92,7 +92,7 @@ size_t Bucket::GetBlobSize(Arena *arena, const std::string &name,
     LOG(INFO) << "Getting Blob " << name << " size from bucket "
               << name_ << '\n';
     BlobID blob_id = GetBlobId(&hermes_->context_, &hermes_->rpc_, name,
-                                     id_);
+                               id_, false);
     if (!IsNullBlobId(blob_id)) {
       result = GetBlobSizeById(&hermes_->context_, &hermes_->rpc_, arena,
                                blob_id);

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -327,6 +327,8 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
 
   result->is_initialized = true;
 
+  WorldBarrier(&comm);
+
   return result;
 }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -190,7 +190,7 @@ BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
   std::string internal_name = MakeInternalBlobName(name, bucket_id);
   BlobID result = {};
   result.as_int = GetId(context, rpc, internal_name.c_str(), kMapType_Blob);
-  IncrementBlobStatsSafely(context, rpc, name, bucket_id, result);
+  IncrementBlobStatsSafely(context, rpc, internal_name, bucket_id, result);
 
   return result;
 }

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -1287,11 +1287,19 @@ std::string GetBucketNameById(SharedMemoryContext *context, RpcContext *rpc,
   }
 }
 
+/**
+ * Returns the score calculated from @p stats.
+ *
+ * A high score indicates a "cold" Blob, or one that has not been accessed very
+ * recently or frequently.
+ *
+ */
 f32 ScoringFunction(MetadataManager *mdm, Stats *stats) {
   f32 recency_weight = 0.5;
   f32 frequency_weight = 0.5;
+  // NOTE(chogan): A high relative_recency corresponds to a "cold" Blob.
   f32 relative_recency = mdm->clock - stats->bits.recency;
-  f32 result = (relative_recency * recency_weight +
+  f32 result = (relative_recency * recency_weight -
                 stats->bits.frequency * frequency_weight);
 
   return result;

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -190,6 +190,7 @@ BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
   std::string internal_name = MakeInternalBlobName(name, bucket_id);
   BlobID result = {};
   result.as_int = GetId(context, rpc, internal_name.c_str(), kMapType_Blob);
+  IncrementBlobStatsSafely(context, rpc, name, bucket_id, result);
 
   return result;
 }
@@ -457,7 +458,6 @@ VBucketID LocalGetNextFreeVBucketId(SharedMemoryContext *context,
     if (!IsNullVBucketId(result)) {
       VBucketInfo *info = GetVBucketInfoByIndex(mdm, result.bits.index);
       info->blobs = {};
-      info->stats = {};
       memset(info->traits, 0, sizeof(TraitID) * kMaxTraitsPerVBucket);
       info->ref_count.store(1);
       info->active = true;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -203,7 +203,8 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
  *
  */
 BlobID GetBlobId(SharedMemoryContext *context, RpcContext *rpc,
-                       const std::string &name, BucketID bucket_id);
+                 const std::string &name, BucketID bucket_id,
+                 bool track_stats = true);
 
 
 

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -105,6 +105,8 @@ BucketID LocalGetOrCreateBucketId(SharedMemoryContext *context,
                                   const std::string &name);
 VBucketID LocalGetOrCreateVBucketId(SharedMemoryContext *context,
                                     const std::string &name);
+f32 LocalGetBlobScore(SharedMemoryContext *context, BucketID bucket_id,
+                      BlobID blob_id);
 
 /**
  * Faster version of std::stoull.

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -360,6 +360,14 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
     req.respond(ret);
   };
 
+  auto rpc_increment_blob_stats_safely =
+    [context](const request &req, BucketID bucket_id, BlobID blob_id) {
+      MetadataManager *mdm = GetMetadataManagerFromContext(context);
+      LocalIncrementBlobStatsSafely(mdm, bucket_id, blob_id);
+
+      req.respond(true);
+  };
+
   // TODO(chogan): Currently these three are only used for testing.
   rpc_server->define("GetBuffers", rpc_get_buffers);
   rpc_server->define("SplitBuffers", rpc_split_buffers).disable_response();
@@ -413,6 +421,8 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_blobs_from_vbucket_info);
   rpc_server->define("RemoteGetBucketNameById",
                      rpc_get_bucket_name_by_id);
+  rpc_server->define("RemoteIncrementBlobStatsSafely",
+                     rpc_increment_blob_stats_safely);
 }
 
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -368,6 +368,13 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
       req.respond(true);
   };
 
+  auto rpc_get_blob_score =
+    [context](const request &req, BucketID bucket_id, BlobID blob_id) {
+      f32 result = LocalGetBlobScore(context, bucket_id, blob_id);
+
+      req.respond(result);
+  };
+
   // TODO(chogan): Currently these three are only used for testing.
   rpc_server->define("GetBuffers", rpc_get_buffers);
   rpc_server->define("SplitBuffers", rpc_split_buffers).disable_response();
@@ -423,6 +430,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_bucket_name_by_id);
   rpc_server->define("RemoteIncrementBlobStatsSafely",
                      rpc_increment_blob_stats_safely);
+  rpc_server->define("RemoteGetBlobScore", rpc_get_blob_score);
 }
 
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,

--- a/test/end_to_end_test.cc
+++ b/test/end_to_end_test.cc
@@ -115,12 +115,12 @@ int main(int argc, char **argv) {
     hermes->AppBarrier();
 
     // Each rank puts a whole blob to its own bucket
-    hapi::Bucket own_bucket(std::string("test_bucket_") +
-                            std::to_string(app_rank), hermes);
-    TestPutGetBucket(own_bucket, app_rank, 0);
-    own_bucket.Destroy();
+    // hapi::Bucket own_bucket(std::string("test_bucket_") +
+    //                         std::to_string(app_rank), hermes);
+    // TestPutGetBucket(own_bucket, app_rank, 0);
+    // own_bucket.Destroy();
 
-    TestBulkTransfer(hermes, app_rank);
+    // TestBulkTransfer(hermes, app_rank);
   } else {
     // Hermes core. No user code here.
   }

--- a/test/end_to_end_test.cc
+++ b/test/end_to_end_test.cc
@@ -115,12 +115,12 @@ int main(int argc, char **argv) {
     hermes->AppBarrier();
 
     // Each rank puts a whole blob to its own bucket
-    // hapi::Bucket own_bucket(std::string("test_bucket_") +
-    //                         std::to_string(app_rank), hermes);
-    // TestPutGetBucket(own_bucket, app_rank, 0);
-    // own_bucket.Destroy();
+    hapi::Bucket own_bucket(std::string("test_bucket_") +
+                            std::to_string(app_rank), hermes);
+    TestPutGetBucket(own_bucket, app_rank, 0);
+    own_bucket.Destroy();
 
-    // TestBulkTransfer(hermes, app_rank);
+    TestBulkTransfer(hermes, app_rank);
   } else {
     // Hermes core. No user code here.
   }


### PR DESCRIPTION
This is the initial infrastructure for `Blob` statistics and scoring. The details can be refined as we discuss more as a group.

* Tracks recency and frequency of accesses for each `Blob`.
* Adds `GetBlobScore` function.

**TODO**: #213. Stat lookups are currently slow (`O(n)`) because they are stored in arrays. Once #212 is finished, I can convert the stats into a `BlobID -> Stats` map.