### PR TITLE
Support relative paths and symlinks in adapters

### DIFF
--- a/adapter/include/hermes/adapter/mpiio.h
+++ b/adapter/include/hermes/adapter/mpiio.h
@@ -37,6 +37,7 @@
 #include <bucket.h>
 #include <vbucket.h>
 
+#include <hermes/adapter/utils.h>
 #include <hermes/adapter/constants.h>
 #include <hermes/adapter/singleton.h>
 #include <hermes/adapter/interceptor.h>

--- a/adapter/include/hermes/adapter/utils.h
+++ b/adapter/include/hermes/adapter/utils.h
@@ -1,0 +1,23 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <experimental/filesystem>
+
+namespace hermes::adapter {
+
+namespace fs = std::experimental::filesystem;
+
+fs::path WeaklyCanonical(const fs::path& p);
+fs::path WeaklyCanonical(const fs::path& p, std::error_code& ec);
+
+}  // namespace hermes::adapter
+

--- a/adapter/src/hermes/adapter/constants.h
+++ b/adapter/src/hermes/adapter/constants.h
@@ -115,8 +115,6 @@ const size_t kPageSize = []() {
     }
   }
 
-  LOG(INFO) << "Adapter page size: " << result << "\n";
-
   return result;
 }();
 

--- a/adapter/src/hermes/adapter/interceptor.cc
+++ b/adapter/src/hermes/adapter/interceptor.cc
@@ -53,6 +53,10 @@ void PopulateBufferingPath() {
   INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(
       config.buffer_pool_shmem_name);
   INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(kHermesExtension);
+
+  // NOTE(chogan): Logging before setting up hermes_paths_exclusion results in
+  // deadlocks in GLOG
+  LOG(INFO) << "Adapter page size: " << kPageSize << "\n";
 }
 
 bool IsTracked(const std::string& path) {

--- a/adapter/src/hermes/adapter/interceptor.cc
+++ b/adapter/src/hermes/adapter/interceptor.cc
@@ -18,6 +18,9 @@
 #include <unistd.h>
 
 #include <regex>
+#include <experimental/filesystem>
+
+namespace fs = std::experimental::filesystem;
 
 namespace hermes::adapter {
 /**
@@ -27,60 +30,64 @@ bool exit = false;
 
 void PopulateBufferingPath() {
   char* hermes_config = getenv(kHermesConf);
-  if (IsRelativePath(hermes_config))
-    LOG(FATAL) << "Hermes Config file: " << hermes_config
-               << "\nis relative. It is not supported yet";
-  if (IsSymLink(hermes_config))
-    LOG(FATAL) << "Hermes Config file: " << hermes_config
-               << "\nis symbolic link. It is not supported yet";
 
   hermes::Config config = {};
   const size_t kConfigMemorySize = KILOBYTES(16);
   hermes::u8 config_memory[kConfigMemorySize];
-  if (hermes_config && strlen(hermes_config) > 0) {
-    INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(hermes_config);
+  if (fs::exists(hermes_config)) {
+    std::string hermes_conf_abs_path = fs::absolute(hermes_config).string();
+    INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(hermes_conf_abs_path);
     hermes::Arena config_arena = {};
     hermes::InitArena(&config_arena, kConfigMemorySize, config_memory);
-    hermes::ParseConfig(&config_arena, hermes_config, &config);
+    hermes::ParseConfig(&config_arena, hermes_conf_abs_path.c_str(), &config);
   } else {
     InitDefaultConfig(&config);
   }
 
   for (const auto& item : config.mount_points) {
     if (!item.empty()) {
-      INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(item);
+      std::string abs_path = fs::absolute(item).string();
+      INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(abs_path);
     }
   }
   INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(
       config.buffer_pool_shmem_name);
   INTERCEPTOR_LIST->hermes_paths_exclusion.push_back(kHermesExtension);
 }
+
 bool IsTracked(const std::string& path) {
   if (hermes::adapter::exit) {
     return false;
   }
   atexit(OnExit);
+
+  std::string abs_path = fs::absolute(path).string();
+
   for (const auto& pth : kPathExclusions) {
-    if (path.find(pth) == 0) {
+    if (abs_path.find(pth) == 0) {
       return false;
     }
   }
+
   for (const auto& pth : INTERCEPTOR_LIST->hermes_flush_exclusion) {
-    if (path.find(pth) != std::string::npos) {
+    if (abs_path.find(pth) != std::string::npos) {
       return false;
     }
   }
+
   if (INTERCEPTOR_LIST->hermes_paths_exclusion.empty()) {
     PopulateBufferingPath();
   }
+
   for (const auto& pth : INTERCEPTOR_LIST->hermes_paths_exclusion) {
-    if (path.find(pth) != std::string::npos ||
-        pth.find(path) != std::string::npos) {
+    if (abs_path.find(pth) != std::string::npos ||
+        pth.find(abs_path) != std::string::npos) {
       return false;
     }
   }
+
   for (const auto& pth : kPathInclusions) {
-    if (path.find(pth) == 0) {
+    if (abs_path.find(pth) == 0) {
       return true;
     }
   }
@@ -113,30 +120,6 @@ bool IsTracked(int fd) {
   if (hermes::adapter::exit) return false;
   atexit(OnExit);
   return IsTracked(GetFilenameFromFD(fd));
-}
-
-bool IsRelativePath(const std::string& path) {
-  std::regex e1("^/.*");
-  std::regex e2("(.*)(\\./)(.*)");
-  // Capture path not starting with "/" or containing "./"
-  return !std::regex_match(path, e1)
-         && std::regex_match(path, e2);
-}
-
-bool IsSymLink(const std::string& path) {
-  std::string cmd = "readlink -f " + path;
-  std::array<char, PATH_MAX> buffer;
-  std::string result;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
-                                                pclose);
-  if (!pipe) {
-    LOG(FATAL) << "popen() failed!";
-  }
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    result += buffer.data();
-  }
-
-  return result.compare(0, result.size()-1, path);
 }
 
 void OnExit(void) { hermes::adapter::exit = true; }

--- a/adapter/src/hermes/adapter/interceptor.h
+++ b/adapter/src/hermes/adapter/interceptor.h
@@ -212,16 +212,6 @@ namespace hermes::adapter {
 void PopulateBufferingPath();
 
 /**
- * Check if path is symbolic link.
- */
-bool IsSymLink(const std::string& path);
-
-/**
- * Check if path is relative path.
- */
-bool IsRelativePath(const std::string& path);
-
-/**
  * Check if path should be tracked. In this method, the path is compared against
  * multiple inclusion and exclusion lists.
  *

--- a/adapter/src/hermes/adapter/mpiio/mpiio.cc
+++ b/adapter/src/hermes/adapter/mpiio/mpiio.cc
@@ -52,8 +52,8 @@ inline bool IsTracked(MPI_File *fh) {
   return existing.second;
 }
 
-int simple_open(MPI_Comm &comm, const char *user_path, int &amode, MPI_Info &info,
-                MPI_File *fh) {
+int simple_open(MPI_Comm &comm, const char *user_path, int &amode,
+                MPI_Info &info, MPI_File *fh) {
   std::string path_str = fs::absolute(user_path).string();
 
   LOG(INFO) << "Open file for filename " << path_str << " in mode " << amode
@@ -73,7 +73,8 @@ int simple_open(MPI_Comm &comm, const char *user_path, int &amode, MPI_Info &inf
     stat.info = info;
     stat.comm = comm;
     hapi::Context ctx;
-    stat.st_bkid = std::make_shared<hapi::Bucket>(path_str, mdm->GetHermes(), ctx);
+    stat.st_bkid = std::make_shared<hapi::Bucket>(path_str, mdm->GetHermes(),
+                                                  ctx);
     mdm->Create(fh, stat);
   } else {
     LOG(INFO) << "File opened before by adapter" << std::endl;

--- a/adapter/src/hermes/adapter/mpiio/mpiio.cc
+++ b/adapter/src/hermes/adapter/mpiio/mpiio.cc
@@ -52,9 +52,11 @@ inline bool IsTracked(MPI_File *fh) {
   return existing.second;
 }
 
-int simple_open(MPI_Comm &comm, const char *path, int &amode, MPI_Info &info,
+int simple_open(MPI_Comm &comm, const char *user_path, int &amode, MPI_Info &info,
                 MPI_File *fh) {
-  LOG(INFO) << "Open file for filename " << path << " in mode " << amode
+  std::string path_str = fs::absolute(user_path).string();
+
+  LOG(INFO) << "Open file for filename " << path_str << " in mode " << amode
             << std::endl;
   int ret = MPI_SUCCESS;
   auto mdm = hermes::adapter::Singleton<MetadataManager>::GetInstance();
@@ -71,7 +73,7 @@ int simple_open(MPI_Comm &comm, const char *path, int &amode, MPI_Info &info,
     stat.info = info;
     stat.comm = comm;
     hapi::Context ctx;
-    stat.st_bkid = std::make_shared<hapi::Bucket>(path, mdm->GetHermes(), ctx);
+    stat.st_bkid = std::make_shared<hapi::Bucket>(path_str, mdm->GetHermes(), ctx);
     mdm->Create(fh, stat);
   } else {
     LOG(INFO) << "File opened before by adapter" << std::endl;
@@ -513,13 +515,6 @@ int HERMES_DECL(MPI_File_open)(MPI_Comm comm, const char *filename, int amode,
                                MPI_Info info, MPI_File *fh) {
   int status;
   if (hermes::adapter::IsTracked(filename)) {
-    if (hermes::adapter::IsRelativePath(filename))
-      LOG(FATAL) << "File: " << filename
-                 << "\nis relative. It is not supported yet";
-    if (hermes::adapter::IsSymLink(filename))
-      LOG(FATAL) << "File: " << filename
-                 << "\nis symbolic link. It is not supported yet";
-
     LOG(INFO) << "Intercept MPI_File_open for filename: " << filename
               << " and mode: " << amode << " is tracked." << std::endl;
     status = open_internal(comm, filename, amode, info, fh);

--- a/adapter/src/hermes/adapter/mpiio/mpiio.cc
+++ b/adapter/src/hermes/adapter/mpiio/mpiio.cc
@@ -16,6 +16,7 @@
 #include <hermes/adapter/mpiio.h>
 #include <thread_pool.h>
 
+#include <hermes/adapter/utils.cc>
 #include <hermes/adapter/mpiio/mapper/balanced_mapper.cc>
 /**
  * Namespace declarations
@@ -29,6 +30,8 @@ using hermes::adapter::mpiio::MetadataManager;
 
 namespace hapi = hermes::api;
 namespace fs = std::experimental::filesystem;
+using hermes::adapter::WeaklyCanonical;
+
 /**
  * Internal Functions.
  */
@@ -54,7 +57,7 @@ inline bool IsTracked(MPI_File *fh) {
 
 int simple_open(MPI_Comm &comm, const char *user_path, int &amode,
                 MPI_Info &info, MPI_File *fh) {
-  std::string path_str = fs::absolute(user_path).string();
+  std::string path_str = WeaklyCanonical(user_path).string();
 
   LOG(INFO) << "Open file for filename " << path_str << " in mode " << amode
             << std::endl;

--- a/adapter/src/hermes/adapter/posix/posix.cc
+++ b/adapter/src/hermes/adapter/posix/posix.cc
@@ -23,6 +23,8 @@ using hermes::adapter::posix::AdapterStat;
 using hermes::adapter::posix::FileStruct;
 using hermes::adapter::posix::MapperFactory;
 using hermes::adapter::posix::MetadataManager;
+using hermes::adapter::WeaklyCanonical;
+using hermes::adapter::ReadGap;
 
 namespace hapi = hermes::api;
 namespace fs = std::experimental::filesystem;
@@ -69,7 +71,7 @@ size_t perform_file_read(const char *filename, off_t file_offset, void *ptr,
   return read_size;
 }
 int simple_open(int ret, const std::string &user_path, int flags) {
-  std::string path_str = fs::absolute(user_path).string();
+  std::string path_str = WeaklyCanonical(user_path).string();
 
   LOG(INFO) << "Open file for filename " << path_str << " with flags " << flags
             << std::endl;

--- a/adapter/src/hermes/adapter/posix/posix.cc
+++ b/adapter/src/hermes/adapter/posix/posix.cc
@@ -68,7 +68,9 @@ size_t perform_file_read(const char *filename, off_t file_offset, void *ptr,
   INTERCEPTOR_LIST->hermes_flush_exclusion.erase(filename);
   return read_size;
 }
-int simple_open(int ret, const std::string &path_str, int flags) {
+int simple_open(int ret, const std::string &user_path, int flags) {
+  std::string path_str = fs::absolute(user_path).string();
+
   LOG(INFO) << "Open file for filename " << path_str << " with flags " << flags
             << std::endl;
   auto mdm = hermes::adapter::Singleton<MetadataManager>::GetInstance();
@@ -411,13 +413,6 @@ int HERMES_DECL(open)(const char *path, int flags, ...) {
     va_end(arg);
   }
   if (hermes::adapter::IsTracked(path)) {
-    if (hermes::adapter::IsRelativePath(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis relative. It is not supported yet";
-    if (hermes::adapter::IsSymLink(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis symbolic link. It is not supported yet";
-
     LOG(INFO) << "Intercept open for filename: " << path
               << " and mode: " << flags << " is tracked." << std::endl;
     ret = open_internal(path, flags, mode);
@@ -442,13 +437,6 @@ int HERMES_DECL(open64)(const char *path, int flags, ...) {
     va_end(arg);
   }
   if (hermes::adapter::IsTracked(path)) {
-    if (hermes::adapter::IsRelativePath(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis relative. It is not supported yet";
-    if (hermes::adapter::IsSymLink(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis symbolic link. It is not supported yet";
-
     LOG(INFO) << "Intercept open for filename: " << path
               << " and mode: " << flags << " is tracked." << std::endl;
     ret = open_internal(path, flags, mode);
@@ -466,13 +454,6 @@ int HERMES_DECL(open64)(const char *path, int flags, ...) {
 int HERMES_DECL(__open_2)(const char *path, int oflag) {
   int ret;
   if (hermes::adapter::IsTracked(path)) {
-    if (hermes::adapter::IsRelativePath(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis relative. It is not supported yet";
-    if (hermes::adapter::IsSymLink(path))
-      LOG(FATAL) << "File: " << path
-                 << "\nis symbolic link. It is not supported yet";
-
     LOG(INFO) << "Intercept __open_2 for filename: " << path
               << " and mode: " << oflag << " is tracked." << std::endl;
     ret = open_internal(path, oflag, 0);

--- a/adapter/src/hermes/adapter/stdio/stdio.cc
+++ b/adapter/src/hermes/adapter/stdio/stdio.cc
@@ -25,6 +25,8 @@ using hermes::adapter::stdio::FileStruct;
 using hermes::adapter::stdio::MapperFactory;
 using hermes::adapter::stdio::MetadataManager;
 using hermes::adapter::stdio::global_flushing_mode;
+using hermes::adapter::WeaklyCanonical;
+using hermes::adapter::ReadGap;
 
 using hermes::u8;
 using hermes::u64;
@@ -101,9 +103,9 @@ int HERMES_DECL(MPI_Init)(int *argc, char ***argv) {
   MAP_OR_FAIL(MPI_Init);
   int status = real_MPI_Init_(argc, argv);
   if (status == 0) {
-    LOG(INFO) << "MPI Init intercepted." << std::endl;
     auto mdm = hermes::adapter::Singleton<MetadataManager>::GetInstance();
     mdm->InitializeHermes(true);
+    LOG(INFO) << "MPI Init intercepted." << std::endl;
   }
   return status;
 }
@@ -121,7 +123,7 @@ int HERMES_DECL(MPI_Finalize)(void) {
  * STDIO
  */
 FILE *simple_open(FILE *ret, const std::string &user_path, const char *mode) {
-  std::string path_str = fs::absolute(user_path).string();
+  std::string path_str = WeaklyCanonical(user_path).string();
 
   LOG(INFO) << "Open file for filename " << path_str << " in mode " << mode
             << std::endl;
@@ -197,7 +199,7 @@ FILE *reopen_internal(const std::string &user_path, const char *mode,
   if (!ret) {
     return ret;
   } else {
-    std::string path_str = fs::absolute(user_path).string();
+    std::string path_str = WeaklyCanonical(user_path).string();
     LOG(INFO) << "Reopen file for filename " << path_str << " in mode " << mode
               << std::endl;
     auto existing = mdm->Find(ret);

--- a/adapter/src/hermes/adapter/utils.cc
+++ b/adapter/src/hermes/adapter/utils.cc
@@ -1,7 +1,203 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 #include <sys/file.h>
 
 using hermes::u8;
 namespace fs = std::experimental::filesystem;
+
+namespace {
+const fs::path::value_type dot = '.';
+inline bool is_dot(fs::path::value_type c) { return c == dot; }
+
+inline bool is_dot(const fs::path& path) {
+  const auto& filename = path.native();
+  return filename.size() == 1 && is_dot(filename[0]);
+}
+
+inline bool is_dotdot(const fs::path& path) {
+  const auto& filename = path.native();
+  return filename.size() == 2 && is_dot(filename[0]) && is_dot(filename[1]);
+}
+}  // namespace
+
+namespace hermes {
+namespace adapter {
+
+// NOTE(chogan): Back port of the C++17 standard fileystem implementation from
+// gcc 9.1 to support gcc 7
+fs::path LexicallyNormal(fs::path &path) {
+  /*
+  C++17 [fs.path.generic] p6
+  - If the path is empty, stop.
+  - Replace each slash character in the root-name with a preferred-separator.
+  - Replace each directory-separator with a preferred-separator.
+  - Remove each dot filename and any immediately following directory-separator.
+  - As long as any appear, remove a non-dot-dot filename immediately followed
+    by a directory-separator and a dot-dot filename, along with any immediately
+    following directory-separator.
+  - If there is a root-directory, remove all dot-dot filenames and any
+    directory-separators immediately following them.
+  - If the last filename is dot-dot, remove any trailing directory-separator.
+  - If the path is empty, add a dot.
+  */
+  fs::path ret;
+  // If the path is empty, stop.
+  if (path.empty()) {
+    return ret;
+  }
+  for (auto& p : path) {
+    if (is_dotdot(p)) {
+      if (ret.has_filename()) {
+        // remove a non-dot-dot filename immediately followed by /..
+        if (!is_dotdot(ret.filename())) {
+          ret.remove_filename();
+        } else {
+          ret /= p;
+        }
+      } else if (!ret.has_relative_path()) {
+        // remove a dot-dot filename immediately after root-directory
+        if (!ret.has_root_directory()) {
+          ret /= p;
+        }
+      } else {
+        // Got a path with a relative path (i.e. at least one non-root
+        // element) and no filename at the end (i.e. empty last element),
+        // so must have a trailing slash. See what is before it.
+        auto elem = (ret.end()--)--;
+        if (elem->has_filename() && !is_dotdot(*elem)) {
+          // Remove the filename before the trailing slash
+          // (equiv. to ret = ret.parent_path().remove_filename())
+          ret = ret.parent_path().remove_filename();
+
+          // if (elem == ret.begin()) {
+          //   ret.clear();
+          // } else {
+          //   ret._M_pathname.erase(elem->_M_pos);
+          //   // Remove empty filename at the end:
+          //   ret._M_cmpts.pop_back();
+          //   // If we still have a trailing non-root dir separator
+          //   // then leave an empty filename at the end:
+          //   if (std::prev(elem)->_M_type() == _Type::_Filename) {
+          //     elem->clear();
+          //   }
+          //   else {  // remove the component completely:
+          //     ret._M_cmpts.pop_back();
+          //   }
+          // }
+        } else {
+          // Append the ".." to something ending in "../" which happens
+          // when normalising paths like ".././.." and "../a/../.."
+          ret /= p;
+        }
+      }
+    } else if (is_dot(p))  {
+      ret /= fs::path();
+    } else {
+      ret /= p;
+    }
+  }
+
+  if (std::distance(ret.begin(), ret.end()) >= 2) {
+    auto back = std::prev(ret.end());
+    // If the last filename is dot-dot, ...
+    if (back->empty() && is_dotdot(*std::prev(back))) {
+      // ... remove any trailing directory-separator.
+      ret = ret.parent_path();
+    }
+  } else if (ret.empty()) {
+    // If the path is empty, add a dot.
+    ret = ".";
+  }
+
+  return ret;
+}
+
+// NOTE(chogan): Backported from GCC 9
+fs::path WeaklyCanonical(const fs::path& p) {
+  fs::path result;
+  if (fs::exists(fs::status(p))) {
+    return fs::canonical(p);
+  }
+
+  fs::path tmp;
+  auto iter = p.begin(), end = p.end();
+  // find leading elements of p that exist:
+  while (iter != end) {
+    tmp = result / *iter;
+    if (fs::exists(fs::status(tmp))) {
+      fs::swap(result, tmp);
+    } else {
+      break;
+    }
+    ++iter;
+  }
+  // canonicalize:
+  if (!result.empty()) {
+    result = fs::canonical(result);
+  }
+  // append the non-existing elements:
+  while (iter != end) {
+    result /= *iter++;
+  }
+  // normalize:
+  return LexicallyNormal(result);
+}
+
+// NOTE(chogan): Backported from GCC 9
+fs::path WeaklyCanonical(const fs::path& p, std::error_code& ec) {
+  fs::path result;
+  fs::file_status st = fs::status(p, ec);
+  if (exists(st)) {
+    return fs::canonical(p, ec);
+  } else if (fs::status_known(st)) {
+    ec.clear();
+  } else {
+    return result;
+  }
+
+  fs::path tmp;
+  auto iter = p.begin(), end = p.end();
+  // find leading elements of p that exist:
+  while (iter != end) {
+    tmp = result / *iter;
+    st = fs::status(tmp, ec);
+    if (exists(st)) {
+      swap(result, tmp);
+    } else {
+      if (fs::status_known(st)) {
+        ec.clear();
+      }
+      break;
+    }
+    ++iter;
+  }
+  // canonicalize:
+  if (!ec && !result.empty()) {
+    result = canonical(result, ec);
+  }
+  if (ec) {
+    result.clear();
+  } else {
+    // append the non-existing elements:
+    while (iter != end) {
+      result /= *iter++;
+    }
+    // normalize:
+    result = LexicallyNormal(result);
+  }
+
+  return result;
+}
 
 void ReadGap(const std::string &filename, size_t seek_offset, u8 *read_ptr,
              size_t read_size, size_t file_bounds) {
@@ -33,3 +229,6 @@ void ReadGap(const std::string &filename, size_t seek_offset, u8 *read_ptr,
     INTERCEPTOR_LIST->hermes_flush_exclusion.erase(filename);
   }
 }
+
+}  // namespace adapter
+}  // namespace hermes

--- a/adapter/test/stdio/CMakeLists.txt
+++ b/adapter/test/stdio/CMakeLists.txt
@@ -91,8 +91,14 @@ set_target_properties(hermes_stdio_adapter_mpi_test PROPERTIES COMPILE_FLAGS "-D
 
 mpi_daemon(hermes_stdio_adapter_mpi_test 2 "~[request_size=range-large]" "" 1)
 mpi_daemon(hermes_stdio_adapter_mpi_test 2 "[request_size=range-large]" "large" 1)
+
+add_executable(adapter_utils_test adapter_utils_test.cc ${ADAPTER_COMMON})
+target_link_libraries(adapter_utils_test Catch2::Catch2 hermes_stdio -lstdc++fs -ldl -lc MPI::MPI_CXX)
+add_dependencies(adapter_utils_test hermes_stdio)
+gcc(adapter_utils_test "")
+
 if(HERMES_INSTALL_TESTS)
-    set(STDIO_TESTS stdio_adapter_mapper_test stdio_adapter_test hermes_stdio_adapter_test stdio_adapter_mpi_test hermes_stdio_adapter_mpi_test)
+    set(STDIO_TESTS stdio_adapter_mapper_test stdio_adapter_test hermes_stdio_adapter_test stdio_adapter_mpi_test hermes_stdio_adapter_mpi_test adapter_utils_test)
     foreach(program ${STDIO_TESTS})
         install(
                 TARGETS

--- a/adapter/test/stdio/adapter_utils_test.cc
+++ b/adapter/test/stdio/adapter_utils_test.cc
@@ -1,0 +1,104 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <catch_config.h>
+
+#include "hermes/adapter/utils.h"
+
+namespace fs = std::experimental::filesystem;
+
+int init(int* argc, char*** argv) {
+  (void)argc;
+  (void)argv;
+  return 0;
+}
+
+int finalize() {
+  return 0;
+}
+
+cl::Parser define_options() {
+  return cl::Parser();
+}
+
+// NOTE(chogan) GCC's test for weakly_canonical
+TEST_CASE("WeaklyCanonical") {
+  namespace had = hermes::adapter;
+
+  const std::error_code bad_ec = make_error_code(std::errc::invalid_argument);
+  std::error_code ec;
+
+  auto dir = fs::path("tmp");
+  if (fs::exists(dir)) {
+    fs::remove_all(dir, ec);
+  }
+
+  fs::create_directory(dir);
+  const auto dirc = fs::canonical(dir);
+  fs::path foo = dir/"foo", bar = dir/"bar";
+  fs::create_directory(foo);
+  fs::create_directory(bar);
+  fs::create_directory(bar/"baz");
+  fs::path p;
+
+  fs::create_symlink("../bar", foo/"bar");
+
+  p = had::WeaklyCanonical(dir/"foo//./bar///../biz/.");
+  REQUIRE(p == dirc/"biz");
+  p = had::WeaklyCanonical(dir/"foo/.//bar/././baz/.");
+  REQUIRE(p == dirc/"bar/baz");
+  p = had::WeaklyCanonical(fs::current_path()/dir/"bar//../foo/bar/baz");
+  REQUIRE(p == dirc/"bar/baz");
+
+  ec = bad_ec;
+  p = had::WeaklyCanonical(dir/"foo//./bar///../biz/.", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"biz");
+  ec = bad_ec;
+  p = had::WeaklyCanonical(dir/"foo/.//bar/././baz/.", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"bar/baz");
+  ec = bad_ec;
+  p = had::WeaklyCanonical(fs::current_path()/dir/"bar//../foo/bar/baz", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"bar/baz");
+
+  ec = bad_ec;
+  p = had::WeaklyCanonical(dir/"bar/", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"bar");
+
+  // As above, but using "foo/.." instead of "foo",
+  // because there is no "foo/bar" symlink
+
+  p = had::WeaklyCanonical(dir/"./bar///../biz/.");
+  REQUIRE(p == dirc/"biz");
+  p = had::WeaklyCanonical(dir/"foo/.././/bar/././baz/.");
+  REQUIRE(p == dirc/"bar/baz");
+  p = had::WeaklyCanonical(fs::current_path()/dir/"bar//../foo/../bar/baz");
+  REQUIRE(p == dirc/"bar/baz");
+
+  ec = bad_ec;
+  p = had::WeaklyCanonical(dir/"foo/..//./bar///../biz/.", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"biz");
+  ec = bad_ec;
+  p = had::WeaklyCanonical(dir/"foo/.././/bar/././baz/.", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"bar/baz");
+  ec = bad_ec;
+  p = had::WeaklyCanonical(fs::current_path()/dir/"bar//../foo/../bar/baz", ec);
+  REQUIRE(!ec);
+  REQUIRE(p == dirc/"bar/baz");
+
+  fs::remove_all(dir, ec);
+}

--- a/adapter/test/stdio/stdio_adapter_mpi_test.cpp
+++ b/adapter/test/stdio/stdio_adapter_mpi_test.cpp
@@ -21,6 +21,7 @@
 #if HERMES_INTERCEPT == 1
 #include <hermes/adapter/stdio.h>
 #endif
+
 namespace fs = std::experimental::filesystem;
 
 namespace hermes::adapter::stdio::test {


### PR DESCRIPTION
Fixes #179, fixes #180.

* Expand all paths intercepted by adapters into their "canonical" forms, which means resolve all symlinks, remove any extra slashes, and resolve all instances of `.` and `..`.
* The C++17 `filesystem` library provides the function `filesystem::weakly_canonical`, which expands paths (both existent and non-existent) as described above. However, it is only available in gcc >= 9. In order to continue supporting gcc 7 (the version installed on the Ares cluster), I've ported `weakly_canonical` from [libstdc++](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/src/c%2B%2B17/fs_ops.cc#L1644) into hermes.