### PR TITLE
Fix InitFilesForBuffering when doing multiple client runs against a single daemon

### DIFF
--- a/adapter/src/hermes/adapter/posix/posix.cc
+++ b/adapter/src/hermes/adapter/posix/posix.cc
@@ -89,11 +89,9 @@ int simple_open(int ret, const std::string &path_str, int flags) {
         }
         /* FIXME(hari) check if this initialization is correct. */
         mdm->InitializeHermes();
-        hapi::Context ctx;
-        /* TODO(hari) how to pass to hermes to make a private bucket
-         * also add how to handle existing buckets of same name */
+        // TODO(hari) how to pass to hermes to make a private bucket
         stat.st_bkid =
-            std::make_shared<hapi::Bucket>(path_str, mdm->GetHermes(), ctx);
+          std::make_shared<hapi::Bucket>(path_str, mdm->GetHermes());
         mdm->Create(ret, stat);
       } else {
         // TODO(hari): @error_handling invalid fh.

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -264,10 +264,8 @@ std::shared_ptr<api::Hermes> InitHermes(Config *config, bool is_daemon,
     MetadataManager *mdm = GetMetadataManagerFromContext(&context);
     rpc.state = (void *)(context.shm_base + mdm->rpc_state_offset);
   }
-  bool create_shared_files = (comm.proc_kind == ProcessKind::kHermes &&
-                              comm.first_on_node);
-  InitFilesForBuffering(&context, create_shared_files, comm.node_id,
-                        comm.first_on_node);
+
+  InitFilesForBuffering(&context, comm);
 
   WorldBarrier(&comm);
 

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -251,9 +251,9 @@ struct SharedMemoryContext {
   /** This will only be valid on Hermes cores, and NULL on client cores. */
   BufferOrganizer *bo;
 
-  // TODO(chogan): Move these into a FileBufferingContext
+  // File buffering context
   std::vector<std::vector<std::string>> buffering_filenames;
-  FILE *open_streams[kMaxDevices][kMaxBufferPoolSlabs];
+  int open_files[kMaxDevices][kMaxBufferPoolSlabs];
   FILE *swap_file;
 };
 
@@ -284,6 +284,7 @@ size_t GetBlobSizeById(SharedMemoryContext *context, RpcContext *rpc,
 void MakeFullShmemName(char *dest, const char *base);
 
 /**
+ * TODO
  * Creates and opens all files that will be used for buffering. Stores open FILE
  * pointers in the @p context. The file buffering paradaigm uses one file per
  * slab for each Device. If `posix_fallocate` is available, and `make_space` is
@@ -297,8 +298,8 @@ void MakeFullShmemName(char *dest, const char *base);
  * @param node_id The node id, used for shared devices.
  * @param first_on_node True if this rank is sequentially the first on the node
  */
-void InitFilesForBuffering(SharedMemoryContext *context, bool make_space,
-                           u32 node_id, bool first_on_node);
+void InitFilesForBuffering(SharedMemoryContext *context,
+                           CommunicationContext &comm);
 
 /**
  * Retrieves information required for accessing the BufferPool shared memory.

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -116,7 +116,7 @@ void InitDefaultConfig(Config *config) {
   config->is_shared_device[0] = 0;
   config->is_shared_device[1] = 0;
   config->is_shared_device[2] = 0;
-  config->is_shared_device[3] = 1;
+  config->is_shared_device[3] = 0;
 
   config->bo_num_threads = 4;
   config->default_rr_split = false;

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
   Assert(config.is_shared_device[0] == 0);
   Assert(config.is_shared_device[1] == 0);
   Assert(config.is_shared_device[2] == 0);
-  Assert(config.is_shared_device[3] == 1);
+  Assert(config.is_shared_device[3] == 0);
 
   Assert(config.bo_num_threads == 4);
 

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -68,7 +68,7 @@ system_view_state_update_interval_ms = 1000;
 mount_points = {"", "./", "./", "./"};
 # For each device, indicate '1' if it is shared among nodes (e.g., burst
 # buffers), or '0' if it is per node (e.g., local NVMe).
-is_shared_device = {0, 0, 0, 1};
+is_shared_device = {0, 0, 0, 0};
 # The mount point of a PFS or object store for swap space, in the event that
 # Hermes buffers become full.
 swap_mount = "./";


### PR DESCRIPTION
Closes #266. Previously the internal buffering files were being truncated by clients, which caused workloads like checkpoint/restart to fail.

* Replaced stdio with posix.
* Now that buffering files on shared devices are implemented correctly, the default config should specify no shared devices.