### PR TITLE
Remove FileMappingTrait

### DIFF
--- a/adapter/src/hermes/adapter/mpiio/mpiio.cc
+++ b/adapter/src/hermes/adapter/mpiio/mpiio.cc
@@ -583,10 +583,9 @@ int HERMES_DECL(MPI_File_close)(MPI_File *fh) {
               }
             }
           }
-          auto file_mapping = hapi::FileMappingTrait(filename, offset_map,
-                                                     nullptr, NULL, NULL);
           bool flush_synchronously = true;
-          hapi::PersistTrait persist_trait(file_mapping, flush_synchronously);
+          hapi::PersistTrait persist_trait(filename, offset_map,
+                                           flush_synchronously);
           file_vbucket.Attach(&persist_trait, ctx);
           file_vbucket.Destroy(ctx);
 
@@ -1103,10 +1102,9 @@ int HERMES_DECL(MPI_File_sync)(MPI_File fh) {
             }
           }
         }
-        auto file_mapping = hapi::FileMappingTrait(filename, offset_map,
-                                                   nullptr, NULL, NULL);
         bool flush_synchronously = true;
-        hapi::PersistTrait persist_trait(file_mapping, flush_synchronously);
+        hapi::PersistTrait persist_trait(filename, offset_map,
+                                         flush_synchronously);
         file_vbucket.Attach(&persist_trait);
         file_vbucket.Destroy();
         for (const auto &vbucket : existing.first.st_vbuckets) {

--- a/adapter/src/hermes/adapter/posix/posix.cc
+++ b/adapter/src/hermes/adapter/posix/posix.cc
@@ -792,10 +792,9 @@ int HERMES_DECL(fsync)(int fd) {
               offset_map.emplace(blob_name, page_index * kPageSize);
             }
           }
-          auto file_mapping = hapi::FileMappingTrait(filename, offset_map,
-                                                     nullptr, NULL, NULL);
           bool flush_synchronously = true;
-          hapi::PersistTrait persist_trait(file_mapping, flush_synchronously);
+          hapi::PersistTrait persist_trait(filename, offset_map,
+                                           flush_synchronously);
           file_vbucket.Attach(&persist_trait, ctx);
           file_vbucket.Destroy(ctx);
           existing.first.st_blobs.clear();
@@ -849,11 +848,9 @@ int HERMES_DECL(close)(int fd) {
               offset_map.emplace(blob_name, page_index * kPageSize);
             }
           }
-          auto file_mapping =
-            hapi::FileMappingTrait(filename, offset_map, nullptr, NULL,
-                                          NULL);
           bool flush_synchronously = true;
-          hapi::PersistTrait persist_trait(file_mapping, flush_synchronously);
+          hapi::PersistTrait persist_trait(filename, offset_map,
+                                           flush_synchronously);
           file_vbucket.Attach(&persist_trait, ctx);
           file_vbucket.Destroy(ctx);
           existing.first.st_blobs.clear();

--- a/src/api/traits.h
+++ b/src/api/traits.h
@@ -59,34 +59,17 @@ struct Trait {
   Trait(TraitID id, TraitIdArray conflict_traits, TraitType type);
 };
 
-#define HERMES_FILE_TRAIT 10
 #define HERMES_PERSIST_TRAIT 11
-
-/** File mapping trait */
-struct FileMappingTrait : public Trait {
-  OnLinkCallback flush_cb;
-  OnLinkCallback load_cb;
-  std::string filename;
-  std::unordered_map<std::string, u64> offset_map;
-  FILE *fh;
-
-  FileMappingTrait() {}
-  FileMappingTrait(const std::string &filename,
-                   std::unordered_map<std::string, u64> &offset_map, FILE *fh,
-                   OnLinkCallback flush_cb, OnLinkCallback load_cb);
-  void onAttach(HermesPtr hermes, VBucketID id, Trait *trait);
-  void onDetach(HermesPtr hermes, VBucketID id, Trait *trait);
-  void onLink(HermesPtr hermes, TraitInput &blob, Trait *trait);
-  void onUnlink(HermesPtr hermes, TraitInput &blob, Trait *trait);
-};
 
 /** (File) Persistence trait */
 struct PersistTrait : public Trait {
-  FileMappingTrait file_mapping;
+  std::string filename;
+  std::unordered_map<std::string, u64> offset_map;
   bool synchronous;
 
   explicit PersistTrait(bool synchronous);
-  explicit PersistTrait(FileMappingTrait mapping,
+  explicit PersistTrait(const std::string &filename,
+                        const std::unordered_map<std::string, u64> &offset_map,
                         bool synchronous = false);
 
   void onAttach(HermesPtr hermes, VBucketID id, Trait *trait);

--- a/test/buffer_organizer_test.cc
+++ b/test/buffer_organizer_test.cc
@@ -73,9 +73,7 @@ void TestBackgroundFlush() {
   hapi::Bucket bkt(bkt_name, hermes);
   hapi::VBucket vbkt(bkt_name, hermes);
 
-  hapi::FileMappingTrait mapping;
-  mapping.filename = final_destination;
-  hapi::PersistTrait persist_trait(mapping, false);
+  hapi::PersistTrait persist_trait(final_destination, {}, false);
   vbkt.Attach(&persist_trait);
 
   std::vector<u8> data(iters);
@@ -86,7 +84,7 @@ void TestBackgroundFlush() {
     std::string blob_name = std::to_string(i);
     bkt.Put(blob_name, blob);
 
-    persist_trait.file_mapping.offset_map.emplace(blob_name, i * io_size);
+    persist_trait.offset_map.emplace(blob_name, i * io_size);
     vbkt.Link(blob_name, bkt_name);
   }
 

--- a/test/trait_test.cc
+++ b/test/trait_test.cc
@@ -119,10 +119,9 @@ TEST_CASE("CustomTrait",
       file_vbucket.Link(blob_name, args.filename);
       offset_map.emplace(blob_name, std::stol(blob_name) * info.FILE_PAGE);
     }
-    auto fm_trait = hapi::FileMappingTrait(fullpath_str, offset_map,
-                                               nullptr, NULL, NULL);
     bool flush_synchronously = true;
-    hapi::PersistTrait persist_trait(fm_trait, flush_synchronously);
+    hapi::PersistTrait persist_trait(fullpath_str, offset_map,
+                                     flush_synchronously);
     file_vbucket.Attach(&persist_trait);
     file_vbucket.Destroy();
     file_bucket.Destroy();


### PR DESCRIPTION
Closes #224. It turns out that the `FileMappingTrait` doesn't have any useful functionality by itself, and merely passed a map and a file name to the `PersistTrait`. This removes the middle man.