### PR TITLE
Relax mpich version requirement.

### DIFF
--- a/ci/hermes/packages/hermes/package.py
+++ b/ci/hermes/packages/hermes/package.py
@@ -9,7 +9,7 @@ class Hermes(CMakePackage):
     depends_on('mochi-thallium~cereal@0.8.3')
     depends_on('catch2@2.13.3')
     depends_on('gortools@7.7')
-    depends_on('mpich@3.3.2~fortran')
+    depends_on('mpich@3.3.2:')
 
     def cmake_args(self):
         args = ['-DCMAKE_INSTALL_PREFIX={}'.format(self.prefix),


### PR DESCRIPTION
The default version is now 3.4.2.