### PR TITLE
Allow workflow runs on all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ name: GitHub Actions
 # events but only for the master branch
 on:
   push:
-    branches: [ master, chogan/**, kimmy/**, hariharan/** ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:


### PR DESCRIPTION
This helps out contributors, and I don't see any downside.