### PR TITLE
Allow more fine-grained control of which adapters get built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,10 @@ option(HERMES_DEBUG_HEAP "Store Heap debug information for visualization." OFF)
 option(HERMES_BUILD_BENCHMARKS "Build the Hermes benchmark suite." OFF)
 option(HERMES_ENABLE_TIMING "Turn on timing of selected functions." OFF)
 option(HERMES_ENABLE_COVERAGE "Enable code coverage." OFF)
-option(HERMES_ENABLE_ADAPTERS "Enable hermes adapters." ON)
+option(HERMES_ENABLE_STDIO_ADAPTER "Build the Hermes stdio adapter." ON)
+option(HERMES_ENABLE_POSIX_ADAPTER "Build the Hermes POSIX adapter." ON)
+option(HERMES_ENABLE_MPIIO_ADAPTER "Build the Hermes MPI-IO adapter." ON)
+option(HERMES_ENABLE_PUBSUB_ADAPTER "Build the Hermes pub/sub adapter." ON)
 option(HERMES_ENABLE_VFD "Build the Hermes HDF5 Virtual File Driver" OFF)
 option(HERMES_ENABLE_WRAPPER "Enable hermes C API wrapper." ON)
 option(HERMES_INSTALL_TESTS "Enable installation of tests." OFF)
@@ -358,7 +361,9 @@ if(CMAKE_PROJECT_NAME STREQUAL HERMES AND BUILD_TESTING)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
 endif()
 
-if(HERMES_ENABLE_ADAPTERS)
+if(HERMES_ENABLE_STDIO_ADAPTER OR HERMES_ENABLE_POSIX_ADAPTER OR
+    HERMES_ENABLE_MPIIO_ADAPTER OR HERMES_ENABLE_PUBSUB_ADAPTER OR
+    HERMES_ENABLE_VFD)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/adapter)
 endif()
 

--- a/adapter/CMakeLists.txt
+++ b/adapter/CMakeLists.txt
@@ -3,10 +3,21 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHERMES_PRELOAD -DHERMES_RPC_THALLIUM")
 
 set(HERMES_ADAPTER_DIR ${CMAKE_SOURCE_DIR}/adapter)
 
-add_subdirectory(stdio)
-add_subdirectory(posix)
-add_subdirectory(mpiio)
-add_subdirectory(pubsub)
+if(HERMES_ENABLE_STDIO_ADAPTER)
+  add_subdirectory(stdio)
+endif()
+
+if(HERMES_ENABLE_POSIX_ADAPTER)
+  add_subdirectory(posix)
+endif()
+
+if(HERMES_ENABLE_MPIIO_ADAPTER)
+  add_subdirectory(mpiio)
+endif()
+
+if(HERMES_ENABLE_PUBSUB_ADAPTER)
+  add_subdirectory(pubsub)
+endif()
 
 if(HERMES_ENABLE_VFD)
   if(HERMES_ENABLE_WRAPPER)

--- a/adapter/test/CMakeLists.txt
+++ b/adapter/test/CMakeLists.txt
@@ -43,10 +43,23 @@ function(mpi_daemon test_exec test_mpi_proc test_args arg_name daemon_procs)
 endfunction()
 
 enable_testing()
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/posix)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/stdio)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/mpiio)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pubsub)
+
+if(HERMES_ENABLE_STDIO_ADAPTER)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/stdio)
+endif()
+
+if(HERMES_ENABLE_POSIX_ADAPTER)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/posix)
+endif()
+
+if(HERMES_ENABLE_MPIIO_ADAPTER)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/mpiio)
+endif()
+
+if(HERMES_ENABLE_PUBSUB_ADAPTER)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pubsub)
+endif()
+
 if(HERMES_ENABLE_VFD)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vfd)
 endif()


### PR DESCRIPTION
Fixes #384. Replaces the catch-all CMake option `HERMES_ENABLE_ADAPTERS` with a variable for each individual adapter: `HERMES_ENABLE_STDIO_ADAPTER`, `HERMES_ENABLE_POSIX_ADAPTER`, `HERMES_ENABLE_MPIIO_ADAPTER`, and `HERMES_ENABLE_PUBSUB_ADAPTER`. All are `ON` by default.