### PR TITLE
Update all references to old SDS repo to new Github Mochi location

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ git clone https://github.com/spack/spack ${SPACK_DIR}
 # set location of hermes_file_staging
 STAGE_DIR=~/hermes_stage
 # no change from this point
-SDS_REPO=${STAGE_DIR}/sds
+MOCHI_REPO=${STAGE_DIR}/mochi
 HERMES_REPO=${STAGE_DIR}/hermes
-git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git ${SDS_REPO}
+git clone https://github.com/mochi-hpc/mochi-spack-packages.git ${MOCHI_REPO}
 git clone https://github.com/HDFGroup/hermes ${HERMES_REPO}
 . ${SPACK_DIR}/share/spack/setup-env.sh
-spack repo add ${SDS_REPO}
+spack repo add ${MOCHI_REPO}
 spack repo add ${HERMES_REPO}/ci/hermes
 spack install hermes
 ```

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 INSTALL_DIR="${HOME}/${LOCAL}"
 SPACK_DIR=${INSTALL_DIR}/spack
-SDS_REPO_DIR=${INSTALL_DIR}/sds-repo
+SDS_REPO_DIR=${INSTALL_DIR}/mochi-spack-packages
 THALLIUM_VERSION=0.8.3
 GOTCHA_VERSION=develop
 CATCH2_VERSION=2.13.3
@@ -20,7 +20,8 @@ set +x
 set -x
 
 cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
-git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git ${SDS_REPO_DIR}
+SDS_REPO=https://github.com/mochi-hpc/mochi-spack-packages.git
+git clone ${SDS_REPO} ${SDS_REPO_DIR}
 
 set +x
 spack repo add ${SDS_REPO_DIR}

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 INSTALL_DIR="${HOME}/${LOCAL}"
 SPACK_DIR=${INSTALL_DIR}/spack
-SDS_REPO_DIR=${INSTALL_DIR}/mochi-spack-packages
+MOCHI_REPO_DIR=${INSTALL_DIR}/mochi-spack-packages
 THALLIUM_VERSION=0.8.3
 GOTCHA_VERSION=develop
 CATCH2_VERSION=2.13.3
@@ -20,11 +20,11 @@ set +x
 set -x
 
 cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
-SDS_REPO=https://github.com/mochi-hpc/mochi-spack-packages.git
-git clone ${SDS_REPO} ${SDS_REPO_DIR}
+MOCHI_REPO=https://github.com/mochi-hpc/mochi-spack-packages.git
+git clone ${MOCHI_REPO} ${MOCHI_REPO_DIR}
 
 set +x
-spack repo add ${SDS_REPO_DIR}
+spack repo add ${MOCHI_REPO_DIR}
 spack repo add ./ci/hermes
 
 GOTCHA_SPEC=gotcha@${GOTCHA_VERSION}

--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -42,19 +42,19 @@ ENV HOME=/home/$USER
 ENV PROJECT=$HOME/source
 ENV INSTALL_DIR=$HOME/install
 ENV SPACK_DIR=$HOME/spack
-ENV SDS_DIR=$HOME/sds
+ENV MOCHI_DIR=$HOME/mochi
 
 RUN echo $INSTALL_DIR && mkdir -p $INSTALL_DIR
 
 RUN git clone https://github.com/spack/spack ${SPACK_DIR}
-RUN git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git ${SDS_DIR}
+RUN git clone https://github.com/mochi-hpc/mochi-spack/packages.git ${MOCHI_DIR}
 RUN git clone https://github.com/HDFGroup/hermes ${PROJECT}
 
 ENV spack=${SPACK_DIR}/bin/spack
 
 RUN . ${SPACK_DIR}/share/spack/setup-env.sh
 
-RUN $spack repo add ${SDS_DIR}
+RUN $spack repo add ${MOCHI_DIR}
 RUN $spack repo add $PROJECT/ci/hermes
 
 RUN $spack compiler find


### PR DESCRIPTION
Closes #191.

The SDS spack repo on gitlab is no longer available.