### PR TITLE
Add release.yml to auto generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Adapters
+      labels:
+        - adapter-stdio
+        - adapter-posix
+        - adapter-mpiio
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
If we add certain labels to pull requests, they will show up in the release notes automatically in the corresponding category.