### PR TITLE
Posix adapter shouldn't rely on O_TMPFILE support

### DIFF
--- a/adapter/posix/posix.h
+++ b/adapter/posix/posix.h
@@ -43,6 +43,10 @@
 #include "posix/mapper/mapper_factory.h"
 #include "posix/metadata_manager.h"
 
+#ifndef O_TMPFILE
+#define O_TMPFILE 0
+#endif
+
 /**
  * Function declarations
  */

--- a/adapter/test/adapter_test_utils.h
+++ b/adapter/test/adapter_test_utils.h
@@ -16,6 +16,22 @@
 #include <cstdio>
 #include <string>
 
+bool FilesystemSupportsTmpfile() {
+  bool result = false;
+
+#if O_TMPFILE
+  // NOTE(chogan): Even if O_TMPFILE is defined, the underlying filesystem might
+  // not support it.
+  int tmp_fd = open("/tmp", O_WRONLY | O_TMPFILE, 0600);
+  if (tmp_fd > 0) {
+    result = true;
+    close(tmp_fd);
+  }
+#endif
+
+  return result;
+}
+
 size_t GetRandomOffset(size_t i, unsigned int offset_seed, size_t stride,
                        size_t total_size) {
   return abs((int)(((i * rand_r(&offset_seed)) % stride) % total_size));

--- a/adapter/test/posix/posix_adapter_basic_test.cpp
+++ b/adapter/test/posix/posix_adapter_basic_test.cpp
@@ -211,23 +211,25 @@ TEST_CASE("Open", "[process=" + std::to_string(info.comm_size) +
     REQUIRE(test::status_orig == 0);
   }
   SECTION("Temporary file") {
-    test::test_open("/tmp", O_WRONLY | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig != -1);
-    test::test_close();
-    REQUIRE(test::status_orig == 0);
-    test::test_open(info.new_file.c_str(), O_RDONLY | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
-    test::test_open(info.new_file.c_str(), O_RDWR | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
-    test::test_open(info.new_file.c_str(), O_APPEND | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
+    if (info.supports_tmpfile) {
+      test::test_open("/tmp", O_WRONLY | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig != -1);
+      test::test_close();
+      REQUIRE(test::status_orig == 0);
+      test::test_open(info.new_file.c_str(), O_RDONLY | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
+      test::test_open(info.new_file.c_str(), O_RDWR | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
+      test::test_open(info.new_file.c_str(), O_APPEND | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
 
-    test::test_open(info.existing_file.c_str(), O_WRONLY | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
-    test::test_open(info.existing_file.c_str(), O_RDONLY | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
-    test::test_open(info.existing_file.c_str(), O_RDWR | O_TMPFILE, 0600);
-    REQUIRE(test::fh_orig == -1);
+      test::test_open(info.existing_file.c_str(), O_WRONLY | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
+      test::test_open(info.existing_file.c_str(), O_RDONLY | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
+      test::test_open(info.existing_file.c_str(), O_RDWR | O_TMPFILE, 0600);
+      REQUIRE(test::fh_orig == -1);
+    }
   }
   posttest();
 }

--- a/adapter/test/posix/posix_adapter_mpi_test.cpp
+++ b/adapter/test/posix/posix_adapter_mpi_test.cpp
@@ -19,6 +19,10 @@
 
 #include "catch_config.h"
 
+#ifndef O_TMPFILE
+#define O_TMPFILE 0
+#endif
+
 #include "adapter_test_utils.h"
 
 #if HERMES_INTERCEPT == 1
@@ -35,6 +39,7 @@ struct Arguments {
 };
 struct Info {
   bool debug = false;
+  bool supports_tmpfile;
   int rank = 0;
   int comm_size = 1;
   std::vector<char> write_data;
@@ -78,10 +83,12 @@ std::vector<char> gen_random(const int len) {
 
   return tmp_s;
 }
+
 int init(int* argc, char*** argv) {
   MPI_Init(argc, argv);
   info.write_data = gen_random(args.request_size);
   info.read_data = std::vector<char>(args.request_size, 'r');
+  info.supports_tmpfile = FilesystemSupportsTmpfile();
   MPI_Comm_rank(MPI_COMM_WORLD, &info.rank);
   MPI_Comm_size(MPI_COMM_WORLD, &info.comm_size);
   if (info.debug && info.rank == 0) {
@@ -92,6 +99,7 @@ int init(int* argc, char*** argv) {
   MPI_Barrier(MPI_COMM_WORLD);
   return 0;
 }
+
 int finalize() {
   MPI_Finalize();
   return 0;

--- a/adapter/test/posix/posix_adapter_test.cpp
+++ b/adapter/test/posix/posix_adapter_test.cpp
@@ -18,16 +18,16 @@
 #include <iostream>
 
 #include "catch_config.h"
-#include "adapter_test_utils.h"
 #if HERMES_INTERCEPT == 1
 #include "posix/posix.h"
 #endif
 
 #ifndef O_TMPFILE
-#define __O_TMPFILE 020000000
-#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
-#define O_TMPFILE_MASK (__O_TMPFILE | O_DIRECTORY | O_CREAT)
+#define O_TMPFILE 0
 #endif
+
+#include "adapter_test_utils.h"
+
 namespace fs = std::experimental::filesystem;
 
 namespace hermes::adapter::posix::test {
@@ -39,6 +39,7 @@ struct Arguments {
 struct Info {
   int rank = 0;
   int comm_size = 1;
+  bool supports_tmpfile;
   std::vector<char> write_data;
   std::vector<char> read_data;
   std::string new_file;
@@ -71,12 +72,15 @@ std::vector<char> gen_random(const int len) {
     tmp_s[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
   return tmp_s;
 }
+
 int init(int* argc, char*** argv) {
   MPI_Init(argc, argv);
   info.write_data = gen_random(args.request_size);
   info.read_data = std::vector<char>(args.request_size, 'r');
+  info.supports_tmpfile = FilesystemSupportsTmpfile();
   return 0;
 }
+
 int finalize() {
   MPI_Finalize();
   return 0;


### PR DESCRIPTION
Kernel versions < 3.11 and certain filesystems (e.g., lustre) don't support the `O_TMPFILE` flag to `open`. The flag is used in two ways in the POSIX adapter.

1. Hermes must treat an `open` with `O_TMPFILE` like an `open` with `O_CREAT`, since both should result in the creation of a `Bucket`.

```C++
if (flags & O_CREAT || flags & O_TMPFILE) {
  // ...
}
```
2. The POSIX adapter tests create temporary files with `O_TMPFILE` to test Hermes' handling of the flag.

To fix 1), I define `O_TMPFILE` to 0 if it's not defined. To fix 2), I only run the `O_TMPFILE` tests after verifying that the kernel and filesystem both support `O_TMPFILE`. 
