### PR TITLE
ci: fix Doxygen installation issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: Install APT Dependencies
         run: |
-          sudo apt update
+          sudo apt update -y
+          sudo apt install -y libunwind-dev
           sudo apt-get install -y autoconf
           sudo apt-get install -y automake
           sudo apt-get install -y libtool
@@ -40,7 +41,8 @@ jobs:
           sudo apt-get install -y zlib1g-dev
           sudo apt-get install -y libsdl2-dev
           sudo apt-get install -y graphviz
-          sudo apt-get install -y doxygen
+          sudo apt-get install -y --no-install-recommends doxygen
+          sudo apt-get install -y libgoogle-glog-dev
 
       - name: Build And Install Dependencies
         if: steps.spack-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Microsoft upgraded ubuntu-latest Action's OS version from 20.x to 22.x.
Doxygen installation fails.
This will fix Doxygen installation.
