### PR TITLE
ADAPTER_MODE=SCRATCH deletes bucket after file close, but has no backing file to re-obtain contents

### DIFF
--- a/adapter/filesystem/filesystem.cc
+++ b/adapter/filesystem/filesystem.cc
@@ -677,6 +677,10 @@ int Filesystem::Close(File &f, AdapterStat &stat, bool destroy) {
     }
     MPI_Barrier(stat.comm);
   }
+  if (INTERCEPTOR_LIST->adapter_mode == AdapterMode::kScratch) {
+    destroy = false;
+  }
+
   Sync(f, stat);
   auto filename = stat.st_bkid->GetName();
   if (mdm->is_mpi) { MPI_Barrier(stat.comm); }

--- a/adapter/mpiio/fs_api.cc
+++ b/adapter/mpiio/fs_api.cc
@@ -533,8 +533,20 @@ void MpiioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   MPI_Offset size = static_cast<MPI_Offset>(stat.st_size);
   MPI_File_get_size(f.mpi_fh_, &size);
   stat.st_size = size;
+  // TODO(llogan): This isn't really parallel-safe.
+  /**
+   * Here, we assume that when bkt_size is 0, then the bucket was just
+   * created and the true size of the file being opened is the
+   * size of the file on the PFS. However, if the user truncated
+   * the file at runtime, this will now be incorrect. Need a
+   * better way to determine what the true size of the file
+   * should be.
+   * */
   if (bucket_exists) {
-    stat.st_size = stat.st_bkid->GetTotalBlobSize();
+    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
+    if (bkt_size > 0) {
+      stat.st_size = bkt_size;
+    }
     LOG(INFO) << "Since bucket exists, should reset its size to: "
               << stat.st_size << std::endl;
   }

--- a/adapter/mpiio/fs_api.cc
+++ b/adapter/mpiio/fs_api.cc
@@ -528,30 +528,11 @@ void MpiioFS::_InitFile(File &f) {
   posix_api->close(fd);*/
 }
 
-void MpiioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
-  (void) bucket_exists;
+void MpiioFS::_OpenInitStats(File &f, AdapterStat &stat) {
   MPI_Offset size = static_cast<MPI_Offset>(stat.st_size);
   MPI_File_get_size(f.mpi_fh_, &size);
   stat.st_size = size;
-  // TODO(llogan): This isn't really parallel-safe.
-  /**
-   * Here, we assume that when bkt_size is 0, then the bucket was just
-   * created and the true size of the file being opened is the
-   * size of the file on the PFS. However, if the user truncated
-   * the file at runtime, this will now be incorrect. Need a
-   * better way to determine what the true size of the file
-   * should be.
-   * */
-  if (bucket_exists) {
-    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
-    if (bkt_size > 0) {
-      stat.st_size = bkt_size;
-    }
-    LOG(INFO) << "Since bucket exists, should reset its size to: "
-              << stat.st_size << std::endl;
-  }
   if (stat.amode & MPI_MODE_APPEND) {
-    stat.st_ptr = stat.st_size;
     stat.is_append = true;
   }
 }

--- a/adapter/mpiio/fs_api.cc
+++ b/adapter/mpiio/fs_api.cc
@@ -533,6 +533,11 @@ void MpiioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   MPI_Offset size = static_cast<MPI_Offset>(stat.st_size);
   MPI_File_get_size(f.mpi_fh_, &size);
   stat.st_size = size;
+  if (bucket_exists) {
+    stat.st_size = stat.st_bkid->GetTotalBlobSize();
+    LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
+              << std::endl;
+  }
   if (stat.amode & MPI_MODE_APPEND) {
     stat.st_ptr = stat.st_size;
     stat.is_append = true;

--- a/adapter/mpiio/fs_api.cc
+++ b/adapter/mpiio/fs_api.cc
@@ -535,8 +535,8 @@ void MpiioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_size = size;
   if (bucket_exists) {
     stat.st_size = stat.st_bkid->GetTotalBlobSize();
-    LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
-              << std::endl;
+    LOG(INFO) << "Since bucket exists, should reset its size to: "
+              << stat.st_size << std::endl;
   }
   if (stat.amode & MPI_MODE_APPEND) {
     stat.st_ptr = stat.st_size;

--- a/adapter/mpiio/fs_api.h
+++ b/adapter/mpiio/fs_api.h
@@ -219,7 +219,7 @@ class MpiioFS : public hermes::adapter::fs::Filesystem {
    * */
 
  private:
-  void _OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) override;
+  void _OpenInitStats(File &f, AdapterStat &stat) override;
   File _RealOpen(AdapterStat &stat, const std::string &path) override;
   size_t _RealWrite(const std::string &filename, off_t offset, size_t size,
                     const u8 *data_ptr,

--- a/adapter/posix/fs_api.cc
+++ b/adapter/posix/fs_api.cc
@@ -40,8 +40,7 @@ void PosixFS::_InitFile(File &f) {
   f.st_ino = st.st_ino;
 }
 
-void PosixFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
-  (void) bucket_exists;
+void PosixFS::_OpenInitStats(File &f, AdapterStat &stat) {
   struct stat st;
   real_api->__fxstat(_STAT_VER, f.fd_, &st);
   stat.st_mode = st.st_mode;
@@ -52,25 +51,7 @@ void PosixFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
-  // TODO(llogan): This isn't really parallel-safe.
-  /**
-   * Here, we assume that when bkt_size is 0, then the bucket was just
-   * created and the true size of the file being opened is the
-   * size of the file on the PFS. However, if the user truncated
-   * the file at runtime, this will now be incorrect. Need a
-   * better way to determine what the true size of the file
-   * should be.
-   * */
-  if (bucket_exists) {
-    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
-    if (bkt_size > 0) {
-      stat.st_size = bkt_size;
-    }
-    LOG(INFO) << "Since bucket exists, should reset its size to: "
-              << stat.st_size << std::endl;
-  }
   if (stat.flags & O_APPEND) {
-    stat.st_ptr = stat.st_size;
     stat.is_append = true;
   }
 }

--- a/adapter/posix/fs_api.cc
+++ b/adapter/posix/fs_api.cc
@@ -52,8 +52,20 @@ void PosixFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
+  // TODO(llogan): This isn't really parallel-safe.
+  /**
+   * Here, we assume that when bkt_size is 0, then the bucket was just
+   * created and the true size of the file being opened is the
+   * size of the file on the PFS. However, if the user truncated
+   * the file at runtime, this will now be incorrect. Need a
+   * better way to determine what the true size of the file
+   * should be.
+   * */
   if (bucket_exists) {
-    stat.st_size = stat.st_bkid->GetTotalBlobSize();
+    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
+    if (bkt_size > 0) {
+      stat.st_size = bkt_size;
+    }
     LOG(INFO) << "Since bucket exists, should reset its size to: "
               << stat.st_size << std::endl;
   }

--- a/adapter/posix/fs_api.cc
+++ b/adapter/posix/fs_api.cc
@@ -52,11 +52,11 @@ void PosixFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
-  /*if (bucket_exists) {
+  if (bucket_exists) {
     stat.st_size = stat.st_bkid->GetTotalBlobSize();
     LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
               << std::endl;
-  }*/
+  }
   if (stat.flags & O_APPEND) {
     stat.st_ptr = stat.st_size;
     stat.is_append = true;

--- a/adapter/posix/fs_api.cc
+++ b/adapter/posix/fs_api.cc
@@ -54,8 +54,8 @@ void PosixFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_ctim = st.st_ctim;
   if (bucket_exists) {
     stat.st_size = stat.st_bkid->GetTotalBlobSize();
-    LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
-              << std::endl;
+    LOG(INFO) << "Since bucket exists, should reset its size to: "
+              << stat.st_size << std::endl;
   }
   if (stat.flags & O_APPEND) {
     stat.st_ptr = stat.st_size;

--- a/adapter/posix/fs_api.h
+++ b/adapter/posix/fs_api.h
@@ -39,7 +39,7 @@ class PosixFS : public hermes::adapter::fs::Filesystem {
   void _InitFile(File &f) override;
 
  private:
-  void _OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) override;
+  void _OpenInitStats(File &f, AdapterStat &stat) override;
   File _RealOpen(AdapterStat &stat, const std::string &path) override;
   size_t _RealWrite(const std::string &filename, off_t offset, size_t size,
                     const u8 *data_ptr,

--- a/adapter/stdio/fs_api.cc
+++ b/adapter/stdio/fs_api.cc
@@ -50,8 +50,20 @@ void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
+  // TODO(llogan): This isn't really parallel-safe.
+  /**
+   * Here, we assume that when bkt_size is 0, then the bucket was just
+   * created and the true size of the file being opened is the
+   * size of the file on the PFS. However, if the user truncated
+   * the file at runtime, this will now be incorrect. Need a
+   * better way to determine what the true size of the file
+   * should be.
+   * */
   if (bucket_exists) {
-    stat.st_size = stat.st_bkid->GetTotalBlobSize();
+    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
+    if (bkt_size > 0) {
+      stat.st_size = bkt_size;
+    }
     LOG(INFO) << "Since bucket exists, should reset its size to: "
               << stat.st_size << std::endl;
   }

--- a/adapter/stdio/fs_api.cc
+++ b/adapter/stdio/fs_api.cc
@@ -39,7 +39,7 @@ void StdioFS::_InitFile(File &f) {
   f.st_ino = st.st_ino;
 }
 
-void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
+void StdioFS::_OpenInitStats(File &f, AdapterStat &stat) {
   struct stat st;
   posix_api->__fxstat(_STAT_VER, f.fd_, &st);
   stat.st_mode = st.st_mode;
@@ -50,25 +50,7 @@ void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
-  // TODO(llogan): This isn't really parallel-safe.
-  /**
-   * Here, we assume that when bkt_size is 0, then the bucket was just
-   * created and the true size of the file being opened is the
-   * size of the file on the PFS. However, if the user truncated
-   * the file at runtime, this will now be incorrect. Need a
-   * better way to determine what the true size of the file
-   * should be.
-   * */
-  if (bucket_exists) {
-    size_t bkt_size = stat.st_bkid->GetTotalBlobSize();
-    if (bkt_size > 0) {
-      stat.st_size = bkt_size;
-    }
-    LOG(INFO) << "Since bucket exists, should reset its size to: "
-              << stat.st_size << std::endl;
-  }
   if (stat.mode_str.find('a') != std::string::npos) {
-    stat.st_ptr = stat.st_size;
     stat.is_append = true;
   }
 }

--- a/adapter/stdio/fs_api.cc
+++ b/adapter/stdio/fs_api.cc
@@ -52,8 +52,8 @@ void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_ctim = st.st_ctim;
   if (bucket_exists) {
     stat.st_size = stat.st_bkid->GetTotalBlobSize();
-    LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
-              << std::endl;
+    LOG(INFO) << "Since bucket exists, should reset its size to: "
+              << stat.st_size << std::endl;
   }
   if (stat.mode_str.find('a') != std::string::npos) {
     stat.st_ptr = stat.st_size;

--- a/adapter/stdio/fs_api.cc
+++ b/adapter/stdio/fs_api.cc
@@ -40,7 +40,6 @@ void StdioFS::_InitFile(File &f) {
 }
 
 void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
-  (void) bucket_exists;
   struct stat st;
   posix_api->__fxstat(_STAT_VER, f.fd_, &st);
   stat.st_mode = st.st_mode;
@@ -51,11 +50,11 @@ void StdioFS::_OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) {
   stat.st_atim = st.st_atim;
   stat.st_mtim = st.st_mtim;
   stat.st_ctim = st.st_ctim;
-  /*if (bucket_exists) {
+  if (bucket_exists) {
     stat.st_size = stat.st_bkid->GetTotalBlobSize();
     LOG(INFO) << "Since bucket exists, should reset its size to: " << stat.st_size
               << std::endl;
-  }*/
+  }
   if (stat.mode_str.find('a') != std::string::npos) {
     stat.st_ptr = stat.st_size;
     stat.is_append = true;

--- a/adapter/stdio/fs_api.h
+++ b/adapter/stdio/fs_api.h
@@ -44,7 +44,7 @@ class StdioFS : public hermes::adapter::fs::Filesystem {
   void _InitFile(File &f) override;
 
  private:
-  void _OpenInitStats(File &f, AdapterStat &stat, bool bucket_exists) override;
+  void _OpenInitStats(File &f, AdapterStat &stat) override;
   File _RealOpen(AdapterStat &stat, const std::string &path) override;
   size_t _RealWrite(const std::string &filename, off_t offset, size_t size,
                     const u8 *data_ptr,


### PR DESCRIPTION
When running IOR, I noticed that ADAPTER_MODE=SCRATCH causes issues when a file is opened-modified-closed more than once in a single lifetime. This is because ADAPTER_MODE=SCRATCH doesn't store the bucket before it's destroyed. Added a condition in filesystem.cc to ensure that when ADAPTER_MODE=SCRATCH, buckets aren't destroyed when the file is closed.