### PR TITLE
Install sample hermes.conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,15 @@ install(
     ${HERMES_INSTALL_DATA_DIR}/cmake/hermes
 )
 
+install(
+  FILES
+    test/data/hermes.conf
+  TYPE
+    DATA
+  RENAME
+    hermes_configuration_example.conf
+)
+
 #-----------------------------------------------------------------------------
 # Configure the hermes-config-version .cmake file for the install directory
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,7 +422,7 @@ install(
   TYPE
     DATA
   RENAME
-    hermes_configuration_example.conf
+    hermes_sample.conf
 )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #347. Installs `hermes.conf` as `<prefix>/share/hermes_configuration_example.conf`.