### PR TITLE
Add a missing HDF5 header.

### DIFF
--- a/adapter/vfd/H5FDhermes.h
+++ b/adapter/vfd/H5FDhermes.h
@@ -21,6 +21,7 @@
 #define H5FDhermes_H
 
 #include <dlfcn.h>
+#include <hdf5.h>
 #include <stdio.h>
 
 #define H5FD_HERMES_NAME  "hermes"


### PR DESCRIPTION
This will fix the compilation error.
```
In file included from /home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:35:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:46:1: error: unknown type name ‘hid_t’; did you mean ‘id_t’?
   46 | hid_t H5FD_hermes_init();
      | ^~~~~
      | id_t
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:47:1: error: unknown type name ‘herr_t’
   47 | herr_t H5Pset_fapl_hermes(hid_t fapl_id, hbool_t persistence, size_t page_size);
      | ^~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:47:27: error: unknown type name ‘hid_t’; did you mean ‘id_t’?
   47 | herr_t H5Pset_fapl_hermes(hid_t fapl_id, hbool_t persistence, size_t page_size);
      |                           ^~~~~
      |                           id_t
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:47:42: error: unknown type name ‘hbool_t’
   47 | herr_t H5Pset_fapl_hermes(hid_t fapl_id, hbool_t persistence, size_t page_size);
      |                                          ^~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:30:16: error: expected declaration specifiers or ‘...’ before ‘*’ token
   30 |   typedef ret_(*real_t_##func_##_) args_;       \
      |                ^
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:49:1: note: in expansion of macro ‘HERMES_FORWARD_DECL’
   49 | HERMES_FORWARD_DECL(H5_init_library, herr_t, ());
      | ^~~~~~~~~~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:31:8: error: expected declaration specifiers or ‘...’ before ‘*’ token
   31 |   ret_(*real_##func_##_) args_ = NULL;
      |        ^
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:49:1: note: in expansion of macro ‘HERMES_FORWARD_DECL’
   49 | HERMES_FORWARD_DECL(H5_init_library, herr_t, ());
      | ^~~~~~~~~~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:30:16: error: expected declaration specifiers or ‘...’ before ‘*’ token
   30 |   typedef ret_(*real_t_##func_##_) args_;       \
      |                ^
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:50:1: note: in expansion of macro ‘HERMES_FORWARD_DECL’
   50 | HERMES_FORWARD_DECL(H5_term_library, herr_t, ());
      | ^~~~~~~~~~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:31:8: error: expected declaration specifiers or ‘...’ before ‘*’ token
   31 |   ret_(*real_##func_##_) args_ = NULL;
      |        ^
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:50:1: note: in expansion of macro ‘HERMES_FORWARD_DECL’
   50 | HERMES_FORWARD_DECL(H5_term_library, herr_t, ());
      | ^~~~~~~~~~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:288:7: error: conflicting types for ‘H5FD_hermes_init’
  288 | hid_t H5FD_hermes_init(void) {
      |       ^~~~~~~~~~~~~~~~
In file included from /home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:35:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:46:7: note: previous declaration of ‘H5FD_hermes_init’ was here
   46 | hid_t H5FD_hermes_init();
      |       ^~~~~~~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c: In function ‘H5_init_library’:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:34:9: error: ‘real_H5_init_library_’ undeclared (first use in this function); did you mean ‘H5_init_library’?
   34 |   if (!(real_##func_##_)) {                                                 \
      |         ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1098:7: note: in expansion of macro ‘MAP_OR_FAIL’
 1098 |       MAP_OR_FAIL(H5_init_library);
      |       ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:34:9: note: each undeclared identifier is reported only once for each function it appears in
   34 |   if (!(real_##func_##_)) {                                                 \
      |         ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1098:7: note: in expansion of macro ‘MAP_OR_FAIL’
 1098 |       MAP_OR_FAIL(H5_init_library);
      |       ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:24: error: ‘real_t_H5_init_library_’ undeclared (first use in this function); did you mean ‘H5_init_library’?
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                        ^~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1098:7: note: in expansion of macro ‘MAP_OR_FAIL’
 1098 |       MAP_OR_FAIL(H5_init_library);
      |       ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:42: error: expected ‘;’ before ‘dlsym’
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                                          ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1098:7: note: in expansion of macro ‘MAP_OR_FAIL’
 1098 |       MAP_OR_FAIL(H5_init_library);
      |       ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1099:19: warning: implicit declaration of function ‘real_H5_init_library_’; did you mean ‘H5_init_library’? [-Wimplicit-function-declaration]
 1099 |       ret_value = real_H5_init_library_();
      |                   ^~~~~~~~~~~~~~~~~~~~~
      |                   H5_init_library
In file included from /home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:35:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c: In function ‘H5_term_library’:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:34:9: error: ‘real_H5_term_library_’ undeclared (first use in this function); did you mean ‘H5_term_library’?
   34 |   if (!(real_##func_##_)) {                                                 \
      |         ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1107:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1107 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:24: error: ‘real_t_H5_term_library_’ undeclared (first use in this function); did you mean ‘H5_term_library’?
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                        ^~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1107:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1107 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:42: error: expected ‘;’ before ‘dlsym’
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                                          ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1107:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1107 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1108:22: warning: implicit declaration of function ‘real_H5_term_library_’; did you mean ‘H5_term_library’? [-Wimplicit-function-declaration]
 1108 |   herr_t ret_value = real_H5_term_library_();
      |                      ^~~~~~~~~~~~~~~~~~~~~
      |                      H5_term_library
In file included from /home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:35:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c: In function ‘MPI_Finalize’:
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:34:9: error: ‘real_H5_term_library_’ undeclared (first use in this function); did you mean ‘H5_term_library’?
   34 |   if (!(real_##func_##_)) {                                                 \
      |         ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1137:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1137 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:24: error: ‘real_t_H5_term_library_’ undeclared (first use in this function); did you mean ‘H5_term_library’?
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                        ^~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1137:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1137 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.h:35:42: error: expected ‘;’ before ‘dlsym’
   35 |     real_##func_##_ = (real_t_##func_##_)dlsym(RTLD_NEXT, #func_);          \
      |                                          ^~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1137:3: note: in expansion of macro ‘MAP_OR_FAIL’
 1137 |   MAP_OR_FAIL(H5_term_library);
      |   ^~~~~~~~~~~
/home/runner/work/hermes/hermes/adapter/vfd/H5FDhermes.c:1138:3: warning: implicit declaration of function ‘real_H5_term_library_’; did you mean ‘H5_term_library’? [-Wimplicit-function-declaration]
 1138 |   real_H5_term_library_();
      |   ^~~~~~~~~~~~~~~~~~~~~
      |   H5_term_library
make[2]: *** [adapter/vfd/CMakeFiles/hdf5_hermes_vfd.dir/build.make:76: adapter/vfd/CMakeFiles/hdf5_hermes_vfd.dir/H5FDhermes.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1824: adapter/vfd/CMakeFiles/hdf5_hermes_vfd.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 57%] Building CXX object adapter/pubsub/CMakeFiles/hermes_pubsub.dir/metadata_manager.cc.o
[ 58%] Linking CXX shared library ../../bin/libhermes_pubsub.so
[ 58%] Built target hermes_pubsub
[ 60%] Linking CXX shared library ../../bin/libhermes_mpiio.so
[ 60%] Built target hermes_mpiio
[ 61%] Linking CXX executable ../bin/trait
[ 61%] Built target trait
make: *** [Makefile:146: all] Error 2
Error: Process completed with exit code 2.
```