### PR TITLE
[CI] Separate install directory from dependency directory

### DIFF
--- a/ci/install_hermes.sh
+++ b/ci/install_hermes.sh
@@ -4,17 +4,20 @@ set -x
 set -e
 set -o pipefail
 
+mkdir -p "${HOME}/install"
+
 mkdir build
 pushd build
 
-INSTALL_PREFIX="${HOME}/${LOCAL}"
+DEPENDENCY_PREFIX="${HOME}/${LOCAL}"
+INSTALL_PREFIX="${HOME}/install"
 
 export CXXFLAGS="${CXXFLAGS} -std=c++17 -Werror -Wall -Wextra"
 cmake                                                      \
     -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}               \
-    -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}                  \
-    -DCMAKE_BUILD_RPATH=${INSTALL_PREFIX}/lib              \
-    -DCMAKE_INSTALL_RPATH=${INSTALL_PREFIX}/lib            \
+    -DCMAKE_PREFIX_PATH=${DEPENDENCY_PREFIX}               \
+    -DCMAKE_BUILD_RPATH=${DEPENDENCY_PREFIX}/lib           \
+    -DCMAKE_INSTALL_RPATH=${DEPENDENCY_PREFIX}/lib         \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE}                       \
     -DCMAKE_CXX_COMPILER=`which mpicxx`                    \
     -DCMAKE_C_COMPILER=`which mpicc`                       \
@@ -24,7 +27,7 @@ cmake                                                      \
     -DHERMES_BUILD_BENCHMARKS=ON                           \
     -DHERMES_COMMUNICATION_MPI=ON                          \
     -DHERMES_BUILD_BUFFER_POOL_VISUALIZER=ON               \
-    -DORTOOLS_DIR=${INSTALL_PREFIX}                        \
+    -DORTOOLS_DIR=${DEPENDENCY_PREFIX}                     \
     -DHERMES_USE_ADDRESS_SANITIZER=ON                      \
     -DHERMES_USE_THREAD_SANITIZER=OFF                      \
     -DHERMES_RPC_THALLIUM=ON                               \


### PR DESCRIPTION
The `~/local` directory in CI is cached to speed up the build, so when we `make install` to that directory the library itself gets cached and future CI runs pick it up when running tests resulting in symbol conflicts. This avoids the problem by installing the library to `~/install`. Fixes #342. Coverage had dropped because it was testing an installed library instead of the one just built.