### PR TITLE
Allow creating debuggable CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,13 @@ on:
     branches: [ master, chogan/**, kimmy/**, hariharan/** ]
   pull_request:
     branches: [ master ]
- 
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -48,18 +54,20 @@ jobs:
           sudo apt-get install -y automake
           sudo apt-get install -y mpich
           sudo apt-get install -y lcov
-          sudo apt-get install -y zlib1g-dev 
+          sudo apt-get install -y zlib1g-dev
           sudo apt-get install -y libsdl2-dev
-          
+
       - name: Build And Install Dependencies
         if: steps.spack-cache.outputs.cache-hit != 'true'
         run: ci/install_deps.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v2
-      
       - name: Build and Test
         run: ci/install_hermes.sh
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
 
       - name: Multi-node Test
         run: pushd ci/cluster && ./multi_node_ci_test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Build And Install Dependencies
         if: steps.spack-cache.outputs.cache-hit != 'true'
         run: ci/install_deps.sh
-          
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v2
+      
       - name: Build and Test
         run: ci/install_hermes.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && (failure() || !failure() }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && (failure() || !failure()) }}
 
       - name: Multi-node Test
         run: pushd ci/cluster && ./multi_node_ci_test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && (failure() || !failure() }}
 
       - name: Multi-node Test
         run: pushd ci/cluster && ./multi_node_ci_test.sh


### PR DESCRIPTION
This allows the ability to manually trigger debug runs of CI. After Hermes is built and tested, the action will display an ssh address where one can log into the machine running the tests and debug failures. Instructions for triggering the workflow are [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).