### PR TITLE
Fixes for using Thallium +cereal

### DIFF
--- a/src/rpc_thallium.h
+++ b/src/rpc_thallium.h
@@ -157,10 +157,9 @@ void load(A &ar, MapType &map_type) {
   ar.read(&val, 1);
   map_type = (MapType)val;
 }
-#endif  // #ifndef THALLIUM_USE_CEREAL
 
 template<typename A>
-void save(A &ar, BoPriority &priority) {
+void save(A &ar, const BoPriority &priority) {
   int val = (int)priority;
   ar.write(&val, 1);
 }
@@ -171,6 +170,7 @@ void load(A &ar, BoPriority &priority) {
   ar.read(&val, 1);
   priority = (BoPriority)val;
 }
+#endif  // #ifndef THALLIUM_USE_CEREAL
 
 template<typename A>
 void save(A &ar, BoOperation &op) {
@@ -199,7 +199,7 @@ void serialize(A &ar, BoTask &bo_task) {
 
 namespace api {
 template<typename A>
-void save(A &ar, api::Context &ctx) {
+void save(A &ar, const api::Context &ctx) {
   ar.write(&ctx.buffer_organizer_retries, 1);
   int val = (int)ctx.policy;
   ar.write(&val, 1);


### PR DESCRIPTION
Cereal requires all objects passed to `save` functions to be `const`. I also had to move the serialization functions for `BoPriority` into the `#ifndef THALLIUM_USE_CEREAL` block because the default thallium serialization doesn't handle enums automatically. 