### PR TITLE
Verify that percentages in the config file add up to 1.0

### DIFF
--- a/adapter/test/data/hermes.conf
+++ b/adapter/test/data/hermes.conf
@@ -26,8 +26,8 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.08;
-transient_arena_percentage = 0.03;
+transfer_window_arena_percentage = 0.03;
+transient_arena_percentage = 0.04;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 32;

--- a/adapter/test/data/hermes_ares.conf
+++ b/adapter/test/data/hermes_ares.conf
@@ -26,8 +26,8 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.08;
-transient_arena_percentage = 0.03;
+transfer_window_arena_percentage = 0.03;
+transient_arena_percentage = 0.04;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/adapter/test/data/hermes_small.conf
+++ b/adapter/test/data/hermes_small.conf
@@ -26,8 +26,8 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.08;
-transient_arena_percentage = 0.03;
+transfer_window_arena_percentage = 0.03;
+transient_arena_percentage = 0.04;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -697,10 +697,11 @@ void CheckConstraints(Config *config) {
 
   // arena_percentages must add up to 1.0
   double arena_percentage_sum = 0;
+  double tolerance = 0.0000001;
   for (int i = 0; i < kArenaType_Count; ++i) {
     arena_percentage_sum += config->arena_percentages[i];
   }
-  if (arena_percentage_sum != 1.0) {
+  if (fabs(1.0 - arena_percentage_sum) > tolerance) {
     PrintExpectedAndFail("the values in arena_percentages to add up to 1.0");
   }
 }

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -689,9 +689,19 @@ Token *EndStatement(Token *tok) {
 }
 
 void CheckConstraints(Config *config) {
+  // rpc_domain must be present if rpc_protocol is "verbs"
   if (config->rpc_protocol.find("verbs") != std::string::npos &&
       config->rpc_domain.empty()) {
     PrintExpectedAndFail("a non-empty value for rpc_domain");
+  }
+
+  // arena_percentages must add up to 1.0
+  double arena_percentage_sum = 0;
+  for (int i = 0; i < kArenaType_Count; ++i) {
+    arena_percentage_sum += config->arena_percentages[i];
+  }
+  if (arena_percentage_sum != 1.0) {
+    PrintExpectedAndFail("the values in arena_percentages to add up to 1.0");
   }
 }
 

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -33,7 +33,8 @@ Config ParseConfigString(Arena *arena, const std::string &config_string) {
   hermes::EntireFile config_file =
     {(u8 *)config_string.data(), config_string.size()};
   hermes::TokenList tokens = hermes::Tokenize(scratch, config_file);
-  Config config;
+  Config config = {};
+  InitDefaultConfig(&config);
   hermes::ParseTokens(&tokens, &config);
 
   return config;


### PR DESCRIPTION
Closes #161. Closes #187.
* Verify that `arena_percentages` in the config file add up to 1.0 (with a tolerance of `1e-7`).
* Verify that each device's `desired_slab_percentages` add up to 1.0 (with a tolerance of `1e-7`).