### PR TITLE
Allow reading host names from a file

### DIFF
--- a/ci/cluster/cluster_utils.sh
+++ b/ci/cluster/cluster_utils.sh
@@ -30,15 +30,17 @@ function hermes_cluster_up() {
         # Change the default hermes.conf file to accommodate multiple nodes and
         # store it at ${cluster_conf} on each node.
         # 1. Replace "./" mount_points and swap_mount with ${docker_home}
-        # 2. Change rpc_server_base_name to 'node'
+        # 2. Use rpc_server_host_file
         # 3. Change num_rpc_threads to 4
-        # 4. Change rpc_host_number_range to {1-2}
         docker exec --user ${docker_user} -w ${hermes_build_dir} ${h} \
                bash -c "sed -e 's|\"\./\"|\""${docker_home}"\"|g' \
-                        -e 's|\"localhost\"|\"node\"|' \
+                        -e 's|rpc_server_host_file = \"\"|rpc_server_host_file = \"hermes_hosts\"|' \
                         -e 's|rpc_num_threads = 1|rpc_num_threads = 4|' \
-                        -e 's|{}|{1-2}|' ${conf_path} > ${cluster_conf}"
+                        ${conf_path} > ${cluster_conf}"
 
+        # Create the hosts file
+        docker exec --user ${docker_user} -w ${hermes_build_dir} ${h} \
+               bash -c "echo -e \"${host1}\n${host2}\n\" > hermes_hosts"
         # Copy ssh keys to ${docker_home}/.ssh
         docker exec ${h} bash -c "cp ${HOME}/.ssh/id_rsa ${docker_home}/.ssh/id_rsa"
         docker exec ${h} bash -c "cp ${HOME}/.ssh/id_rsa.pub ${docker_home}/.ssh/id_rsa.pub"

--- a/ci/cluster/multi_node_ci_test.sh
+++ b/ci/cluster/multi_node_ci_test.sh
@@ -2,6 +2,11 @@
 
 set -x -e
 
+if [[ "${CI}" != "true" ]]; then
+    echo "This script is only meant to be run within Github actions"
+    exit 1
+fi
+
 . cluster_utils.sh
 
 # Create ssh keys for the cluster to use

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -235,16 +235,9 @@ SharedMemoryContext InitHermesCore(Config *config, CommunicationContext *comm,
                                              host_names.size());
 
     for (size_t i = 0; i < host_names.size(); ++i) {
-      size_t host_name_size = host_names[i].size();
-      ShmemString s = {};
-      char *host_name = PushArray<char>(&arenas[kArenaType_MetaData],
-                                        host_name_size);
-      memcpy(host_name, host_names[i].data(), host_name_size);
-      s.size = (u32)host_name_size;
-      // TODO(chogan): Offset is from the beginning of this ShmemString
-      // instance. Use API to enforce this.
-      s.offset = (u8 *)host_name - (u8 *)&rpc->host_names[i];
-      rpc->host_names[i] = s;
+      char *host_name_mem = PushArray<char>(&arenas[kArenaType_MetaData],
+                                            host_names[i].size());
+      MakeShmemString(&rpc->host_names[i], (u8 *)host_name_mem, host_names[i]);
     }
 
     mdm->host_names_offset = (u8 *)rpc->host_names - (u8 *)shmem_base;

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -68,6 +68,7 @@ static const char *kConfigVariableStrings[ConfigVariable_Count] = {
   "max_buckets_per_node",
   "max_vbuckets_per_node",
   "system_view_state_update_interval_ms",
+  "rpc_server_host_file",
   "rpc_server_base_name",
   "rpc_server_suffix",
   "buffer_pool_shmem_name",
@@ -907,6 +908,10 @@ void ParseTokens(TokenList *tokens, Config *config) {
       }
       case ConfigVariable_SystemViewStateUpdateInterval: {
         config->system_view_state_update_interval_ms = ParseInt(&tok);
+        break;
+      }
+      case ConfigVariable_RpcServerHostFile: {
+        config->rpc_server_host_file = ParseString(&tok);
         break;
       }
       case ConfigVariable_RpcServerBaseName: {

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -55,6 +55,7 @@ enum ConfigVariable {
   ConfigVariable_MaxBucketsPerNode,
   ConfigVariable_MaxVBucketsPerNode,
   ConfigVariable_SystemViewStateUpdateInterval,
+  ConfigVariable_RpcServerHostFile,
   ConfigVariable_RpcServerBaseName,
   ConfigVariable_RpcServerSuffix,
   ConfigVariable_BufferPoolShmemName,

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -200,6 +200,9 @@ struct Config {
   /** If non-zero, the device is shared among all nodes (e.g., burst buffs) */
   int is_shared_device[kMaxDevices];
 
+  /** TODO(chogan) */
+  std::string rpc_server_host_file;
+
   /** The hostname of the RPC server, minus any numbers that Hermes may
    * auto-generate when the rpc_hostNumber_range is specified. */
   std::string rpc_server_base_name;

--- a/src/hermes_types.h
+++ b/src/hermes_types.h
@@ -200,7 +200,7 @@ struct Config {
   /** If non-zero, the device is shared among all nodes (e.g., burst buffs) */
   int is_shared_device[kMaxDevices];
 
-  /** TODO(chogan) */
+  /** The name of a file that contains host names, 1 per line */
   std::string rpc_server_host_file;
 
   /** The hostname of the RPC server, minus any numbers that Hermes may

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -27,6 +27,11 @@ static const u32 kGlobalMutexNodeId = 1;
 
 struct RpcContext;
 
+struct ShmemString {
+  u32 offset;
+  u32 size;
+};
+
 enum MapType {
   kMapType_Bucket,
   kMapType_VBucket,
@@ -113,6 +118,7 @@ struct MetadataManager {
   VBucketID first_free_vbucket;
 
   ptrdiff_t rpc_state_offset;
+  ptrdiff_t host_names_offset;
   ptrdiff_t host_numbers_offset;
   ptrdiff_t system_view_state_offset;
   ptrdiff_t global_system_view_state_offset;

--- a/src/metadata_management.h
+++ b/src/metadata_management.h
@@ -27,9 +27,31 @@ static const u32 kGlobalMutexNodeId = 1;
 
 struct RpcContext;
 
+/**
+ * Representation of a non-NULL-terminated string in shared memory.
+ *
+ * Both the ShmemString iteself and the memory for the string it represents must
+ * reside in the same shared memory segement, and the ShmemString must be stored
+ * at a lower address than the string memory because the offset is from the
+ * ShmemString instance itself. Here is a diagram:
+ *
+ * |-----------8 bytes offset ------------|
+ * [ ShmemString | offset: 8 | size: 16 ] [ "string in memory" ]
+ *
+ * @see MakeShmemString()
+ * @see GetShmemString()
+ *
+ */
 struct ShmemString {
+  /** offset is from the address of this ShmemString instance iteself */
   u32 offset;
+  /** The size of the string (not NULL terminated) */
   u32 size;
+
+  ShmemString(const ShmemString &) = delete;
+  ShmemString(const ShmemString &&) = delete;
+  ShmemString& operator=(const ShmemString &) = delete;
+  ShmemString& operator=(const ShmemString &&) = delete;
 };
 
 enum MapType {
@@ -460,6 +482,29 @@ void LocalReplaceBlobIdInBucket(SharedMemoryContext *context,
 void ReplaceBlobIdInBucket(SharedMemoryContext *context, RpcContext *rpc,
                            BucketID bucket_id, BlobID old_blob_id,
                            BlobID new_blob_id);
+
+/**
+ * Creates a ShmemString with the value @p val at location @p memory.
+ *
+ * @pre The address of @p sms must be lower than @p memory because the @p offset
+ *      is from the beginning of the @sms.
+ *
+ * @param[out] sms The ShmemString instance to be filled out.
+ * @param memory The location in shared memory to store the @p val.
+ * @param val The string to store.
+ */
+void MakeShmemString(ShmemString *sms, u8 *memory, const std::string &val);
+
+/**
+ * Retrieves a ShmemString into a std::string
+ *
+ * @param sms The ShmemString that represents the internal string
+ *
+ * @return A newly allocated std::string containing a copy of the string from
+ *         shared memory, or an empty std::string if the ShmemString is invalid.
+ */
+std::string GetShmemString(ShmemString *sms);
+
 }  // namespace hermes
 
 #endif  // HERMES_METADATA_MANAGEMENT_H_

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -42,9 +42,13 @@ struct RpcContext {
   /** Array of host numbers in shared memory. This size is
    * RpcContext::num_nodes */
   int *host_numbers;
+  /** Array of host names stored in shared memory. This array size is
+   * RpcContext::num_nodes. */
+  ShmemString *host_names;
   u32 node_id;
   u32 num_nodes;
   int port;
+  bool use_host_file;
   /** The host name without the host number. Allows programmatic construction of
    * predictable host names like cluster-node-1, cluster-node-2, etc. without
    * storing extra copies of the base hostname.*/

--- a/src/rpc_thallium.cc
+++ b/src/rpc_thallium.cc
@@ -769,12 +769,10 @@ void FinalizeClient(SharedMemoryContext *context, RpcContext *rpc,
 
 std::string GetHostNameFromNodeId(RpcContext *rpc, u32 node_id) {
   std::string result;
-  // NOTE(chogan): node_id 0 is reserved as the NULL node
-  u32 index = node_id - 1;
   if (rpc->use_host_file) {
-    ShmemString *shmem_string = &rpc->host_names[index];
-    const char *host_name = (char *)((u8 *)shmem_string + shmem_string->offset);
-    result = std::string(host_name, shmem_string->size);
+    // NOTE(chogan): node_id 0 is reserved as the NULL node
+    u32 index = node_id - 1;
+    result = GetShmemString(&rpc->host_names[index]);
   } else {
     std::string host_number = GetHostNumberAsString(rpc, node_id);
     result = (std::string(rpc->base_hostname) + host_number +

--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -214,7 +214,7 @@ void load(A &ar, api::Context &ctx) {
 }
 }  // namespace api
 
-std::string GetRpcAddress(Config *config, const std::string &host_number,
+std::string GetRpcAddress(RpcContext *rpc, Config *config, u32 node_id,
                           int port);
 
 static inline ThalliumState *GetThalliumState(RpcContext *rpc) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -91,6 +91,7 @@ void InitDefaultConfig(Config *config) {
 
   config->num_buffer_organizer_retries = 3;
 
+  config->rpc_server_host_file = "";
   config->rpc_server_base_name = "localhost";
   config->rpc_server_suffix = "";
   config->rpc_protocol = "ofi+sockets";

--- a/test/config_parser_test.cc
+++ b/test/config_parser_test.cc
@@ -204,6 +204,8 @@ void TestDefaultConfig(Arena *arena, const char *config_file) {
   Assert(config.buffer_organizer_port == 8081);
   Assert(config.rpc_num_threads == 1);
 
+  Assert(config.rpc_server_host_file == "");
+
   const char expected_rpc_server_name[] = "localhost";
   Assert(config.rpc_server_base_name == expected_rpc_server_name);
   Assert(config.rpc_server_suffix.empty());

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -73,6 +73,12 @@ swap_mount = "./";
 # The number of times the buffer organizer will attempt to place a blob from
 # swap space into the hierarchy before giving up.
 num_buffer_organizer_retries = 3;
+
+# A path to a file containing a list of server names, 1 per line. If your
+# servers are named according to a pattern (e.g., server-1, server-2, etc.),
+# prefer the `rpc_server_base_name` and `rpc_host_number_range` options.
+rpc_server_host_file = "";
+
 # Base hostname for the RPC servers.
 rpc_server_base_name = "localhost";
 # RPC server name suffix. This is appended to the the base name plus host

--- a/test/data/hermes.conf
+++ b/test/data/hermes.conf
@@ -76,7 +76,8 @@ num_buffer_organizer_retries = 3;
 
 # A path to a file containing a list of server names, 1 per line. If your
 # servers are named according to a pattern (e.g., server-1, server-2, etc.),
-# prefer the `rpc_server_base_name` and `rpc_host_number_range` options.
+# prefer the `rpc_server_base_name` and `rpc_host_number_range` options. If this
+# option is not empty, it will override anything in `rpc_server_base_name`.
 rpc_server_host_file = "";
 
 # Base hostname for the RPC servers.


### PR DESCRIPTION
Closes #350. Adds a configuration parameter `rpc_server_host_file` allowing users to specify their host names in a file, 1 per line, rather than generating them from a pattern.