### PR TITLE
Build docker images all in one step to avoid potentially building on different incompatible architectures

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yml
+++ b/.github/workflows/build_and_push_docker_images.yml
@@ -4,31 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       build_docker_images:
-        description: 'An existing tag for which to build new docker images and publish them to dockerhub'
+        description: 'If ''true'', force a build of the docker images and push them to dockerhub'
         required: false
-        default: ''
+        default: false
 jobs:
   build-docker-images:
     if: ${{ github.ref_type == 'tag' || github.event.inputs.build_docker_images }}
     runs-on: ubuntu-20.04
-    strategy:
-      # user depends on dev depends on deps, so don't run in parallel
-      max-parallel: 1
-      matrix:
-        include:
-          - dockerfile: deps
-            tag: hermes-deps
-          - dockerfile: dev
-            tag: hermes-dev
-          - dockerfile: user
-            tag: hermes
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Checkout the appropriate tag if we're forcing a docker build by
-          # using the `build_docker_images` workflow dispatch input.
-          ref: ${{ github.event.input.build_docker_images }}
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -36,11 +21,27 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build ${{matrix.dockerfile}}.Dockerfile
+      - name: Build and push deps.Dockerfile
         uses: docker/build-push-action@v2
         with:
           context: ./
-          file: ./docker/${{matrix.dockerfile}}.Dockerfile
+          file: ./docker/deps.Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: hdfgroup/${{matrix.tag}}:latest
+          tags: hdfgroup/hermes-deps:latest
+      - name: Build and push dev.Dockerfile
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/dev.Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: hdfgroup/hermes-dev:latest
+      - name: Build and push user.Dockerfile
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/user.Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: hdfgroup/hermes:latest


### PR DESCRIPTION
I originally set the 3 docker builds up as a matrix in order to reduce code duplication. However, that has the effect of running the three builds on 3 different github-hosted runners. The problem with this is that the runners could be provisioned on multiple different architectures (see [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners) and [here](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series)). If the `deps.Dockerfile` gets built on Haswell for example, and the `dev.Dockerfile` gets built on Cascade Lake, then the `dev.Dockerfile` doesn't recognize the dependencies that spack installed in `deps.Dockerfile` because the architecture is part of the package hash. In order to ensure that all 3 images are built on the same architecture, I've put them sequentially in the same job.

Additionally, we can't accept a tag as a workflow dispatch input because checking out an older tag would lose the changes at the HEAD of the branch we're building. For example, I want to build the `v0.4.0-beta` tag, but If I check out that tag, then the docker files are at the top level directory instead of in the `docker` folder. That means if the docker builds fail on the initial tag, we have to either do another release, or build from `HEAD` instead of the tag.