### PR TITLE
Control default warnings in CI instead of forcing them on everyone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,11 +121,6 @@ if(NOT "${CMAKE_CXX_STANDARD}")
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
-if(NOT CMAKE_CXX_FLAGS)
- set (CMAKE_CXX_FLAGS "-Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
- message (STATUS "Warnings Configuration: default: ${CMAKE_CXX_FLAGS}")
-endif()
-
 #-----------------------------------------------------------------------------
 # Targets built within this project are exported at Install time for use
 # by other projects.


### PR DESCRIPTION
We use strict warnings in CI, but they are already set [here](https://github.com/HDFGroup/hermes/blob/master/ci/install_hermes.sh#L15).