### PR TITLE
Remove transfer_window_arena_percentage from config file

### DIFF
--- a/adapter/test/data/hermes.conf
+++ b/adapter/test/data/hermes.conf
@@ -26,8 +26,7 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.03;
-transient_arena_percentage = 0.04;
+transient_arena_percentage = 0.07;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 32;

--- a/adapter/test/data/hermes_ares.conf
+++ b/adapter/test/data/hermes_ares.conf
@@ -26,8 +26,7 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.03;
-transient_arena_percentage = 0.04;
+transient_arena_percentage = 0.07;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/adapter/test/data/hermes_small.conf
+++ b/adapter/test/data/hermes_small.conf
@@ -26,8 +26,7 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.08;
-transfer_window_arena_percentage = 0.03;
-transient_arena_percentage = 0.04;
+transient_arena_percentage = 0.07;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -61,7 +61,6 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "latencies_us",
   "buffer_pool_arena_percentage",
   "metadata_arena_percentage",
-  "transfer_window_arena_percentage",
   "transient_arena_percentage",
   "mount_points",
   "swap_mount",
@@ -878,11 +877,6 @@ void ParseTokens(TokenList *tokens, Config *config) {
       case ConfigVariable_MetadataArenaPercentage: {
         f32 val = ParseFloat(&tok);
         config->arena_percentages[hermes::kArenaType_MetaData] = val;
-        break;
-      }
-      case ConfigVariable_TransferWindowArenaPercentage: {
-        f32 val = ParseFloat(&tok);
-        config->arena_percentages[hermes::kArenaType_TransferWindow] = val;
         break;
       }
       case ConfigVariable_TransientArenaPercentage: {

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -48,7 +48,6 @@ enum ConfigVariable {
   ConfigVariable_LatenciesUs,
   ConfigVariable_BufferPoolArenaPercentage,
   ConfigVariable_MetadataArenaPercentage,
-  ConfigVariable_TransferWindowArenaPercentage,
   ConfigVariable_TransientArenaPercentage,
   ConfigVariable_MountPoints,
   ConfigVariable_SwapMount,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -147,7 +147,6 @@ enum ArenaType {
   kArenaType_BufferPool,      /**< Buffer pool: This must always be first! */
   kArenaType_MetaData,        /**< Metadata                                */
   kArenaType_Transient,       /**< Scratch space                           */
-  kArenaType_TransferWindow,  /**< Data transfer                           */
 
   kArenaType_Count            /**< Sentinel value                          */
 };

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -81,8 +81,7 @@ void InitDefaultConfig(Config *config) {
   // rounding errors?
   config->arena_percentages[kArenaType_BufferPool] = 0.85f;
   config->arena_percentages[kArenaType_MetaData] = 0.04f;
-  config->arena_percentages[kArenaType_TransferWindow] = 0.08f;
-  config->arena_percentages[kArenaType_Transient] = 0.03f;
+  config->arena_percentages[kArenaType_Transient] = 0.11f;
 
   config->mount_points[0] = "";
   config->mount_points[1] = "./";

--- a/test/buffer_pool_test.cc
+++ b/test/buffer_pool_test.cc
@@ -41,7 +41,7 @@ static void GetSwapConfig(hermes::Config *config) {
   InitDefaultConfig(config);
   // NOTE(chogan): Make capacities small so that a Put of 1MB will go to swap
   // space. After metadata, this configuration gives us 1 4KB RAM buffer.
-  config->capacities[0] = KILOBYTES(32);
+  config->capacities[0] = KILOBYTES(26);
   config->capacities[1] = 8;
   config->capacities[2] = 8;
   config->capacities[3] = 8;
@@ -138,7 +138,7 @@ static void MakeTwoBufferRAMConfig(hermes::Config *config) {
   InitDefaultConfig(config);
   config->num_devices = 1;
   config->num_targets = 1;
-  config->capacities[0] = KILOBYTES(36);
+  config->capacities[0] = KILOBYTES(32);
   config->desired_slab_percentages[0][0] = 1;
   config->desired_slab_percentages[0][1] = 0;
   config->desired_slab_percentages[0][2] = 0;

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -185,8 +185,7 @@ void TestDefaultConfig(Arena *arena, const char *config_file) {
 
   Assert(config.arena_percentages[hermes::kArenaType_BufferPool] == 0.85f);
   Assert(config.arena_percentages[hermes::kArenaType_MetaData] == 0.04f);
-  Assert(config.arena_percentages[hermes::kArenaType_Transient] == 0.03f);
-  Assert(config.arena_percentages[hermes::kArenaType_TransferWindow] == 0.08f);
+  Assert(config.arena_percentages[hermes::kArenaType_Transient] == 0.11f);
 
   Assert(config.mount_points[0] == "");
   Assert(config.mount_points[1] == "./");

--- a/test/data/ares.conf
+++ b/test/data/ares.conf
@@ -26,8 +26,7 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.04;
-transfer_window_arena_percentage = 0.08;
-transient_arena_percentage = 0.03;
+transient_arena_percentage = 0.11;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/test/data/bucket_test.conf
+++ b/test/data/bucket_test.conf
@@ -26,8 +26,7 @@ latencies_us = {15, 250000, 500000, 1000000};
 
 buffer_pool_arena_percentage = 0.85;
 metadata_arena_percentage = 0.04;
-transfer_window_arena_percentage = 0.08;
-transient_arena_percentage = 0.03;
+transient_arena_percentage = 0.11;
 
 max_buckets_per_node = 16;
 max_vbuckets_per_node = 8;

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -50,10 +50,8 @@ latencies_us = {15, 250000, 500000, 1000000};
 buffer_pool_arena_percentage = 0.85;
 # The percentage of Hermes memory to reserve for metadata.
 metadata_arena_percentage = 0.04;
-# The percentage of Hermes memory to reserve for data transfers.
-transfer_window_arena_percentage = 0.08;
 # The percentage of Hermes memory to reserve for short term storage.
-transient_arena_percentage = 0.03;
+transient_arena_percentage = 0.11;
 
 # The maxiumum number of buckets that can be created.
 max_buckets_per_node = 16;


### PR DESCRIPTION
Closes #154. The transfer window arena wasn't being used for anything so it was just wasting memory. Removing this option also makes the config file simpler.