### PR TITLE
Fix several build-related issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,37 @@ if(HERMES_BUILD_BUFFER_POOL_VISUALIZER)
   endif()
 endif()
 
+# HDF5
+if(HERMES_ENABLE_VFD)
+  set(HERMES_REQUIRED_HDF5_VERSION 1.13.0)
+  set(HERMES_REQUIRED_HDF5_COMPONENTS C)
+  find_package(HDF5 ${HERMES_REQUIRED_HDF5_VERSION} CONFIG NAMES hdf5
+    COMPONENTS ${HERMES_REQUIRED_HDF5_COMPONENTS} shared)
+  if(HDF5_FOUND)
+    message(STATUS "found HDF5 ${HDF5_VERSION} at ${HDF5_INCLUDE_DIR}")
+    set(HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES
+      ${HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES}
+      ${HDF5_INCLUDE_DIR})
+    set(HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES
+      ${HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES}
+      ${HDF5_C_SHARED_LIBRARY})
+  else()
+    # Allow for HDF5 autotools builds
+    find_package(HDF5 ${HERMES_REQUIRED_HDF5_VERSION} MODULE REQUIRED
+      COMPONENTS ${HERMES_REQUIRED_HDF5_COMPONENTS})
+    if(HDF5_FOUND)
+      set(HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES
+        ${HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES}
+        ${HDF5_INCLUDE_DIRS})
+      set(HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES
+        ${HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES}
+        ${HDF5_LIBRARIES})
+    else()
+      message(FATAL_ERROR "Could not find HDF5, please set HDF5_DIR (1.13.0) or HDF5_ROOT (1.13.1).")
+    endif()
+  endif()
+endif()
+
 #-----------------------------------------------------------------------------
 # Coverage
 #-----------------------------------------------------------------------------

--- a/adapter/test/vfd/CMakeLists.txt
+++ b/adapter/test/vfd/CMakeLists.txt
@@ -17,7 +17,6 @@ target_link_libraries(hermes_vfd_test
   glog::glog
   stdc++fs
   ${HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES}
-  ${HDF5_HERMES_VFD_EXT_PKG_DEPENDENCIES}
 )
 
 if(HERMES_USE_ADDRESS_SANITIZER)

--- a/adapter/vfd/CMakeLists.txt
+++ b/adapter/vfd/CMakeLists.txt
@@ -29,45 +29,6 @@ if(NOT HDF5_HERMES_VFD_EXPORTED_TARGETS)
   set(HDF5_HERMES_VFD_EXPORTED_TARGETS "${HDF5_HERMES_VFD_PACKAGE}-targets")
 endif()
 
-#------------------------------------------------------------------------------
-# External dependencies
-#------------------------------------------------------------------------------
-#HDF5
-
-set(HERMES_REQUIRED_HDF5_COMPONENTS C)
-
-find_package(HDF5 1.13.0 NO_MODULE NAMES hdf5 COMPONENTS ${HERMES_REQUIRED_HDF5_COMPONENTS} shared)
-if(HDF5_FOUND)
-  set(HDF5_C_SHARED_LIBRARY hdf5-shared)
-#  if(NOT TARGET ${HDF5_C_SHARED_LIBRARY})
-#      message(FATAL_ERROR "Could not find hdf5 shared target, please make "
-#"sure that HDF5 has ben compiled with shared libraries enabled.")
-#    endif()
-  set(HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES
-      ${HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES}
-      ${HDF5_INCLUDE_DIR}
-     )
-  set(HDF5_HERMES_VFD_EXT_PKG_DEPENDENCIES
-      ${HDF5_HERMES_VFD_EXT_PKG_DEPENDENCIES}
-      ${HDF5_C_SHARED_LIBRARY}
-     )
-else()
-# Allow for HDF5 autotools builds
-  find_package(HDF5 1.13.0 MODULE REQUIRED COMPONENTS ${HERMES_REQUIRED_HDF5_COMPONENTS})
-  if(HDF5_FOUND)
-    set(HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES
-        ${HDF5_HERMES_VFD_EXT_INCLUDE_DEPENDENCIES}
-        ${HDF5_INCLUDE_DIRS}
-       )
-    set(HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES
-        ${HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES}
-        ${HDF5_LIBRARIES}
-       )
-  else()
-    message(FATAL_ERROR "Could not find HDF5, please check HDF5_DIR.")
-  endif()
-endif()
-
 set(HDF5_HERMES_VFD_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/H5FDhermes.h
   ${CMAKE_CURRENT_SOURCE_DIR}/H5FDhermes.c
@@ -85,9 +46,7 @@ target_include_directories(hdf5_hermes_vfd
 target_link_libraries(hdf5_hermes_vfd
   hermes_wrapper
   MPI::MPI_C
-  ${HDF5_HERMES_VFD_EXPORTED_LIBS}
   ${HDF5_HERMES_VFD_EXT_LIB_DEPENDENCIES}
-  ${HDF5_HERMES_VFD_EXT_PKG_DEPENDENCIES}
 )
 
 set(HDF5_HERMES_VFD_EXPORTED_LIBS hdf5_hermes_vfd ${HDF5_HERMES_VFD_EXPORTED_LIBS} PARENT_SCOPE)

--- a/adapter/vfd/H5FDhermes.c
+++ b/adapter/vfd/H5FDhermes.c
@@ -19,7 +19,9 @@
  *          and buffer datasets in Hermes buffering systems with
  *          multiple storage tiers.
  */
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit 3
+
 set -x
 set -e
 set -o pipefail

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -26,7 +26,8 @@ set +x
 . ${SPACK_DIR}/share/spack/setup-env.sh
 set -x
 
-cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
+# cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
+spack external find
 MOCHI_REPO=https://github.com/mochi-hpc/mochi-spack-packages.git
 # TODO(chogan): We pin this commit because in the past using the HEAD of 'main'
 # has been unstable. We update at controlled intervals rather than putting out
@@ -38,7 +39,6 @@ pushd ${MOCHI_REPO_DIR}
 git checkout ${MOCHI_SPACK_PACKAGES_COMMIT}
 popd
 
-spack external find
 spack repo add ${MOCHI_REPO_DIR}
 spack repo add ./ci/hermes
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -38,6 +38,7 @@ pushd ${MOCHI_REPO_DIR}
 git checkout ${MOCHI_SPACK_PACKAGES_COMMIT}
 popd
 
+spack external find
 spack repo add ${MOCHI_REPO_DIR}
 spack repo add ./ci/hermes
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -13,6 +13,7 @@ CATCH2_VERSION=2.13.3
 SPACK_VERSION=0.18.0
 HDF5_VERSION=1_13_1
 
+git clone https://github.com/ChristopherHogan/IOR
 echo "Installing dependencies at ${INSTALL_DIR}"
 mkdir -p ${INSTALL_DIR}
 
@@ -54,3 +55,19 @@ mkdir -p ${SPACK_STAGING_DIR}
 spack view --verbose symlink ${SPACK_STAGING_DIR} ${ALL_SPECS}
 
 cp -LRnv ${SPACK_STAGING_DIR}/* ${INSTALL_DIR}
+
+# IOR
+pushd ~
+git clone https://github.com/ChristopherHogan/ior
+pushd ior
+git checkout chogan/hermes
+./bootstrap
+mkdir -p build
+pushd build
+CPPFLAGS=-I${INSTALL_DIR}/include \
+        LDFLAGS="-L${INSTALL_DIR}/lib -Wl,-rpath,${INSTALL_DIR}/lib" \
+        ../configure --prefix=${INSTALL_DIR} --with-hdf5=yes
+make -j 4 && make install
+popd
+popd
+popd

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -10,26 +10,11 @@ MOCHI_REPO_DIR=${INSTALL_DIR}/mochi-spack-packages
 THALLIUM_VERSION=0.10.0
 GOTCHA_VERSION=develop
 CATCH2_VERSION=2.13.3
-SPACK_VERSION=0.17.2
-HDF5_VERSION=1_13_0
+SPACK_VERSION=0.18.0
+HDF5_VERSION=1_13_1
 
 echo "Installing dependencies at ${INSTALL_DIR}"
 mkdir -p ${INSTALL_DIR}
-
-# HDF5
-# TODO: Use spack package once 1.13.0 is available in a release (currently
-# only on the develop branch)
-git clone https://github.com/HDFGroup/hdf5
-pushd hdf5
-git checkout hdf5-${HDF5_VERSION}
-bash autogen.sh
-mkdir -p build
-pushd build
-CXXFLAGS=-I"${INSTALL_DIR}/include" LDFLAGS="-L${INSTALL_DIR}/lib -Wl,-rpath,${INSTALL_DIR}/lib" \
-        ../configure --prefix="${INSTALL_DIR}"
-make -j 4 && make install
-popd
-popd
 
 # Spack
 git clone https://github.com/spack/spack ${SPACK_DIR}
@@ -60,10 +45,12 @@ THALLIUM_SPEC="mochi-thallium@${THALLIUM_VERSION} ^mercury~boostsys"
 CATCH2_SPEC="catch2@${CATCH2_VERSION}"
 GLPK_SPEC="glpk"
 GLOG_SPEC="glog"
+HDF5_SPEC="hdf5@${HDF5_VERSION}"
+ALL_SPECS="${THALLIUM_SPEC} ${CATCH2_SPEC} ${GLPK_SPEC} ${GLOG_SPEC} ${HDF5_SPEC}"
 
-spack install ${THALLIUM_SPEC} ${CATCH2_SPEC} ${GLPK_SPEC} ${GLOG_SPEC}
+spack install ${ALL_SPECS}
 SPACK_STAGING_DIR=~/spack_staging
 mkdir -p ${SPACK_STAGING_DIR}
-spack view --verbose symlink ${SPACK_STAGING_DIR} ${THALLIUM_SPEC} ${CATCH2_SPEC} ${GLPK_SPEC} ${GLOG_SPEC}
+spack view --verbose symlink ${SPACK_STAGING_DIR} ${ALL_SPECS}
 
 cp -LRnv ${SPACK_STAGING_DIR}/* ${INSTALL_DIR}

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -13,7 +13,6 @@ CATCH2_VERSION=2.13.3
 SPACK_VERSION=0.18.0
 HDF5_VERSION=1_13_1
 
-git clone https://github.com/ChristopherHogan/IOR
 echo "Installing dependencies at ${INSTALL_DIR}"
 mkdir -p ${INSTALL_DIR}
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-exit 3
-
 set -x
 set -e
 set -o pipefail
@@ -28,8 +26,7 @@ set +x
 . ${SPACK_DIR}/share/spack/setup-env.sh
 set -x
 
-# cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
-spack external find
+cp ci/packages.yaml ${SPACK_DIR}/etc/spack/packages.yaml
 MOCHI_REPO=https://github.com/mochi-hpc/mochi-spack-packages.git
 # TODO(chogan): We pin this commit because in the past using the HEAD of 'main'
 # has been unstable. We update at controlled intervals rather than putting out

--- a/ci/install_hermes.sh
+++ b/ci/install_hermes.sh
@@ -12,6 +12,9 @@ pushd build
 DEPENDENCY_PREFIX="${HOME}/${LOCAL}"
 INSTALL_PREFIX="${HOME}/install"
 
+# Need h5diff and ior on the PATH
+export PATH="${DEPENDENCY_PREFIX}/bin:${PATH}"
+
 export CXXFLAGS="${CXXFLAGS} -std=c++17 -Werror -Wall -Wextra"
 cmake                                                      \
     -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}               \
@@ -37,7 +40,6 @@ cmake                                                      \
     ..
 
 cmake --build . -- -j4
-# Need h5diff on the PATH
-PATH="${DEPENDENCY_PREFIX}/bin:${PATH}" ctest -VV
+ctest -VV
 
 popd

--- a/ci/packages.yaml
+++ b/ci/packages.yaml
@@ -3,13 +3,13 @@ packages:
     target: [x86_64]
   mpich:
     externals:
-    - spec: mpich@3.3
-      prefix: /opt/mpich-3.3-intel
+    - spec: mpich@3.3.2
+      prefix: /usr
     buildable: False
   cmake:
     externals:
-    - spec: cmake@3.10.0
-      prefix: /usr/local/cmake-3.10.0
+    - spec: cmake@3.23.2
+      prefix: /usr/local
     buildable: False
   autoconf:
     externals:
@@ -18,7 +18,7 @@ packages:
     buildable: False
   automake:
     externals:
-    - spec: automake@1.15
+    - spec: automake@1.16
       prefix: /usr
     buildable: False
   libtool:
@@ -28,7 +28,7 @@ packages:
     buildable: False
   m4:
     externals:
-    - spec: m4@4.17
+    - spec: m4@1.4.18
       prefix: /usr
     buildable: False
   pkg-config:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ target_include_directories(hermes
 target_link_libraries(hermes
   PUBLIC ${GLPK_LIBRARIES}
   PUBLIC thallium
+  PUBLIC glog::glog
   PUBLIC "$<$<BOOL:${HERMES_INTERCEPT_IO}>:${GOTCHA_MODULE_LIBS}>"
   PRIVATE $<$<BOOL:${HERMES_COMMUNICATION_MPI}>:MPI::MPI_CXX>
 )


### PR DESCRIPTION
* Move `find_package(HDF5 ...)` calls to top level `CMakeLists.txt` file so both the `adapter/vfd` and `adapter/test` folders can use hdf5.
* Update spack to `0.18.0`
* Update hdf5 to `1.13.1`
* Install hdf5 with spack instead of manually.
* Add IOR so that IOR+VFD tests are run.
* Add `glog` as a dependency of `libhermes`.
* Update `ci/packages.yaml` for latest Github runners.