### PR TITLE
Move blob loop from VBucket::Attach to PersistTrait

### DIFF
--- a/src/api/traits.h
+++ b/src/api/traits.h
@@ -30,17 +30,17 @@ typedef BlobInfo TraitInput;
 struct Trait;
 using HermesPtr = std::shared_ptr<Hermes>;
 
-typedef
-std::function<void(HermesPtr, TraitInput &, Trait *)> TraitCallback;
+typedef std::function<void(HermesPtr, TraitInput &, Trait *)> OnLinkCallback;
+typedef std::function<void(HermesPtr, VBucketID, Trait *)> OnAttachCallback;
 
 struct Trait {
   TraitID id;
   TraitIdArray conflict_traits;
   TraitType type;
-  TraitCallback onAttachFn;
-  TraitCallback onDetachFn;
-  TraitCallback onLinkFn;
-  TraitCallback onUnlinkFn;
+  OnAttachCallback onAttachFn;
+  OnAttachCallback onDetachFn;
+  OnLinkCallback onLinkFn;
+  OnLinkCallback onUnlinkFn;
 
   Trait() {}
   Trait(TraitID id, TraitIdArray conflict_traits, TraitType type);
@@ -50,8 +50,8 @@ struct Trait {
 #define HERMES_PERSIST_TRAIT 11
 
 struct FileMappingTrait : public Trait {
-  TraitCallback flush_cb;
-  TraitCallback load_cb;
+  OnLinkCallback flush_cb;
+  OnLinkCallback load_cb;
   std::string filename;
   std::unordered_map<std::string, u64> offset_map;
   FILE *fh;
@@ -59,9 +59,9 @@ struct FileMappingTrait : public Trait {
   FileMappingTrait() {}
   FileMappingTrait(const std::string &filename,
                    std::unordered_map<std::string, u64> &offset_map, FILE *fh,
-                   TraitCallback flush_cb, TraitCallback load_cb);
-  void onAttach(HermesPtr hermes, TraitInput &blob, Trait *trait);
-  void onDetach(HermesPtr hermes, TraitInput &blob, Trait *trait);
+                   OnLinkCallback flush_cb, OnLinkCallback load_cb);
+  void onAttach(HermesPtr hermes, VBucketID id, Trait *trait);
+  void onDetach(HermesPtr hermes, VBucketID id, Trait *trait);
   void onLink(HermesPtr hermes, TraitInput &blob, Trait *trait);
   void onUnlink(HermesPtr hermes, TraitInput &blob, Trait *trait);
 };
@@ -74,8 +74,8 @@ struct PersistTrait : public Trait {
   explicit PersistTrait(FileMappingTrait mapping,
                         bool synchronous = false);
 
-  void onAttach(HermesPtr hermes, TraitInput &blob, Trait *trait);
-  void onDetach(HermesPtr hermes, TraitInput &blob, Trait *trait);
+  void onAttach(HermesPtr hermes, VBucketID id, Trait *trait);
+  void onDetach(HermesPtr hermes, VBucketID id, Trait *trait);
   void onLink(HermesPtr hermes, TraitInput &blob, Trait *trait);
   void onUnlink(HermesPtr hermes, TraitInput &blob, Trait *trait);
 };

--- a/src/api/vbucket.cc
+++ b/src/api/vbucket.cc
@@ -181,22 +181,12 @@ Status VBucket::Attach(Trait* trait, Context& ctx) {
     }
   }
   if (!selected_trait) {
-    auto blob_ids =
-        GetBlobsFromVBucketInfo(&hermes_->context_, &hermes_->rpc_, id_);
-    for (const auto& blob_id : blob_ids) {
-      Trait* t = static_cast<Trait*>(trait);
-      TraitInput input;
-      auto bucket_id =
-          GetBucketIdFromBlobId(&hermes_->context_, &hermes_->rpc_, blob_id);
-      input.bucket_name =
-          GetBucketNameById(&hermes_->context_, &hermes_->rpc_, bucket_id);
-      input.blob_name =
-          GetBlobNameFromId(&hermes_->context_, &hermes_->rpc_, blob_id);
-      if (t->onAttachFn != nullptr) {
-        t->onAttachFn(hermes_, input, trait);
-        // TODO(hari): @errorhandling Check if attach was successful
-      }
+    Trait* t = static_cast<Trait*>(trait);
+    if (t->onAttachFn != nullptr) {
+      t->onAttachFn(hermes_, id_, trait);
+      // TODO(hari): @errorhandling Check if attach was successful
     }
+
     attached_traits_.push_back(trait);
   } else {
     ret = TRAIT_EXISTS_ALREADY;
@@ -232,22 +222,12 @@ Status VBucket::Detach(Trait* trait, Context& ctx) {
     }
   }
   if (selected_trait) {
-    auto blob_ids =
-        GetBlobsFromVBucketInfo(&hermes_->context_, &hermes_->rpc_, id_);
-    for (const auto& blob_id : blob_ids) {
-      Trait* t = static_cast<Trait*>(trait);
-      TraitInput input;
-      auto bucket_id =
-          GetBucketIdFromBlobId(&hermes_->context_, &hermes_->rpc_, blob_id);
-      input.bucket_name =
-          GetBucketNameById(&hermes_->context_, &hermes_->rpc_, bucket_id);
-      input.blob_name =
-          GetBlobNameFromId(&hermes_->context_, &hermes_->rpc_, blob_id);
-      if (t->onDetachFn != nullptr) {
-        t->onDetachFn(hermes_, input, trait);
-        // TODO(hari): @errorhandling Check if detach was successful
-      }
+    Trait* t = static_cast<Trait*>(trait);
+    if (t->onDetachFn != nullptr) {
+      t->onDetachFn(hermes_, id_, trait);
+      // TODO(hari): @errorhandling Check if detach was successful
     }
+
     attached_traits_.erase(selected_trait_iter);
   } else {
     ret = TRAIT_NOT_VALID;
@@ -341,7 +321,7 @@ Status VBucket::Destroy(Context& ctx) {
     for (const auto& t : attached_traits_) {
       if (t->onDetachFn != nullptr) {
         TraitInput input = {};
-        t->onDetachFn(hermes_, input, t);
+        t->onDetachFn(hermes_, id_, t);
         // TODO(hari): @errorhandling Check if detach was successful
       }
     }

--- a/test/bucket_test.cc
+++ b/test/bucket_test.cc
@@ -32,7 +32,7 @@ int compress_blob(HermesPtr hermes, hapi::TraitInput &input,
 struct MyTrait : public hapi::Trait {
   int compress_level;
   MyTrait() : Trait(10001, hermes::TraitIdArray(), hapi::TraitType::META) {
-    onAttachFn =
+    onLinkFn =
       std::bind(&compress_blob, std::placeholders::_1, std::placeholders::_2,
                 std::placeholders::_3);
   }


### PR DESCRIPTION
Looping through each `Blob` is a choice the `onAttach` callback of each `Trait` should make rather than doing it for all `Trait`s in `VBucket::Attach`. 