### PR TITLE
Add locks for each Blob and store Stats in a map

### DIFF
--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -105,4 +105,50 @@ int MoveToTarget(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id,
   return result;
 }
 
+void LocalIncrementFlushCount(SharedMemoryContext *context,
+                              const std::string &vbkt_name) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  VBucketID id = LocalGetVBucketId(context, vbkt_name.c_str());
+  VBucketInfo *info = LocalGetVBucketInfoById(mdm, id);
+  int flush_count = info->async_flush_count.fetch_add(1);
+  VLOG(1) << "Flush count on VBucket " << vbkt_name << " incremented to "
+          << flush_count + 1 << "\n";
+}
+
+void LocalDecrementFlushCount(SharedMemoryContext *context,
+                         const std::string &vbkt_name) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  VBucketID id = LocalGetVBucketId(context, vbkt_name.c_str());
+  VBucketInfo *info = LocalGetVBucketInfoById(mdm, id);
+  int flush_count = info->async_flush_count.fetch_sub(1);
+  VLOG(1) << "Flush count on VBucket " << vbkt_name << " decremented to "
+          << flush_count - 1 << "\n";
+}
+
+void IncrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
+                         const std::string &vbkt_name) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  u32 target_node = HashString(mdm, rpc, vbkt_name.c_str());
+
+  if (target_node == rpc->node_id) {
+    LocalIncrementFlushCount(context, vbkt_name);
+  } else {
+    RpcCall<void>(rpc, target_node, "RemoteIncrementFlushCount",
+                  vbkt_name);
+  }
+}
+
+void DecrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
+                         const std::string &vbkt_name) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  u32 target_node = HashString(mdm, rpc, vbkt_name.c_str());
+
+  if (target_node == rpc->node_id) {
+    LocalDecrementFlushCount(context, vbkt_name);
+  } else {
+    RpcCall<void>(rpc, target_node, "RemoteDecrementFlushCount",
+                  vbkt_name);
+  }
+}
+
 }  // namespace hermes

--- a/src/buffer_organizer.cc
+++ b/src/buffer_organizer.cc
@@ -133,7 +133,7 @@ void IncrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
   if (target_node == rpc->node_id) {
     LocalIncrementFlushCount(context, vbkt_name);
   } else {
-    RpcCall<void>(rpc, target_node, "RemoteIncrementFlushCount",
+    RpcCall<bool>(rpc, target_node, "RemoteIncrementFlushCount",
                   vbkt_name);
   }
 }
@@ -146,7 +146,7 @@ void DecrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
   if (target_node == rpc->node_id) {
     LocalDecrementFlushCount(context, vbkt_name);
   } else {
-    RpcCall<void>(rpc, target_node, "RemoteDecrementFlushCount",
+    RpcCall<bool>(rpc, target_node, "RemoteDecrementFlushCount",
                   vbkt_name);
   }
 }

--- a/src/buffer_organizer.h
+++ b/src/buffer_organizer.h
@@ -65,7 +65,14 @@ void BoCopy(SharedMemoryContext *context, BufferID src, TargetID dest);
 void BoDelete(SharedMemoryContext *context, BufferID src);
 
 void ShutdownBufferOrganizer(SharedMemoryContext *context);
-
+void IncrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
+                         const std::string &vbkt_name);
+void DecrementFlushCount(SharedMemoryContext *context, RpcContext *rpc,
+                         const std::string &vbkt_name);
+void LocalIncrementFlushCount(SharedMemoryContext *context,
+                              const std::string &vbkt_name);
+void LocalDecrementFlushCount(SharedMemoryContext *context,
+                              const std::string &vbkt_name);
 }  // namespace hermes
 
 #endif  // HERMES_BUFFER_ORGANIZER_H_

--- a/src/buffer_pool.cc
+++ b/src/buffer_pool.cc
@@ -111,9 +111,11 @@ void Finalize(SharedMemoryContext *context, CommunicationContext *comm,
 }
 
 void LockBuffer(BufferHeader *header) {
-  bool expected = false;
-  while (header->locked.compare_exchange_weak(expected, true)) {
-    // NOTE(chogan): Spin until we get the lock
+  while (true) {
+    bool expected = false;
+    if (header->locked.compare_exchange_weak(expected, true)) {
+      break;
+    }
   }
 }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -83,7 +83,7 @@ static u32 GetBlobNodeId(BlobID id) {
 
 void LocalPut(MetadataManager *mdm, const char *key, u64 val,
               MapType map_type) {
-  PutToStorageStr(mdm, key, val, map_type);
+  PutToStorage(mdm, key, val, map_type);
 }
 
 void LocalPut(MetadataManager *mdm, BlobID key, const BlobInfo &value) {
@@ -91,7 +91,7 @@ void LocalPut(MetadataManager *mdm, BlobID key, const BlobInfo &value) {
 }
 
 u64 LocalGet(MetadataManager *mdm, const char *key, MapType map_type) {
-  u64 result = GetFromStorageStr(mdm, key, map_type);
+  u64 result = GetFromStorage(mdm, key, map_type);
 
   return result;
 }
@@ -101,7 +101,7 @@ void LocalDelete(MetadataManager *mdm, BlobID key) {
 }
 
 void LocalDelete(MetadataManager *mdm, const char *key, MapType map_type) {
-  DeleteFromStorageStr(mdm, key, map_type);
+  DeleteFromStorage(mdm, key, map_type);
 }
 
 MetadataManager *GetMetadataManagerFromContext(SharedMemoryContext *context) {
@@ -289,8 +289,8 @@ BucketInfo *LocalGetBucketInfoByIndex(MetadataManager *mdm, u32 index) {
 std::string LocalGetBlobNameFromId(SharedMemoryContext *context,
                                    BlobID blob_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  std::string blob_name = ReverseGetFromStorageStr(mdm, blob_id.as_int,
-                                                   kMapType_BlobId);
+  std::string blob_name = ReverseGetFromStorage(mdm, blob_id.as_int,
+                                                kMapType_BlobId);
 
   std::string result;
   if (blob_name.size() > kBucketIdStringSize) {
@@ -341,8 +341,8 @@ u64 HexStringToU64(const std::string &s) {
 
 BucketID LocalGetBucketIdFromBlobId(SharedMemoryContext *context, BlobID id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  std::string internal_name = ReverseGetFromStorageStr(mdm, id.as_int,
-                                                       kMapType_BlobId);
+  std::string internal_name = ReverseGetFromStorage(mdm, id.as_int,
+                                                    kMapType_BlobId);
   BucketID result = {};
   if (internal_name.size() > kBucketIdStringSize) {
     result.as_int = HexStringToU64(internal_name);
@@ -1303,7 +1303,7 @@ std::string LocalGetBucketNameById(SharedMemoryContext *context,
                                    BucketID blob_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   std::string bucket_name =
-      ReverseGetFromStorageStr(mdm, blob_id.as_int, kMapType_Bucket);
+      ReverseGetFromStorage(mdm, blob_id.as_int, kMapType_Bucket);
   return bucket_name;
 }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -1350,7 +1350,10 @@ int LocalGetNumOutstandingFlushingTasks(SharedMemoryContext *context,
                                         VBucketID id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
   VBucketInfo *info = LocalGetVBucketInfoById(mdm, id);
-  int result = info->async_flush_count;
+  int result = 0;
+  if (info) {
+    result = info->async_flush_count;
+  }
 
   return result;
 }

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -639,11 +639,9 @@ BufferIdArray GetBufferIdsFromBlobId(Arena *arena,
 void LocalCreateBlobMetadata(MetadataManager *mdm, const std::string &blob_name,
                              BlobID blob_id) {
   LocalPut(mdm, blob_name.c_str(), blob_id.as_int, kMapType_BlobId);
-  BlobInfo blob_info;
-  blob_info.stats = {};
-  blob_info.lock.ticket.store(0);
-  blob_info.lock.serving.store(0);
-
+  BlobInfo blob_info = {};
+  blob_info.stats.frequency = 1;
+  blob_info.stats.recency = mdm->clock++;
   LocalPut(mdm, blob_id, blob_info);
 }
 

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -270,7 +270,7 @@ void LocalDeleteBlobInfo(MetadataManager *mdm, BlobID blob_id) {
 void LocalDeleteBlobId(MetadataManager *mdm, const std::string &name,
                   BucketID bucket_id) {
   std::string internal_name = MakeInternalBlobName(name, bucket_id);
-  LocalDelete(mdm, name.c_str(), kMapType_BlobId);
+  LocalDelete(mdm, internal_name.c_str(), kMapType_BlobId);
 }
 
 void DeleteBlobId(MetadataManager *mdm, RpcContext *rpc,

--- a/src/metadata_management.cc
+++ b/src/metadata_management.cc
@@ -1415,7 +1415,7 @@ void LockBlob(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id) {
   if (target_node == rpc->node_id) {
     LocalLockBlob(context, blob_id);
   } else {
-    RpcCall<void>(rpc, target_node, "RemoteLockBlob", blob_id);
+    RpcCall<bool>(rpc, target_node, "RemoteLockBlob", blob_id);
   }
 }
 
@@ -1424,7 +1424,7 @@ void UnlockBlob(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id) {
   if (target_node == rpc->node_id) {
     LocalUnlockBlob(context, blob_id);
   } else {
-    RpcCall<void>(rpc, target_node, "RemoteUnlockBlob", blob_id);
+    RpcCall<bool>(rpc, target_node, "RemoteUnlockBlob", blob_id);
   }
 }
 

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -70,11 +70,6 @@ struct BlobInfo {
     lock.serving.store(0);
   }
 
-  BlobInfo(const BlobInfo &other) : stats(other.stats) {
-    lock.ticket.store(other.lock.ticket.load());
-    lock.serving.store(other.lock.serving.load());
-  }
-
   BlobInfo& operator=(const BlobInfo &other) {
     stats = other.stats;
     lock.ticket.store(other.lock.ticket.load());

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -30,18 +30,15 @@ struct RpcContext;
 enum MapType {
   kMapType_Bucket,
   kMapType_VBucket,
-  kMapType_Blob,
+  kMapType_BlobId,
+  kMapType_BlobInfo,
 
   kMapType_Count
 };
 
-union Stats {
-  struct {
-    u32 recency;
-    u32 frequency;
-  } bits;
-
-  u64 as_int;
+struct Stats {
+  u32 recency;
+  u32 frequency;
 };
 
 const int kIdListChunkSize = 10;
@@ -62,13 +59,36 @@ struct BufferIdArray {
   u32 length;
 };
 
+struct BlobInfo {
+  Stats stats;
+  TicketMutex lock;
+
+  BlobInfo() {
+    stats.recency = 0;
+    stats.frequency = 0;
+    lock.ticket.store(0);
+    lock.serving.store(0);
+  }
+
+  BlobInfo(const BlobInfo &other) : stats(other.stats) {
+    lock.ticket.store(other.lock.ticket.load());
+    lock.serving.store(other.lock.serving.load());
+  }
+
+  BlobInfo& operator=(const BlobInfo &other) {
+    stats = other.stats;
+    lock.ticket.store(other.lock.ticket.load());
+    lock.serving.store(other.lock.serving.load());
+
+    return *this;
+  }
+};
+
 struct BucketInfo {
   BucketID next_free;
   ChunkedIdList blobs;
   std::atomic<int> ref_count;
   bool active;
-  /** stats[i] corresponds to the BlobID at blobs[i]. */
-  ChunkedIdList stats;
 };
 
 static constexpr int kMaxTraitsPerVBucket = 8;
@@ -77,6 +97,7 @@ struct VBucketInfo {
   VBucketID next_free;
   ChunkedIdList blobs;
   std::atomic<int> ref_count;
+  std::atomic<int> async_flush_count;
   TraitID traits[kMaxTraitsPerVBucket];
   bool active;
 };
@@ -103,7 +124,8 @@ struct MetadataManager {
 
   ptrdiff_t bucket_map_offset;
   ptrdiff_t vbucket_map_offset;
-  ptrdiff_t blob_map_offset;
+  ptrdiff_t blob_id_map_offset;
+  ptrdiff_t blob_info_map_offset;
 
   ptrdiff_t swap_filename_prefix_offset;
   ptrdiff_t swap_filename_suffix_offset;
@@ -122,8 +144,10 @@ struct MetadataManager {
   TicketMutex bucket_map_mutex;
   /** Lock for accessing the `IdMap` located at `vbucket_map_offset` */
   TicketMutex vbucket_map_mutex;
-  /** Lock for accessing the `IdMap` located at `blob_map_offset` */
-  TicketMutex blob_map_mutex;
+  /** Lock for accessing the `IdMap` located at `blob_id_map_offset` */
+  TicketMutex blob_id_map_mutex;
+  /** Lock for accessing the `BlobInfoMap` located at `blob_info_map_offset` */
+  TicketMutex blob_info_map_mutex;
   /** Lock for accessing `IdList`s and `ChunkedIdList`s */
   TicketMutex id_mutex;
 
@@ -386,16 +410,33 @@ std::string GetBucketNameById(SharedMemoryContext *context, RpcContext *rpc,
 /**
  *
  */
-void IncrementBlobStatsSafely(SharedMemoryContext *context, RpcContext *rpc,
-                              const std::string &name, BucketID bucket_id,
-                              BlobID blob_id);
+void IncrementBlobStats(SharedMemoryContext *context, RpcContext *rpc,
+                        BlobID blob_id);
 
 /**
  *
  */
-void LocalIncrementBlobStatsSafely(MetadataManager *mdm, BucketID bucket_id,
-                                   BlobID blob_id);
+void LocalIncrementBlobStats(MetadataManager *mdm, BlobID blob_id);
 
+/**
+ *
+ */
+void LockBlob(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id);
+
+/**
+ *
+ */
+void UnlockBlob(SharedMemoryContext *context, RpcContext *rpc, BlobID blob_id);
+
+/**
+ *
+ */
+void LocalLockBlob(SharedMemoryContext *context, BlobID blob_id);
+
+/**
+ *
+ */
+void LocalUnlockBlob(SharedMemoryContext *context, BlobID blob_id);
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -105,8 +105,7 @@ BucketID LocalGetOrCreateBucketId(SharedMemoryContext *context,
                                   const std::string &name);
 VBucketID LocalGetOrCreateVBucketId(SharedMemoryContext *context,
                                     const std::string &name);
-f32 LocalGetBlobScore(SharedMemoryContext *context, BucketID bucket_id,
-                      BlobID blob_id);
+f32 LocalGetBlobScore(SharedMemoryContext *context, BlobID blob_id);
 
 /**
  * Faster version of std::stoull.
@@ -135,6 +134,12 @@ std::vector<BlobID> LocalGetBlobsFromVBucketInfo(SharedMemoryContext *context,
                                                  VBucketID vbucket_id);
 std::string LocalGetBucketNameById(SharedMemoryContext *context,
                                    BucketID blob_id);
+
+
+int LocalGetNumOutstandingFlushingTasks(SharedMemoryContext *context,
+                                        VBucketID id);
+int GetNumOutstandingFlushingTasks(SharedMemoryContext *context,
+                                   RpcContext *rpc, VBucketID id);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_management_internal.h
+++ b/src/metadata_management_internal.h
@@ -140,6 +140,8 @@ int LocalGetNumOutstandingFlushingTasks(SharedMemoryContext *context,
                                         VBucketID id);
 int GetNumOutstandingFlushingTasks(SharedMemoryContext *context,
                                    RpcContext *rpc, VBucketID id);
+void LocalCreateBlobMetadata(MetadataManager *mdm, const std::string &blob_name,
+                             BlobID blob_id);
 
 }  // namespace hermes
 #endif  // HERMES_METADATA_MANAGEMENT_INTERNAL_H_

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -18,8 +18,8 @@ namespace hermes {
 /**
  *
  */
-void PutToStorageStr(MetadataManager *mdm, const char *key, u64 val,
-                     MapType map_type);
+void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
+                  MapType map_type);
 
 /**
  *
@@ -29,12 +29,12 @@ void PutToStorage(MetadataManager *mdm, BlobID key, const BlobInfo &val);
 /**
  *
  */
-u64 GetFromStorageStr(MetadataManager *mdm, const char *key, MapType map_type);
+u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type);
 
 /**
  *
  */
-std::string ReverseGetFromStorageStr(MetadataManager *mdm, u64 id,
+std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
                                   MapType map_type);
 
 /**
@@ -45,8 +45,8 @@ void DeleteFromStorage(MetadataManager *mdm, BlobID key, bool lock);
 /**
  *
  */
-void DeleteFromStorageStr(MetadataManager *mdm, const char *key,
-                          MapType map_type);
+void DeleteFromStorage(MetadataManager *mdm, const char *key,
+                       MapType map_type);
 
 /**
  *

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -45,8 +45,7 @@ void DeleteFromStorage(MetadataManager *mdm, BlobID key, bool lock);
 /**
  *
  */
-void DeleteFromStorage(MetadataManager *mdm, const char *key,
-                       MapType map_type);
+void DeleteFromStorage(MetadataManager *mdm, const char *key, MapType map_type);
 
 /**
  *

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -18,24 +18,30 @@ namespace hermes {
 /**
  *
  */
-void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
-                MapType map_type);
+void PutToStorageStr(MetadataManager *mdm, const char *key, u64 val,
+                     MapType map_type);
 
 /**
  *
  */
-u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type);
+void PutToStorage(MetadataManager *mdm, BlobID key, const BlobInfo &val);
 
 /**
  *
  */
-std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
+u64 GetFromStorageStr(MetadataManager *mdm, const char *key, MapType map_type);
+
+/**
+ *
+ */
+std::string ReverseGetFromStorageStr(MetadataManager *mdm, u64 id,
                                   MapType map_type);
 
 /**
  *
  */
-void DeleteFromStorage(MetadataManager *mdm, const char *key, MapType map_type);
+void DeleteFromStorageStr(MetadataManager *mdm, const char *key,
+                          MapType map_type);
 
 /**
  *
@@ -68,6 +74,16 @@ std::vector<TargetID> LocalGetNeighborhoodTargets(SharedMemoryContext *context);
  */
 std::vector<BlobID> LocalGetBlobIds(SharedMemoryContext *context,
                                     BucketID bucket_id);
+/**
+ *
+ */
+BlobInfo *GetBlobInfoPtr(MetadataManager *mdm, BlobID blob_id);
+
+/**
+ *
+ */
+void ReleaseBlobInfoPtr(MetadataManager *mdm);
+
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_STORAGE_H_

--- a/src/metadata_storage.h
+++ b/src/metadata_storage.h
@@ -40,6 +40,11 @@ std::string ReverseGetFromStorageStr(MetadataManager *mdm, u64 id,
 /**
  *
  */
+void DeleteFromStorage(MetadataManager *mdm, BlobID key, bool lock);
+
+/**
+ *
+ */
 void DeleteFromStorageStr(MetadataManager *mdm, const char *key,
                           MapType map_type);
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -744,8 +744,8 @@ void PutToStorage(MetadataManager *mdm, BlobID key, const BlobInfo &val) {
   CheckHeapOverlap(mdm);
 }
 
-void PutToStorageStr(MetadataManager *mdm, const char *key, u64 val,
-                     MapType map_type) {
+void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
+                  MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   shput(map, key, val, heap);
@@ -755,7 +755,7 @@ void PutToStorageStr(MetadataManager *mdm, const char *key, u64 val,
   CheckHeapOverlap(mdm);
 }
 
-u64 GetFromStorageStr(MetadataManager *mdm, const char *key, MapType map_type) {
+u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   u64 result = shget(map, key, heap);
@@ -764,7 +764,7 @@ u64 GetFromStorageStr(MetadataManager *mdm, const char *key, MapType map_type) {
   return result;
 }
 
-std::string ReverseGetFromStorageStr(MetadataManager *mdm, u64 id,
+std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
                                      MapType map_type) {
   std::string result;
   IdMap *map = GetMap(mdm, map_type);
@@ -802,8 +802,8 @@ void DeleteFromStorage(MetadataManager *mdm, BlobID key, bool lock) {
   }
 }
 
-void DeleteFromStorageStr(MetadataManager *mdm, const char *key,
-                          MapType map_type) {
+void DeleteFromStorage(MetadataManager *mdm, const char *key,
+                       MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   shdel(map, key, heap);

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -392,7 +392,7 @@ void IncrementBlobStats(SharedMemoryContext *context, RpcContext *rpc,
     MetadataManager *mdm = GetMetadataManagerFromContext(context);
     LocalIncrementBlobStats(mdm, blob_id);
   } else {
-    RpcCall<void>(rpc, target_node, "RemoteIncrementBlobStats", blob_id);
+    RpcCall<bool>(rpc, target_node, "RemoteIncrementBlobStats", blob_id);
   }
 }
 

--- a/src/metadata_storage_stb_ds.cc
+++ b/src/metadata_storage_stb_ds.cc
@@ -26,6 +26,11 @@ struct IdMap {
   u64 value;
 };
 
+struct BlobInfoMap {
+  BlobID key;
+  BlobInfo value;
+};
+
 static IdMap *GetMapByOffset(MetadataManager *mdm, u32 offset) {
   IdMap *result =(IdMap *)((u8 *)mdm + offset);
 
@@ -44,8 +49,8 @@ static IdMap *GetVBucketMap(MetadataManager *mdm) {
   return result;
 }
 
-static IdMap *GetBlobMap(MetadataManager *mdm) {
-  IdMap *result = GetMapByOffset(mdm, mdm->blob_map_offset);
+static IdMap *GetBlobIdMap(MetadataManager *mdm) {
+  IdMap *result = GetMapByOffset(mdm, mdm->blob_id_map_offset);
 
   return result;
 }
@@ -87,8 +92,12 @@ TicketMutex *GetMapMutex(MetadataManager *mdm, MapType map_type) {
       mutex = &mdm->vbucket_map_mutex;
       break;
     }
-    case kMapType_Blob: {
-      mutex = &mdm->blob_map_mutex;
+    case kMapType_BlobId: {
+      mutex = &mdm->blob_id_map_mutex;
+      break;
+    }
+    case kMapType_BlobInfo: {
+      mutex = &mdm->blob_info_map_mutex;
       break;
     }
     default: {
@@ -120,13 +129,21 @@ IdMap *GetMap(MetadataManager *mdm, MapType map_type) {
       result = GetVBucketMap(mdm);
       break;
     }
-    case kMapType_Blob: {
-      result = GetBlobMap(mdm);
+    case kMapType_BlobId: {
+      result = GetBlobIdMap(mdm);
       break;
     }
     default:
       HERMES_INVALID_CODE_PATH;
   }
+
+  return result;
+}
+
+BlobInfoMap *GetBlobInfoMap(MetadataManager *mdm) {
+  TicketMutex *mutex = GetMapMutex(mdm, kMapType_BlobInfo);
+  BeginTicketMutex(mutex);
+  BlobInfoMap *result = (BlobInfoMap *)((u8 *)mdm + mdm->blob_info_map_offset);
 
   return result;
 }
@@ -145,8 +162,12 @@ void ReleaseMap(MetadataManager *mdm, MapType map_type) {
       mutex = &mdm->vbucket_map_mutex;
       break;
     }
-    case kMapType_Blob: {
-      mutex = &mdm->blob_map_mutex;
+    case kMapType_BlobId: {
+      mutex = &mdm->blob_id_map_mutex;
+      break;
+    }
+    case kMapType_BlobInfo: {
+      mutex = &mdm->blob_info_map_mutex;
       break;
     }
     default: {
@@ -155,6 +176,36 @@ void ReleaseMap(MetadataManager *mdm, MapType map_type) {
   }
 
   EndTicketMutex(mutex);
+}
+
+/**
+ * Takes a lock on mdm->blob_info_map_mutex. Requires a corresponding
+ * ReleaseBlobInfoPtr call.
+ */
+BlobInfo *GetBlobInfoPtr(MetadataManager *mdm, BlobID blob_id) {
+  Heap *map_heap = GetMapHeap(mdm);
+  BlobInfoMap *map = GetBlobInfoMap(mdm);
+  BlobInfoMap *element = hmgetp_null(map, blob_id, map_heap);
+
+  BlobInfo *result = 0;
+  if (element) {
+    result = &element->value;
+  }
+
+  return result;
+}
+
+void ReleaseBlobInfoPtr(MetadataManager *mdm) {
+  EndTicketMutex(&mdm->blob_info_map_mutex);
+}
+
+BlobInfo LocalGetBlobInfo(SharedMemoryContext *context, BlobID blob_id) {
+  MetadataManager *mdm = GetMetadataManagerFromContext(context);
+  Heap *map_heap = GetMapHeap(mdm);
+  BlobInfoMap *map = GetBlobInfoMap(mdm);
+  BlobInfo result = hmget(map, blob_id, map_heap);
+
+  return result;
 }
 
 /**
@@ -314,14 +365,24 @@ void SetChunkedIdListElement(MetadataManager *mdm, ChunkedIdList *id_list,
   }
 }
 
-void LocalIncrementBlobStats(MetadataManager *mdm, ChunkedIdList *stats,
-                             u32 index) {
-  Stats stat = {};
-  stat.as_int = GetChunkedIdListElement(mdm, stats, index);
-  stat.bits.frequency++;
-  stat.bits.recency = mdm->clock++;
+void LocalIncrementBlobStats(MetadataManager *mdm, BlobID blob_id) {
+  BlobInfo *info = GetBlobInfoPtr(mdm, blob_id);
+  if (info) {
+    info->stats.frequency++;
+    info->stats.recency = mdm->clock++;
+  }
+  ReleaseBlobInfoPtr(mdm);
+}
 
-  SetChunkedIdListElement(mdm, stats, index, stat.as_int);
+void IncrementBlobStats(SharedMemoryContext *context, RpcContext *rpc,
+                        BlobID blob_id) {
+  u32 target_node = GetBlobNodeId(blob_id);
+  if (target_node == rpc->node_id) {
+    MetadataManager *mdm = GetMetadataManagerFromContext(context);
+    LocalIncrementBlobStats(mdm, blob_id);
+  } else {
+    RpcCall<void>(rpc, target_node, "RemoteIncrementBlobStats", blob_id);
+  }
 }
 
 i64 GetIndexOfId(MetadataManager *mdm, ChunkedIdList *id_list, u64 id) {
@@ -342,41 +403,40 @@ i64 GetIndexOfId(MetadataManager *mdm, ChunkedIdList *id_list, u64 id) {
 /** Protects the @p bucket_id's 'blobs' ChunkedIdList before incrementing its
  *  Stats.
  */
-void LocalIncrementBlobStatsSafely(MetadataManager *mdm, BucketID bucket_id,
-                                   BlobID blob_id) {
-  BeginTicketMutex(&mdm->bucket_mutex);
-  BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  i64 index = GetIndexOfId(mdm, &info->blobs, blob_id.as_int);
-  if (index < 0) {
-    LOG(WARNING) << "BlobID " << blob_id.as_int << " not found in Bucket "
-                 << bucket_id.as_int << std::endl;
-  } else {
-    LocalIncrementBlobStats(mdm, &info->stats, (u32)index);
-  }
-  EndTicketMutex(&mdm->bucket_mutex);
-}
+// void LocalIncrementBlobStatsSafely(MetadataManager *mdm, BucketID bucket_id,
+//                                    BlobID blob_id) {
+//   BeginTicketMutex(&mdm->bucket_mutex);
+//   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
+//   i64 index = GetIndexOfId(mdm, &info->blobs, blob_id.as_int);
+//   if (index < 0) {
+//     LOG(WARNING) << "BlobID " << blob_id.as_int << " not found in Bucket "
+//                  << bucket_id.as_int << std::endl;
+//   } else {
+//     LocalIncrementBlobStats(mdm, blob_id);
+//   }
+//   EndTicketMutex(&mdm->bucket_mutex);
+// }
 
-void IncrementBlobStatsSafely(SharedMemoryContext *context, RpcContext *rpc,
-                              const std::string &name, BucketID bucket_id,
-                              BlobID blob_id) {
-  MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  u32 target_node = HashString(mdm, rpc, name.c_str());
+// void IncrementBlobStatsSafely(SharedMemoryContext *context, RpcContext *rpc,
+//                               const std::string &name, BucketID bucket_id,
+//                               BlobID blob_id) {
+//   MetadataManager *mdm = GetMetadataManagerFromContext(context);
+//   u32 target_node = HashString(mdm, rpc, name.c_str());
 
-  if (target_node == rpc->node_id) {
-    LocalIncrementBlobStatsSafely(mdm, bucket_id, blob_id);
-  } else {
-    RpcCall<bool>(rpc, target_node, "RemoteIncrementBlobStatsSafely", bucket_id,
-                  blob_id);
-  }
-}
+//   if (target_node == rpc->node_id) {
+//     LocalIncrementBlobStatsSafely(mdm, bucket_id, blob_id);
+//   } else {
+//     RpcCall<bool>(rpc, target_node, "RemoteIncrementBlobStatsSafely",
+//                   bucket_id, blob_id);
+//   }
+// }
 
 void LocalAddBlobIdToBucket(MetadataManager *mdm, BucketID bucket_id,
                             BlobID blob_id) {
   BeginTicketMutex(&mdm->bucket_mutex);
   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  u32 index = AppendToChunkedIdList(mdm, &info->blobs, blob_id.as_int);
-  AppendToChunkedIdList(mdm, &info->stats, 0);
-  LocalIncrementBlobStats(mdm, &info->stats, index);
+  AppendToChunkedIdList(mdm, &info->blobs, blob_id.as_int);
+  LocalIncrementBlobStats(mdm, blob_id);
   EndTicketMutex(&mdm->bucket_mutex);
 
   CheckHeapOverlap(mdm);
@@ -488,20 +548,13 @@ void LocalRemoveBlobFromBucketInfo(SharedMemoryContext *context,
   BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
   ChunkedIdList *blobs = &info->blobs;
 
-  u32 index = 0;
   BlobID *blobs_arr = (BlobID *)GetIdsPtr(mdm, *blobs);
   for (u32 i = 0; i < blobs->length; ++i) {
     if (blobs_arr[i].as_int == blob_id.as_int) {
       blobs_arr[i] = blobs_arr[--blobs->length];
-      index = i;
       break;
     }
   }
-  ReleaseIdsPtr(mdm);
-
-  // Make the same change to the Stats array to maintain the correct order
-  u64 *stats = GetIdsPtr(mdm, info->stats);
-  stats[index] = stats[--info->stats.length];
   ReleaseIdsPtr(mdm);
 
   EndTicketMutex(&mdm->bucket_mutex);
@@ -583,7 +636,6 @@ bool LocalDestroyBucket(SharedMemoryContext *context, RpcContext *rpc,
     // Reset BucketInfo to initial values
     info->ref_count.store(0);
     info->active = false;
-    info->stats = {};
 
     mdm->num_buckets--;
     info->next_free = mdm->first_free_bucket;
@@ -622,6 +674,7 @@ bool LocalDestroyVBucket(SharedMemoryContext *context, const char *vbucket_name,
 
     // Reset VBucketInfo to initial values
     info->ref_count.store(0);
+    info->async_flush_count.store(0);
     info->active = false;
 
     mdm->num_vbuckets--;
@@ -676,8 +729,17 @@ LocalGetNeighborhoodTargets(SharedMemoryContext *context) {
   return result;
 }
 
-void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
-                  MapType map_type) {
+void PutToStorage(MetadataManager *mdm, BlobID key, const BlobInfo &val) {
+  Heap *heap = GetMapHeap(mdm);
+  BlobInfoMap *map = GetBlobInfoMap(mdm);
+  hmput(map, key, val, heap);
+  ReleaseMap(mdm, kMapType_BlobInfo);
+
+  CheckHeapOverlap(mdm);
+}
+
+void PutToStorageStr(MetadataManager *mdm, const char *key, u64 val,
+                     MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   shput(map, key, val, heap);
@@ -687,7 +749,7 @@ void PutToStorage(MetadataManager *mdm, const char *key, u64 val,
   CheckHeapOverlap(mdm);
 }
 
-u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type) {
+u64 GetFromStorageStr(MetadataManager *mdm, const char *key, MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   u64 result = shget(map, key, heap);
@@ -696,8 +758,8 @@ u64 GetFromStorage(MetadataManager *mdm, const char *key, MapType map_type) {
   return result;
 }
 
-std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
-                                  MapType map_type) {
+std::string ReverseGetFromStorageStr(MetadataManager *mdm, u64 id,
+                                     MapType map_type) {
   std::string result;
   IdMap *map = GetMap(mdm, map_type);
   size_t map_size = shlen(map);
@@ -717,8 +779,8 @@ std::string ReverseGetFromStorage(MetadataManager *mdm, u64 id,
   return result;
 }
 
-void DeleteFromStorage(MetadataManager *mdm, const char *key,
-                       MapType map_type) {
+void DeleteFromStorageStr(MetadataManager *mdm, const char *key,
+                          MapType map_type) {
   Heap *heap = GetMapHeap(mdm);
   IdMap *map = GetMap(mdm, map_type);
   shdel(map, key, heap);
@@ -811,9 +873,9 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
   ReleaseIdsPtr(mdm);
   mdm->node_targets = node_targets;
 
-  // ID Maps
+  // Maps
 
-  i64 total_map_capacity = GetHeapFreeList(map_heap)->size / 3;
+  i64 remaining_map_capacity = GetHeapFreeList(map_heap)->size / 3;
 
   IdMap *bucket_map = 0;
   // TODO(chogan): We can either calculate an average expected size here, or
@@ -826,30 +888,49 @@ void InitMetadataStorage(SharedMemoryContext *context, MetadataManager *mdm,
   u32 max_buckets = config->max_buckets_per_node + 1;
   u32 max_vbuckets = config->max_vbuckets_per_node + 1;
 
+  // Create Bucket name -> BucketID map
   sh_new_strdup(bucket_map, max_buckets, map_heap);
   shdefault(bucket_map, 0, map_heap);
   mdm->bucket_map_offset = GetOffsetFromMdm(mdm, bucket_map);
   u32 bucket_map_num_bytes = map_heap->extent;
-  total_map_capacity -= bucket_map_num_bytes;
-  assert(total_map_capacity > 0);
+  remaining_map_capacity -= bucket_map_num_bytes;
+  assert(remaining_map_capacity > 0);
 
-  // TODO(chogan): Just one map means better size estimate, but it's probably
-  // slower because they'll all share a lock.
-
+  // Create VBucket name -> VBucketID map
   IdMap *vbucket_map = 0;
   sh_new_strdup(vbucket_map, max_vbuckets, map_heap);
   shdefault(vbucket_map, 0, map_heap);
   mdm->vbucket_map_offset = GetOffsetFromMdm(mdm, vbucket_map);
   u32 vbucket_map_num_bytes = map_heap->extent - bucket_map_num_bytes;
-  total_map_capacity -= vbucket_map_num_bytes;
-  assert(total_map_capacity > 0);
+  remaining_map_capacity -= vbucket_map_num_bytes;
+  assert(remaining_map_capacity > 0);
 
-  IdMap *blob_map = 0;
   // NOTE(chogan): Each map element requires twice its size for storage.
-  size_t blob_map_capacity = total_map_capacity / (2 * sizeof(IdMap));
-  sh_new_strdup(blob_map, blob_map_capacity, map_heap);
+  size_t id_map_element_size = 2 * sizeof(IdMap);
+  size_t blob_info_map_element_size = 2 * sizeof(BlobInfoMap);
+  size_t bytes_per_blob = id_map_element_size + blob_info_map_element_size;
+  size_t num_blobs_supported = remaining_map_capacity / bytes_per_blob;
+  LOG(INFO) << "Metadata can support " << num_blobs_supported
+            << " Blobs per node\n";
+
+  // TODO(chogan): Add sizeof(stbds_array_header) to each map
+
+  // Create Blob name -> BlobID map
+  IdMap *blob_map = 0;
+  sh_new_strdup(blob_map, num_blobs_supported, map_heap);
   shdefault(blob_map, 0, map_heap);
-  mdm->blob_map_offset = GetOffsetFromMdm(mdm, blob_map);
+  mdm->blob_id_map_offset = GetOffsetFromMdm(mdm, blob_map);
+
+  // Create BlobID -> BlobInfo map
+  BlobInfoMap *blob_info_map = 0;
+  blob_info_map =
+    (BlobInfoMap *)stbds_arrgrowf(blob_info_map, sizeof(*blob_info_map), 0,
+                                  num_blobs_supported, map_heap);
+  blob_info_map =
+    (BlobInfoMap *)STBDS_ARR_TO_HASH(blob_info_map, sizeof(*blob_info_map));
+  BlobInfo default_blob_info = {};
+  hmdefault(blob_info_map, default_blob_info, map_heap);
+  mdm->blob_info_map_offset = GetOffsetFromMdm(mdm, blob_info_map);
 }
 
 std::vector<BlobID> LocalGetBlobsFromVBucketInfo(SharedMemoryContext *context,
@@ -882,36 +963,23 @@ void LocalRemoveBlobFromVBucketInfo(SharedMemoryContext *context,
   EndTicketMutex(&mdm->vbucket_mutex);
 }
 
-f32 LocalGetBlobScore(SharedMemoryContext *context, BucketID bucket_id,
-                      BlobID blob_id) {
+f32 LocalGetBlobScore(SharedMemoryContext *context, BlobID blob_id) {
   MetadataManager *mdm = GetMetadataManagerFromContext(context);
-  BeginTicketMutex(&mdm->bucket_mutex);
-  BucketInfo *info = LocalGetBucketInfoById(mdm, bucket_id);
-  i64 index = GetIndexOfId(mdm, &info->stats, blob_id.as_int);
+  BlobInfo info = LocalGetBlobInfo(context, blob_id);
 
-  Stats stats = {};
-  if (index < 0) {
-    LOG(WARNING) << "BlobID " << blob_id.as_int << " not found in Stats array "
-                 << " of BucketID " << bucket_id.as_int << std::endl;
-  } else {
-    stats.as_int = GetChunkedIdListElement(mdm, &info->stats, (u32)index);
-  }
-  EndTicketMutex(&mdm->bucket_mutex);
-
-  f32 result = ScoringFunction(mdm, &stats);
+  f32 result = ScoringFunction(mdm, &info.stats);
 
   return result;
 }
 
 f32 GetBlobScore(SharedMemoryContext *context, RpcContext *rpc,
-                 BucketID bucket_id, BlobID blob_id) {
+                 BlobID blob_id) {
   f32 result = 0;
   u32 target_node = GetBlobNodeId(blob_id);
   if (target_node == rpc->node_id) {
-    result = LocalGetBlobScore(context, bucket_id, blob_id);
+    result = LocalGetBlobScore(context, blob_id);
   } else {
-    result = RpcCall<f32>(rpc, target_node, "RemoteGetBlobScore", bucket_id,
-                          blob_id);
+    result = RpcCall<f32>(rpc, target_node, "RemoteGetBlobScore", blob_id);
   }
 
   return result;

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -341,8 +341,6 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   auto rpc_finalize = [rpc](const request &req) {
     ThalliumState *state = GetThalliumState(rpc);
     state->engine->finalize();
-
-    req.respond(true);
   };
 
   auto rpc_remove_blob_from_vbucket_info = [context](const request &req,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -339,6 +339,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   };
 
   auto rpc_finalize = [rpc](const request &req) {
+    (void)req;
     ThalliumState *state = GetThalliumState(rpc);
     state->engine->finalize();
   };

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -410,6 +410,15 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
     req.respond(true);
   };
 
+  auto rpc_create_blob_metadata =
+    [context](const request &req, const std::string &blob_name,
+              BlobID blob_id) {
+      MetadataManager *mdm = GetMetadataManagerFromContext(context);
+      LocalCreateBlobMetadata(mdm, blob_name, blob_id);
+
+      req.respond(true);
+  };
+
   // TODO(chogan): Currently these three are only used for testing.
   rpc_server->define("GetBuffers", rpc_get_buffers);
   rpc_server->define("SplitBuffers", rpc_split_buffers).disable_response();
@@ -471,6 +480,7 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_num_outstanding_flushing_tasks);
   rpc_server->define("RemoteLockBlob", rpc_lock_blob);
   rpc_server->define("RemoteUnlockBlob", rpc_unlock_blob);
+  rpc_server->define("RemoteCreateBlobMetadata", rpc_create_blob_metadata);
 }
 
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -339,40 +339,79 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
   };
 
   auto rpc_finalize = [rpc](const request &req) {
-    (void)req;
     ThalliumState *state = GetThalliumState(rpc);
     state->engine->finalize();
+
+    req.respond(true);
   };
 
   auto rpc_remove_blob_from_vbucket_info = [context](const request &req,
                                                     VBucketID vbucket_id,
                                                     BlobID blob_id) {
     LocalRemoveBlobFromVBucketInfo(context, vbucket_id, blob_id);
+
     req.respond(true);
   };
+
   auto rpc_get_blobs_from_vbucket_info = [context](const request &req,
                                                   VBucketID vbucket_id) {
     auto ret = LocalGetBlobsFromVBucketInfo(context, vbucket_id);
-    req.respond(ret);
-  };
-  auto rpc_get_bucket_name_by_id = [context](const request &req, BucketID id) {
-    auto ret = LocalGetBucketNameById(context, id);
+
     req.respond(ret);
   };
 
-  auto rpc_increment_blob_stats_safely =
-    [context](const request &req, BucketID bucket_id, BlobID blob_id) {
+  auto rpc_get_bucket_name_by_id = [context](const request &req, BucketID id) {
+    auto ret = LocalGetBucketNameById(context, id);
+
+    req.respond(ret);
+  };
+
+  auto rpc_increment_blob_stats =
+    [context](const request &req, BlobID blob_id) {
       MetadataManager *mdm = GetMetadataManagerFromContext(context);
-      LocalIncrementBlobStatsSafely(mdm, bucket_id, blob_id);
+      LocalIncrementBlobStats(mdm, blob_id);
 
       req.respond(true);
   };
 
   auto rpc_get_blob_score =
-    [context](const request &req, BucketID bucket_id, BlobID blob_id) {
-      f32 result = LocalGetBlobScore(context, bucket_id, blob_id);
+    [context](const request &req, BlobID blob_id) {
+      f32 result = LocalGetBlobScore(context, blob_id);
 
       req.respond(result);
+  };
+
+  auto rpc_increment_flush_count = [context](const request &req,
+                                             const std::string &name) {
+    LocalIncrementFlushCount(context, name);
+
+    req.respond(true);
+  };
+
+  auto rpc_decrement_flush_count = [context](const request &req,
+                                             const std::string &name) {
+    LocalDecrementFlushCount(context, name);
+
+    req.respond(true);
+  };
+
+  auto rpc_get_num_outstanding_flushing_tasks =
+    [context](const request &req, VBucketID id) {
+      int result = LocalGetNumOutstandingFlushingTasks(context, id);
+
+      req.respond(result);
+  };
+
+  auto rpc_lock_blob = [context](const request &req, BlobID id) {
+    LocalLockBlob(context, id);
+
+    req.respond(true);
+  };
+
+  auto rpc_unlock_blob = [context](const request &req, BlobID id) {
+    LocalUnlockBlob(context, id);
+
+    req.respond(true);
   };
 
   // TODO(chogan): Currently these three are only used for testing.
@@ -428,9 +467,14 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                      rpc_get_blobs_from_vbucket_info);
   rpc_server->define("RemoteGetBucketNameById",
                      rpc_get_bucket_name_by_id);
-  rpc_server->define("RemoteIncrementBlobStatsSafely",
-                     rpc_increment_blob_stats_safely);
+  rpc_server->define("RemoteIncrementBlobStats", rpc_increment_blob_stats);
   rpc_server->define("RemoteGetBlobScore", rpc_get_blob_score);
+  rpc_server->define("RemoteIncrementFlushCount", rpc_increment_flush_count);
+  rpc_server->define("RemoteDecrementFlushCount", rpc_decrement_flush_count);
+  rpc_server->define("RemoteGetNumOutstandingFlushingTasks",
+                     rpc_get_num_outstanding_flushing_tasks);
+  rpc_server->define("RemoteLockBlob", rpc_lock_blob);
+  rpc_server->define("RemoteUnlockBlob", rpc_unlock_blob);
 }
 
 void StartBufferOrganizer(SharedMemoryContext *context, RpcContext *rpc,

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -349,20 +349,17 @@ void ThalliumStartRpcServer(SharedMemoryContext *context, RpcContext *rpc,
                                                     VBucketID vbucket_id,
                                                     BlobID blob_id) {
     LocalRemoveBlobFromVBucketInfo(context, vbucket_id, blob_id);
-
     req.respond(true);
   };
 
   auto rpc_get_blobs_from_vbucket_info = [context](const request &req,
                                                   VBucketID vbucket_id) {
     auto ret = LocalGetBlobsFromVBucketInfo(context, vbucket_id);
-
     req.respond(ret);
   };
 
   auto rpc_get_bucket_name_by_id = [context](const request &req, BucketID id) {
     auto ret = LocalGetBucketNameById(context, id);
-
     req.respond(ret);
   };
 

--- a/src/stb_ds.h
+++ b/src/stb_ds.h
@@ -599,7 +599,7 @@ extern void * stbds_shmode_func(size_t elemsize, size_t capacity, int mode, Heap
 #define stbds_hmget_ts(t, k, temp,heap)  (stbds_hmgetp_ts(t,k,temp,heap)->value)
 #define stbds_hmlen(t)        ((t) ? (ptrdiff_t) stbds_header((t)-1)->length-1 : 0)
 #define stbds_hmlenu(t)       ((t) ?             stbds_header((t)-1)->length-1 : 0)
-#define stbds_hmgetp_null(t,k)  (stbds_hmgeti(t,k) == -1 ? NULL : &(t)[stbds_temp(t)-1])
+#define stbds_hmgetp_null(t,k,heap)  (stbds_hmgeti(t,k,heap) == -1 ? NULL : &(t)[stbds_temp(t)-1])
 
 #define stbds_shput(t, k, v, heap)                                           \
   ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) (k), sizeof (t)->key, STBDS_HM_STRING, heap), \
@@ -1665,6 +1665,11 @@ struct TestStrMap {
   int value;
 };
 
+struct TestStbdsMap {
+  stbds_struct key;
+  int value;
+};
+
 void stbds_unit_tests(Heap *heap)
 {
 #if defined(_MSC_VER) && _MSC_VER <= 1200 && defined(__cplusplus)
@@ -1678,9 +1683,9 @@ void stbds_unit_tests(Heap *heap)
   // struct { char *key;        int value; }  *strmap  = NULL;
   struct TestIntMap *intmap = NULL;
   struct TestStrMap *strmap = NULL;
-  // struct { stbds_struct key; int value; }  *map     = NULL;
-  // stbds_struct                             *map2    = NULL;
-  // stbds_struct2                            *map3    = NULL;
+  struct TestStbdsMap *map = NULL;
+  stbds_struct                             *map2    = NULL;
+  stbds_struct2                            *map3    = NULL;
   // stbds_string_arena                        sa      = { 0 };
   // int key3[2] = { 1,2 };
   ptrdiff_t temp;
@@ -1797,60 +1802,68 @@ void stbds_unit_tests(Heap *heap)
     shfree(strmap, heap);
   }
 
-  // {
-  //   struct { char *key; char value; } *hash = NULL;
-  //   char name[4] = "jen";
-  //   shput(hash, "bob"   , 'h', heap);
-  //   shput(hash, "sally" , 'e', heap);
-  //   shput(hash, "fred"  , 'l', heap);
-  //   shput(hash, "jen"   , 'x', heap);
-  //   shput(hash, "doug"  , 'o', heap);
+  {
+    struct { char *key; char value; } *hash = NULL;
+    sh_new_strdup(hash, 10, heap);
+    char name[4] = "jen";
+    shput(hash, "bob"   , 'h', heap);
+    shput(hash, "sally" , 'e', heap);
+    shput(hash, "fred"  , 'l', heap);
+    shput(hash, "jen"   , 'x', heap);
+    shput(hash, "doug"  , 'o', heap);
 
-  //   shput(hash, name    , 'l', heap);
-  //   shfree(hash, heap);
-  // }
+    shput(hash, name    , 'l', heap);
+    shfree(hash, heap);
+  }
 
-  // for (i=0; i < testsize; i += 2) {
-  //   stbds_struct s = { i,i*2,i*3,i*4 };
-  //   hmput(map, s, i*5, heap);
-  // }
+  // NOTE(chogan): Preallocate map to avoid realloc
+  map = (TestStbdsMap *)stbds_arrgrowf(map, sizeof(*map), 0, testsize, heap);
+  map = (TestStbdsMap *)STBDS_ARR_TO_HASH(map, sizeof(*map));
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    hmput(map, s, i*5, heap);
+  }
 
-  // for (i=0; i < testsize; i += 1) {
-  //   stbds_struct s = { i,i*2,i*3  ,i*4 };
-  //   stbds_struct t = { i,i*2,i*3+1,i*4 };
-  //   if (i & 1) STBDS_ASSERT(hmget(map, s, heap) == 0);
-  //   else       STBDS_ASSERT(hmget(map, s, heap) == i*5);
-  //   if (i & 1) STBDS_ASSERT(hmget_ts(map, s, temp, heap) == 0);
-  //   else       STBDS_ASSERT(hmget_ts(map, s, temp, heap) == i*5);
-  //   //STBDS_ASSERT(hmget(map, t.key) == 0);
-  // }
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct s = { i,i*2,i*3  ,i*4 };
+    // stbds_struct t = { i,i*2,i*3+1,i*4 };
+    if (i & 1) STBDS_ASSERT(hmget(map, s, heap) == 0);
+    else       STBDS_ASSERT(hmget(map, s, heap) == i*5);
+    if (i & 1) STBDS_ASSERT(hmget_ts(map, s, temp, heap) == 0);
+    else       STBDS_ASSERT(hmget_ts(map, s, temp, heap) == i*5);
+    //STBDS_ASSERT(hmget(map, t.key) == 0);
+  }
+  hmfree(map, heap);
 
-  // for (i=0; i < testsize; i += 2) {
-  //   stbds_struct s = { i,i*2,i*3,i*4 };
-  //   hmputs(map2, s, heap);
-  // }
-  // hmfree(map, heap);
+  map2 = (stbds_struct *)stbds_arrgrowf(map2, sizeof(*map2), 0, testsize, heap);
+  map2 = (stbds_struct *)STBDS_ARR_TO_HASH(map2, sizeof(*map2));
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    hmputs(map2, s, heap);
+  }
 
-  // for (i=0; i < testsize; i += 1) {
-  //   stbds_struct s = { i,i*2,i*3,i*4 };
-  //   stbds_struct t = { i,i*2,i*3+1,i*4 };
-  //   if (i & 1) STBDS_ASSERT(hmgets(map2, s.key, heap).d == 0);
-  //   else       STBDS_ASSERT(hmgets(map2, s.key, heap).d == i*4);
-  //   //STBDS_ASSERT(hmgetp(map2, t.key) == 0);
-  // }
-  // hmfree(map2, heap);
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    // stbds_struct t = { i,i*2,i*3+1,i*4 };
+    if (i & 1) STBDS_ASSERT(hmgets(map2, s.key, heap).d == 0);
+    else       STBDS_ASSERT(hmgets(map2, s.key, heap).d == i*4);
+    //STBDS_ASSERT(hmgetp(map2, t.key) == 0);
+  }
+  hmfree(map2, heap);
 
-  // for (i=0; i < testsize; i += 2) {
-  //   stbds_struct2 s = { { i,i*2 }, i*3,i*4, i*5 };
-  //   hmputs(map3, s, heap);
-  // }
-  // for (i=0; i < testsize; i += 1) {
-  //   stbds_struct2 s = { { i,i*2}, i*3, i*4, i*5 };
-  //   stbds_struct2 t = { { i,i*2}, i*3+1, i*4, i*5 };
-  //   if (i & 1) STBDS_ASSERT(hmgets(map3, s.key, heap).d == 0);
-  //   else       STBDS_ASSERT(hmgets(map3, s.key, heap).d == i*5);
-  //   //STBDS_ASSERT(hmgetp(map3, t.key) == 0);
-  // }
+  map3 = (stbds_struct2 *)stbds_arrgrowf(map3, sizeof(*map3), 0, testsize, heap);
+  map3 = (stbds_struct2 *)STBDS_ARR_TO_HASH(map3, sizeof(*map3));
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct2 s = { { i,i*2 }, i*3,i*4, i*5 };
+    hmputs(map3, s, heap);
+  }
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct2 s = { { i,i*2}, i*3, i*4, i*5 };
+    // stbds_struct2 t = { { i,i*2}, i*3+1, i*4, i*5 };
+    if (i & 1) STBDS_ASSERT(hmgets(map3, s.key, heap).d == 0);
+    else       STBDS_ASSERT(hmgets(map3, s.key, heap).d == i*5);
+    //STBDS_ASSERT(hmgetp(map3, t.key) == 0);
+  }
 #endif
 }
 #endif

--- a/test/mdm_test.cc
+++ b/test/mdm_test.cc
@@ -313,6 +313,29 @@ void TestSwapBlobsExistInBucket() {
   hermes->Finalize(true);
 }
 
+static void TestBlobInfoMap() {
+  HermesPtr hermes = hapi::InitHermes(NULL, true);
+
+  const int kIters = 4;
+  hapi::Bucket bkt("test_blob_info_map", hermes);
+
+  hapi::Blob data(64, 'x');
+
+  for (int i = 0; i < kIters; ++i) {
+    std::string name = "blob_" + std::to_string(i);
+    bkt.Put(name, data);
+  }
+
+  for (int i = 0; i < kIters; ++i) {
+    std::string name = "blob_" + std::to_string(i);
+    bkt.DeleteBlob(name);
+  }
+
+  bkt.Destroy();
+
+  hermes->Finalize(true);
+}
+
 int main(int argc, char **argv) {
   int mpi_threads_provided;
   MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_threads_provided);
@@ -339,6 +362,7 @@ int main(int argc, char **argv) {
   hermes->Finalize(true);
 
   TestSwapBlobsExistInBucket();
+  TestBlobInfoMap();
 
   MPI_Finalize();
 

--- a/test/stb_map_test.cc
+++ b/test/stb_map_test.cc
@@ -27,7 +27,7 @@
 using namespace hermes;  // NOLINT(*)
 
 int main() {
-  Arena arena = InitArenaAndAllocate(MEGABYTES(32));
+  Arena arena = InitArenaAndAllocate(MEGABYTES(64));
   TemporaryMemory temp_memory = BeginTemporaryMemory(&arena);
   Heap *heap = InitHeapInArena(&arena, true, 8);
   stbds_unit_tests(heap);


### PR DESCRIPTION
* Maintain a `flush_count` on `VBuckets` so we don't destroy one with outstanding flushes.
* Add a map to the MDM to store `Stats` and `TicketMutex` for each `Blob`. Moving the `Stats` to a map improves the lookup efficiency from `O(n)` to `O(1)`. The Blob mutexes are required for implementing asynchronous flushing.
* Enable unit tests in `stb_ds.h` for maps with non-string keys. Previously we were only using maps with string keys. Also added a couple bug fixes from upstream.