### PR TITLE
SHM data structure import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,8 @@ if(HERMES_BUILD_BUFFER_POOL_VISUALIZER AND SDL2_FOUND)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/buffer_pool_visualizer)
 endif()
 
+include_directories(${CMAKE_SOURCE_DIR}/hermes_shm/include)
+add_subdirectory(hermes_shm)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/data_stager)
 
 #-----------------------------------------------------------------------------

--- a/adapter/adapter_generator/adapter_generator/create_interceptor.py
+++ b/adapter/adapter_generator/adapter_generator/create_interceptor.py
@@ -156,6 +156,7 @@ class ApiClass:
         # Create the class definition
         self.h_lines.append(f"namespace hermes::adapter::{namespace} {{")
         self.h_lines.append(f"")
+        self.h_lines.append(f"/** Pointers to the real {namespace} API */")
         self.h_lines.append(f"class API {{")
 
         # Create class function pointers

--- a/adapter/filesystem/filesystem.h
+++ b/adapter/filesystem/filesystem.h
@@ -201,6 +201,11 @@ struct IoOptions {
     return opts;
   }
 
+  /**
+   * Ensure that I/O goes only to Hermes, and does not fall back to PFS.
+   *
+   * @param orig_opts The original options to modify
+   * */
   static IoOptions PlaceInHermes(IoOptions &orig_opts) {
     IoOptions opts(orig_opts);
     opts.seek_ = false;

--- a/adapter/mpiio/real_api.h
+++ b/adapter/mpiio/real_api.h
@@ -62,6 +62,7 @@ typedef int (*MPI_File_sync_t)(MPI_File fh);
 
 namespace hermes::adapter::mpiio {
 
+/** Pointers to the real mpiio API */
 class API {
  public:
   /** MPI_Init */

--- a/adapter/posix/real_api.h
+++ b/adapter/posix/real_api.h
@@ -54,6 +54,7 @@ typedef int (*close_t)(int fd);
 
 namespace hermes::adapter::posix {
 
+/** Pointers to the real posix API */
 class API {
  public:
   /** MPI_Init */

--- a/adapter/stdio/real_api.h
+++ b/adapter/stdio/real_api.h
@@ -61,6 +61,7 @@ typedef long int (*ftell_t)(FILE * fp);
 
 namespace hermes::adapter::stdio {
 
+/** Pointers to the real stdio API */
 class API {
  public:
   /** MPI_Init */

--- a/hermes_shm/CMakeLists.txt
+++ b/hermes_shm/CMakeLists.txt
@@ -47,17 +47,17 @@ if(BUILD_MPI_TESTS)
 endif()
 
 # OpenMP
-if(BUILD_OpenMP_TESTS)
-    find_package(OpenMP REQUIRED COMPONENTS C CXX)
-    message(STATUS "found omp.h at ${OpenMP_CXX_INCLUDE_DIRS}")
-endif()
+#if(BUILD_OpenMP_TESTS)
+#    find_package(OpenMP REQUIRED COMPONENTS C CXX)
+#    message(STATUS "found omp.h at ${OpenMP_CXX_INCLUDE_DIRS}")
+#endif()
 
 ##################Build HermesShm main packages
 add_subdirectory(src)
 
 ##################MODULES & TESTS
 set(TEST_MAIN ${CMAKE_SOURCE_DIR}/test/unit)
-if (BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(test)
-endif()
+#if (BUILD_TESTS)
+#    enable_testing()
+#    add_subdirectory(test)
+#endif()

--- a/hermes_shm/CMakeLists.txt
+++ b/hermes_shm/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+###################OPTIONS
+option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" ON)
+option(BUILD_TESTS "Wether or not to build unit tests" OFF)
+option(BUILD_MPI_TESTS "Build tests which depend on MPI" OFF)
+option(BUILD_OpenMP_TESTS "Build tests which depend on OpenMP" OFF)
+option(BUILD_Boost_TESTS "Build tests which depend on libboost" OFF)
+
+##################CMAKE MODULES
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
+
+##################OPTIMIZATION
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("IN DEBUG MODE")
+    set(CMAKE_CXX_FLAGS "-g -O0")
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    message("IN RELEASE MODE")
+    set(CMAKE_CXX_FLAGS "-g -O3")
+endif()
+function(make_gprof exec_name exec_dir)
+    message("gprof -b -A -p -q ${exec_dir}/${exec_name} gmon.out > gprof_out.txt")
+    add_custom_target(
+      ${exec_name}_gprof
+      COMMAND gprof -b -A -p -q ${exec_dir}/${exec_name} gmon.out)
+endfunction()
+
+##################REQUIRED EXTERNAL LIBRARIES
+
+# YAML-CPP
+find_package(yaml-cpp REQUIRED)
+message(STATUS "found yaml-cpp at ${yaml-cpp_DIR}")
+
+# Catch2
+find_package(Catch2 3.0.1 REQUIRED)
+message(STATUS "found catch2.h at ${Catch2_CXX_INCLUDE_DIRS}")
+
+# MPICH
+if(BUILD_MPI_TESTS)
+    find_package(MPI REQUIRED COMPONENTS C CXX)
+    message(STATUS "found mpi.h at ${MPI_CXX_INCLUDE_DIRS}")
+endif()
+
+# OpenMP
+if(BUILD_OpenMP_TESTS)
+    find_package(OpenMP REQUIRED COMPONENTS C CXX)
+    message(STATUS "found omp.h at ${OpenMP_CXX_INCLUDE_DIRS}")
+endif()
+
+##################Build HermesShm main packages
+add_subdirectory(src)
+
+##################MODULES & TESTS
+set(TEST_MAIN ${CMAKE_SOURCE_DIR}/test/unit)
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/hermes_shm/CMakeLists.txt
+++ b/hermes_shm/CMakeLists.txt
@@ -32,19 +32,19 @@ endfunction()
 
 ##################REQUIRED EXTERNAL LIBRARIES
 
-# YAML-CPP
-find_package(yaml-cpp REQUIRED)
-message(STATUS "found yaml-cpp at ${yaml-cpp_DIR}")
-
-# Catch2
-find_package(Catch2 3.0.1 REQUIRED)
-message(STATUS "found catch2.h at ${Catch2_CXX_INCLUDE_DIRS}")
-
-# MPICH
-if(BUILD_MPI_TESTS)
-    find_package(MPI REQUIRED COMPONENTS C CXX)
-    message(STATUS "found mpi.h at ${MPI_CXX_INCLUDE_DIRS}")
-endif()
+## YAML-CPP
+#find_package(yaml-cpp REQUIRED)
+#message(STATUS "found yaml-cpp at ${yaml-cpp_DIR}")
+#
+## Catch2
+#find_package(Catch2 3.0.1 REQUIRED)
+#message(STATUS "found catch2.h at ${Catch2_CXX_INCLUDE_DIRS}")
+#
+## MPICH
+#if(BUILD_MPI_TESTS)
+#    find_package(MPI REQUIRED COMPONENTS C CXX)
+#    message(STATUS "found mpi.h at ${MPI_CXX_INCLUDE_DIRS}")
+#endif()
 
 # OpenMP
 #if(BUILD_OpenMP_TESTS)

--- a/hermes_shm/include/hermes_shm/constants/data_structure_singleton_macros.h
+++ b/hermes_shm/include/hermes_shm/constants/data_structure_singleton_macros.h
@@ -1,0 +1,27 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_CONSTANTS_DATA_STRUCTURE_SINGLETON_MACROS_H_H
+#define HERMES_SHM_INCLUDE_HERMES_SHM_CONSTANTS_DATA_STRUCTURE_SINGLETON_MACROS_H_H
+
+#include <hermes_shm/util/singleton.h>
+
+#define HERMES_SHM_SYSTEM_INFO scs::Singleton<hermes_shm::SystemInfo>::GetInstance()
+#define HERMES_SHM_SYSTEM_INFO_T hermes_shm::SystemInfo*
+
+#define HERMES_SHM_MEMORY_MANAGER scs::Singleton<hermes_shm::ipc::MemoryManager>::GetInstance()
+#define HERMES_SHM_MEMORY_MANAGER_T hermes_shm::ipc::MemoryManager*
+
+#define HERMES_SHM_THREAD_MANAGER scs::Singleton<hermes_shm::ThreadManager>::GetInstance()
+#define HERMES_SHM_THREAD_MANAGER_T hermes_shm::ThreadManager*
+
+#endif  // include_labstor_constants_data_structure_singleton_macros_h

--- a/hermes_shm/include/hermes_shm/constants/macros.h
+++ b/hermes_shm/include/hermes_shm/constants/macros.h
@@ -1,0 +1,30 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MACROS_H
+#define HERMES_SHM_MACROS_H
+
+#define KILOBYTES(n) ((size_t)(n) * (1<<10))
+#define MEGABYTES(n) ((size_t)(n) * (1<<20))
+#define GIGABYTES(n) ((size_t)(n) * (1<<30))
+
+#define TYPE_BITS(type) ((sizeof(type)*8))
+
+#define TYPE_WRAP(...) (__VA_ARGS__)
+
+#define TYPE_UNWRAP(X) ESC(ISH X)
+#define ISH(...) ISH __VA_ARGS__
+#define ESC(...) ESC_(__VA_ARGS__)
+#define ESC_(...) VAN ## __VA_ARGS__
+#define VANISH
+
+#endif  // HERMES_SHM_MACROS_H

--- a/hermes_shm/include/hermes_shm/data_structures/data_structure.h
+++ b/hermes_shm/include/hermes_shm/data_structures/data_structure.h
@@ -1,0 +1,22 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_DATA_STRUCTURE_H_
+#define HERMES_SHM_DATA_STRUCTURES_DATA_STRUCTURE_H_
+
+#include "internal/shm_archive.h"
+#include "internal/shm_container.h"
+#include "internal/shm_smart_ptr.h"
+#include "internal/shm_macros.h"
+#include "internal/shm_container.h"
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_DATA_STRUCTURE_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_archive.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_archive.h
@@ -1,0 +1,105 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_SHM_ARCHIVE_H_
+#define HERMES_SHM_DATA_STRUCTURES_SHM_ARCHIVE_H_
+
+#include "hermes_shm/memory/memory_manager.h"
+#include "shm_macros.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * Indicates that a data structure can be stored directly in memory or
+ * shared memory.
+ * */
+class ShmPredictable {};
+
+/**
+ * Indicates that a data structure can be archived in shared memory
+ * and has a corresponding TypedPointer override.
+ * */
+class ShmArchiveable : public ShmPredictable {
+  /**
+   * Initialize a SHM data structure in shared-memory.
+   * Constructors may wrap around these.
+   * */
+  // void shm_init(...);
+
+  /**
+   * Destroys the shared-memory allocated by the object.
+   * Destructors may wrap around this.
+   * */
+  // void shm_destroy();
+
+  /**
+   * Deep copy of an object. Wrapped by copy constructor
+   * */
+  // void shm_strong_copy(const CLASS_NAME &other);
+  // SHM_INHERIT_COPY_OPS(CLASS_NAME)
+
+  /**
+   * Copies only the object's pointers.
+   * */
+  // void WeakCopy(const CLASS_NAME &other);
+
+  /**
+   * Moves the object's contents into another object
+   * */
+  // void shm_weak_move(CLASS_NAME &other);
+  // SHM_INHERIT_MOVE_OPS(CLASS_NAME)
+
+  /**
+   * Store object into a TypedPointer
+   * */
+  // void shm_serialize(TypedPointer<TYPED_CLASS> &ar) const;
+  // SHM_SERIALIZE_OPS(TYPED_CLASS)
+
+  /**
+   * Construct object from a TypedPointer.
+   * */
+  // void shm_deserialize(const TypedPointer<TYPED_CLASS> &ar);
+  // SHM_DESERIALIZE_OPS(TYPED_CLASS)
+};
+
+/**
+ * Enables a specific TypedPointer type to be serialized
+ * */
+#define SHM_SERIALIZE_OPS(TYPED_CLASS)\
+  void operator>>(hipc::TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+    shm_serialize(ar);\
+  }\
+  void operator>>(hipc::TypedAtomicPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+    shm_serialize(ar);\
+  }
+
+/**
+ * Enables a specific TypedPointer type to be deserialized
+ * */
+#define SHM_DESERIALIZE_OPS(TYPED_CLASS)\
+  void operator<<(const hipc::TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) {\
+    shm_deserialize(ar);\
+  }\
+  void operator<<(\
+    const hipc::TypedAtomicPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) {\
+    shm_deserialize(ar);\
+  }
+
+/** Enables serialization + deserialization for data structures */
+#define SHM_SERIALIZE_DESERIALIZE_OPS(AR_TYPE)\
+  SHM_SERIALIZE_OPS(AR_TYPE)\
+  SHM_DESERIALIZE_OPS(AR_TYPE)
+
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_SHM_ARCHIVE_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_archive_or_t.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_archive_or_t.h
@@ -1,0 +1,249 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_SHM_AR_H_
+#define HERMES_SHM_DATA_STRUCTURES_SHM_AR_H_
+
+#include "hermes_shm/memory/memory.h"
+#include "hermes_shm/data_structures/data_structure.h"
+#include "hermes_shm/types/tuple_base.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * Constructs a TypedPointer in-place
+ * */
+template<typename T>
+class _ShmHeaderOrT_Header {
+ public:
+  typedef typename T::header_t header_t;
+  header_t obj_hdr_;
+
+ public:
+  /** Default constructor */
+  _ShmHeaderOrT_Header() = default;
+
+  /** Construct + store object */
+  template<typename ...Args>
+  explicit _ShmHeaderOrT_Header(Allocator *alloc, Args&& ...args) {
+    T(obj_hdr_, alloc, std::forward<Args>(args)...).UnsetDestructable();
+  }
+
+  /** Construct + store object (hermes_shm rval argpack) */
+  template<typename ArgPackT>
+  void PiecewiseInit(Allocator *alloc,
+                     ArgPackT &&args) {
+    T obj;
+    PassArgPack::Call(
+      MergeArgPacks::Merge(make_argpack(obj, obj_hdr_, alloc),
+                           std::forward<ArgPackT>(args)),
+      [](auto&& ...Args) constexpr {
+        Allocator::ConstructObj<T>(std::forward<decltype(Args)>(Args)...);
+      });
+    obj.UnsetDestructable();
+  }
+
+  /** Destructor */
+  ~_ShmHeaderOrT_Header() = default;
+
+  /** Shm destructor */
+  void shm_destroy(Allocator *alloc) {
+    auto ar = internal_ref(alloc);
+    T obj;
+    obj.shm_deserialize(ar);
+    obj.shm_destroy();
+  }
+
+  /** Returns a reference to the internal object */
+  TypedPointer<T> internal_ref(Allocator *alloc) {
+    return TypedPointer<T>(alloc->Convert<header_t, Pointer>(&obj_hdr_));
+  }
+
+  /** Returns a reference to the internal object */
+  TypedPointer<T> internal_ref(Allocator *alloc) const {
+    return TypedPointer<T>(alloc->Convert<header_t, Pointer>(&obj_hdr_));
+  }
+
+  /** Move constructor */
+  _ShmHeaderOrT_Header(_ShmHeaderOrT_Header &&other) noexcept
+  : obj_hdr_(std::move(other.obj_hdr_)) {}
+
+  /** Move assignment operator */
+  _ShmHeaderOrT_Header& operator=(_ShmHeaderOrT_Header &&other) noexcept {
+    obj_hdr_ = std::move(other.obj_hdr_);
+    return *this;
+  }
+
+  /** Copy constructor */
+  _ShmHeaderOrT_Header(const _ShmHeaderOrT_Header &other)
+  : obj_hdr_(other.obj_hdr_) {
+  }
+
+  /** Copy assignment operator */
+  _ShmHeaderOrT_Header& operator=(const _ShmHeaderOrT_Header &other) {
+    obj_hdr_ = other.obj_hdr_;
+  }
+};
+
+/**
+ * Constructs an object in-place
+ * */
+template<typename T>
+class _ShmHeaderOrT_T {
+ public:
+  char obj_[sizeof(T)]; /**< Store object without constructing */
+
+ public:
+  /** Default constructor */
+  _ShmHeaderOrT_T() {
+    Allocator::ConstructObj<T>(internal_ref(nullptr));
+  }
+
+  /** Construct + store object (C++ argpack) */
+  template<typename ...Args>
+  explicit _ShmHeaderOrT_T(Allocator *alloc, Args&& ...args) {
+    Allocator::ConstructObj<T>(
+      internal_ref(alloc), std::forward<Args>(args)...);
+  }
+
+  /** Construct + store object (hermes_shm rval argpack) */
+  template<typename ArgPackT>
+  void PiecewiseInit(Allocator *alloc,
+                     ArgPackT &&args) {
+    hermes_shm::PassArgPack::Call(
+      MergeArgPacks::Merge(
+        make_argpack(internal_ref(alloc)),
+        std::forward<ArgPackT>(args)),
+      [](auto&& ...Args) constexpr {
+        Allocator::ConstructObj<T>(std::forward<decltype(Args)>(Args)...);
+      });
+  }
+
+  /** Shm destructor */
+  void shm_destroy(Allocator *alloc) {}
+
+  /** Destructor. Does nothing. */
+   ~_ShmHeaderOrT_T() = default;
+
+  /** Returns a reference to the internal object */
+  T& internal_ref(Allocator *alloc) {
+    (void) alloc;
+    return reinterpret_cast<T&>(obj_);
+  }
+
+  /** Returns a reference to the internal object */
+  T& internal_ref(Allocator *alloc) const {
+    (void) alloc;
+    return reinterpret_cast<T&>(obj_);
+  }
+
+  /** Move constructor */
+  _ShmHeaderOrT_T(_ShmHeaderOrT_T &&other) noexcept {
+    Allocator::ConstructObj<_ShmHeaderOrT_T>(
+      obj_, std::move(other.internal_ref()));
+  }
+
+  /** Move assignment operator */
+  _ShmHeaderOrT_T& operator=(_ShmHeaderOrT_T &&other) noexcept {
+    internal_ref() = std::move(other.internal_ref());
+    return *this;
+  }
+
+  /** Copy constructor */
+  _ShmHeaderOrT_T(const _ShmHeaderOrT_T &other) {
+    Allocator::ConstructObj<_ShmHeaderOrT_T>(
+      obj_, other);
+  }
+
+  /** Copy assignment operator */
+  _ShmHeaderOrT_T& operator=(const _ShmHeaderOrT_T &other) {
+    internal_ref() = other.internal_ref();
+    return *this;
+  }
+};
+
+/**
+ * Whether or not to use _ShmHeaderOrT or _ShmHeaderOrT_T
+ * */
+#define SHM_MAKE_HEADER_OR_T(T) \
+  SHM_X_OR_Y(T, _ShmHeaderOrT_Header<T>, _ShmHeaderOrT_T<T>)
+
+/**
+ * Used for data structures which intend to store:
+ * 1. An archive if the data type is SHM_ARCHIVEABLE
+ * 2. The raw type if the data type is anything else
+ *
+ * E.g., used in unordered_map for storing collision entries.
+ * E.g., used in a list for storing list entries.
+ * */
+template<typename T>
+class ShmHeaderOrT {
+ public:
+  typedef SHM_ARCHIVE_OR_REF(T) T_Ar;
+  typedef SHM_MAKE_HEADER_OR_T(T) T_Hdr;
+  T_Hdr obj_;
+
+  /** Default constructor */
+  ShmHeaderOrT() = default;
+
+  /** Construct + store object */
+  template<typename ...Args>
+  explicit ShmHeaderOrT(Args&& ...args)
+  : obj_(std::forward<Args>(args)...) {}
+
+  /** Construct + store object (hermes_shm rval argpack) */
+  template<typename ArgPackT>
+  void PiecewiseInit(Allocator *alloc, ArgPackT &&args) {
+    obj_.PiecewiseInit(alloc, std::forward<ArgPackT>(args));
+  }
+
+  /** Destructor */
+  ~ShmHeaderOrT() = default;
+
+  /** Returns a reference to the internal object */
+  T_Ar internal_ref(Allocator *alloc) {
+    return obj_.internal_ref(alloc);
+  }
+
+  /** Returns a reference to the internal object */
+  T_Ar internal_ref(Allocator *alloc) const {
+    return obj_.internal_ref(alloc);
+  }
+
+  /** Shm destructor */
+  void shm_destroy(Allocator *alloc) {
+    obj_.shm_destroy(alloc);
+  }
+
+  /** Move constructor */
+  ShmHeaderOrT(ShmHeaderOrT &&other) noexcept
+  : obj_(std::move(other.obj_)) {}
+
+  /** Move assignment operator */
+  ShmHeaderOrT& operator=(ShmHeaderOrT &&other) noexcept {
+    obj_ = std::move(other.obj_);
+    return *this;
+  }
+
+  /** Copy constructor */
+  ShmHeaderOrT(const ShmHeaderOrT &other)
+  : obj_(other.obj_) {}
+
+  /** Copy assignment operator */
+  ShmHeaderOrT& operator=(const ShmHeaderOrT &other) {
+    obj_ = other.obj_;
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_SHM_AR_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_container.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_container.h
@@ -1,0 +1,84 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_SHM_CONTAINER_H_
+#define HERMES_SHM_SHM_CONTAINER_H_
+
+#include "hermes_shm/memory/memory_manager.h"
+#include "hermes_shm/constants/macros.h"
+#include "shm_container_macro.h"
+#include "shm_macros.h"
+#include "shm_archive.h"
+#include "shm_ref.h"
+#include "shm_deserialize.h"
+
+namespace hipc = hermes_shm::ipc;
+
+namespace hermes_shm::ipc {
+
+/** Bits used for determining how to destroy an object */
+/// The container's header has been allocated
+#define SHM_CONTAINER_VALID BIT_OPT(uint16_t, 0)
+/// The container header is initialized
+#define SHM_CONTAINER_DATA_VALID BIT_OPT(uint16_t, 1)
+/// The header was allocated by this container
+#define SHM_CONTAINER_HEADER_DESTRUCTABLE BIT_OPT(uint16_t, 2)
+/// The container should free all data when destroyed
+#define SHM_CONTAINER_DESTRUCTABLE BIT_OPT(uint16_t, 3)
+
+/** The shared-memory header used for data structures */
+template<typename T>
+struct ShmHeader;
+
+/** The ShmHeader used for base containers */
+struct ShmBaseHeader {
+  bitfield32_t flags_;
+
+  /** Default constructor */
+  ShmBaseHeader() = default;
+
+  /** Copy constructor */
+  ShmBaseHeader(const ShmBaseHeader &other) {}
+
+  /** Copy assignment operator */
+  ShmBaseHeader& operator=(const ShmBaseHeader &other) {
+    return *this;
+  }
+
+  /**
+   * Disable copying of the flag field, as all flags
+   * pertain to a particular ShmHeader allocation.
+   * */
+  void strong_copy(const ShmBaseHeader &other) {}
+
+  /** Publicize bitfield operations */
+  INHERIT_BITFIELD_OPS(flags_, uint16_t)
+};
+
+/** The ShmHeader used for wrapper containers */
+struct ShmWrapperHeader {};
+
+/**
+ * ShmContainers all have a header, which is stored in
+ * shared memory as a TypedPointer.
+ * */
+class ShmContainer : public ShmArchiveable {};
+
+/** Typed nullptr */
+template<typename T>
+static inline T* typed_nullptr() {
+  return reinterpret_cast<T*>(NULL);
+}
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_SHM_CONTAINER_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_container_extend_macro.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_container_extend_macro.h
@@ -1,0 +1,255 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXTEND_MACRO_H_
+#define HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXTEND_MACRO_H_
+#define SHM_CONTAINER_EXTEND_TEMPLATE(CLASS_NAME,TYPED_CLASS,TYPED_HEADER)\
+public:\
+/**====================================\
+ * Variables & Types\
+ *===================================*/\
+\
+typedef TYPE_UNWRAP(TYPED_HEADER) header_t; /**< Required by all ShmContainers */\
+header_t *header_; /**< The shared-memory header for this container */\
+ContainerT obj_; /**< The object being wrapped around */\
+\
+public:\
+/**====================================\
+ * Constructors\
+ * ===================================*/\
+\
+/** Constructor. Allocate header with default allocator. */\
+template<typename ...Args>\
+explicit TYPE_UNWRAP(CLASS_NAME)(Args &&...args) {\
+shm_init(std::forward<Args>(args)...);\
+}\
+\
+/** Constructor. Allocate header with default allocator. */\
+template<typename ...Args>\
+void shm_init(Args &&...args) {\
+}\
+\
+/**====================================\
+ * Serialization\
+ * ===================================*/\
+\
+/** Serialize into a Pointer */\
+void shm_serialize(TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+  obj_.shm_serialize(ar);\
+}\
+\
+/** Serialize into an AtomicPointer */\
+void shm_serialize(TypedAtomicPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+  obj_.shm_serialize(ar);\
+}\
+\
+/** Override << operators */\
+SHM_SERIALIZE_OPS((TYPE_UNWRAP(TYPED_CLASS)))\
+\
+/**====================================\
+ * Deserialization\
+ * ===================================*/\
+\
+/** Deserialize object from a raw pointer */\
+bool shm_deserialize(const TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) {\
+  return obj_.shm_deserialize(ar);\
+}\
+\
+/** Deserialize object from allocator + offset */\
+bool shm_deserialize(Allocator *alloc, OffsetPointer header_ptr) {\
+  return obj_.shm_deserialize(alloc, header_ptr);\
+}\
+\
+/** Deserialize object from another object (weak copy) */\
+bool shm_deserialize(const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  return obj_.shm_deserialize(other);\
+}\
+\
+/** Deserialize object from allocator + header */\
+bool shm_deserialize(Allocator *alloc,\
+                     TYPE_UNWRAP(TYPED_HEADER) *header) {\
+  return obj_.shm_deserialize(alloc, header);\
+}\
+\
+/** Constructor. Deserialize the object from the reference. */\
+template<typename ...Args>\
+void shm_init(hipc::ShmRef<TYPE_UNWRAP(TYPED_CLASS)> &obj) {\
+  shm_deserialize(obj->GetAllocator(), obj->header_);\
+}\
+\
+/** Override >> operators */\
+SHM_DESERIALIZE_OPS ((TYPE_UNWRAP(TYPED_CLASS)))\
+\
+/**====================================\
+ * Destructors\
+ * ===================================*/\
+\
+/** Destructor */\
+~TYPE_UNWRAP(CLASS_NAME)() {\
+  obj_.shm_destroy(true);\
+}\
+\
+/** Shm Destructor */\
+void shm_destroy(bool destroy_header = true) {\
+  obj_.shm_destroy(false);\
+  if (!IsValid()) { return; }\
+  if (IsDataValid()) {\
+    shm_destroy_main();\
+  }\
+  UnsetDataValid();\
+  if (destroy_header &&\
+    obj_.header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {\
+    GetAllocator()->template\
+      FreePtr<TYPE_UNWRAP(TYPED_HEADER)>(header_);\
+    UnsetValid();\
+  }\
+}\
+\
+/**====================================\
+ * Move Operations\
+ * ===================================*/\
+\
+/** Move constructor */\
+TYPE_UNWRAP(CLASS_NAME)(TYPE_UNWRAP(CLASS_NAME) &&other) noexcept\
+: obj_(std::move(other)) {}\
+\
+/** Move assignment operator */\
+TYPE_UNWRAP(CLASS_NAME)& operator=(TYPE_UNWRAP(CLASS_NAME) &&other) noexcept {\
+obj_ = std::move(other.obj_);\
+return *this;\
+}\
+\
+/** Move shm_init constructor */\
+void shm_init_main(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   TYPE_UNWRAP(CLASS_NAME) &&other) noexcept {\
+  shm_weak_move(header, alloc, other);\
+}\
+\
+/** Move operation */\
+void shm_weak_move(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   TYPE_UNWRAP(CLASS_NAME) &other) {\
+  obj_.shm_weak_move(header, alloc, other);\
+}\
+\
+/**====================================\
+ * Copy Operations\
+ * ===================================*/\
+\
+/** Copy constructor */\
+TYPE_UNWRAP(CLASS_NAME)(const TYPE_UNWRAP(CLASS_NAME) &other) noexcept {\
+  shm_init(other);\
+}\
+\
+/** Copy assignment constructor */\
+TYPE_UNWRAP(CLASS_NAME) &operator=(const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (this != &other) {\
+    shm_strong_copy(\
+      typed_nullptr<TYPE_UNWRAP(TYPED_HEADER) >(),\
+      typed_nullptr<Allocator>(),\
+      other);\
+  }\
+  return *this;\
+}\
+\
+/** Copy shm_init constructor */\
+void shm_init_main(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  shm_strong_copy(header, alloc, other);\
+}\
+\
+/** Strong Copy operation */\
+void shm_strong_copy(TYPE_UNWRAP(TYPED_HEADER) *header, hipc::Allocator *alloc,\
+                     const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (other.IsNull()) { return; }\
+  shm_destroy(false);\
+  shm_strong_copy_main(header, alloc, other);\
+  SetDestructable();\
+}\
+\
+/**====================================\
+ * Container Flag Operations\
+ * ===================================*/\
+\
+/** Sets this object as destructable */\
+void SetDestructable() {\
+  obj_.SetDestructable();\
+}\
+\
+/** Sets this object as not destructable */\
+void UnsetDestructable() {\
+  obj_.UnsetDestructable();\
+}\
+\
+/** Check if this container is destructable */\
+bool IsDestructable() const {\
+  return obj_.IsDestructable();\
+}\
+\
+/** Check if container has a valid header */\
+bool IsValid() const {\
+  return obj_.IsValid();\
+}\
+\
+/** Set container header invalid */\
+void UnsetValid() {\
+  obj_.UnsetValid();\
+}\
+\
+/**====================================\
+ * Header Flag Operations\
+ * ===================================*/\
+\
+/** Check if header's data is valid */\
+bool IsDataValid() const {\
+  return obj_.IsDataValid();\
+}\
+\
+/** Check if header's data is valid */\
+void UnsetDataValid() const {\
+  return obj_.UnsetDataValid();\
+}\
+\
+/** Check if null */\
+bool IsNull() const {\
+  return obj_.IsNull();\
+}\
+\
+/** Get a typed pointer to the object */\
+template<typename POINTER_T>\
+POINTER_T GetShmPointer() const {\
+  return GetAllocator()->template\
+    Convert<TYPE_UNWRAP(TYPED_HEADER), POINTER_T>(header_);\
+}\
+\
+/**====================================\
+ * Query Operations\
+ * ===================================*/\
+\
+/** Get the allocator for this container */\
+Allocator* GetAllocator() {\
+  return obj_.GetAllocator();\
+}\
+\
+/** Get the allocator for this container */\
+Allocator* GetAllocator() const {\
+  return obj_.GetAllocator();\
+}\
+\
+/** Get the shared-memory allocator id */\
+allocator_id_t GetAllocatorId() const {\
+  return GetAllocator()->GetId();\
+}\
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXTEND_MACRO_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_container_macro.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_container_macro.h
@@ -1,0 +1,360 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_MACRO_H_
+#define HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_MACRO_H_
+#define SHM_CONTAINER_TEMPLATE(CLASS_NAME,TYPED_CLASS,TYPED_HEADER)\
+public:\
+/**====================================\
+ * Variables & Types\
+ * ===================================*/\
+\
+typedef TYPE_UNWRAP(TYPED_HEADER) header_t; /** Header type query */\
+header_t *header_; /**< Header of the shared-memory data structure */\
+hipc::Allocator *alloc_; /**< hipc::Allocator used for this data structure */\
+hermes_shm::bitfield32_t flags_; /**< Flags used data structure status */\
+\
+public:\
+/**====================================\
+ * Constructors\
+ * ===================================*/\
+\
+/** Constructor. Allocate header with default allocator. */\
+template<typename ...Args>\
+explicit TYPE_UNWRAP(CLASS_NAME)(Args&& ...args) {\
+shm_init(std::forward<Args>(args)...);\
+}\
+\
+/** Constructor. Allocate header with default allocator. */\
+template<typename ...Args>\
+void shm_init(Args&& ...args) {\
+  shm_destroy(false);\
+  shm_init_main(hipc::typed_nullptr<TYPE_UNWRAP(TYPED_HEADER)>(),\
+                hipc::typed_nullptr<hipc::Allocator>(),\
+                std::forward<Args>(args)...);\
+}\
+\
+/** Constructor. Allocate header with specific allocator. */\
+template<typename ...Args>\
+void shm_init(hipc::Allocator *alloc, Args&& ...args) {\
+  shm_destroy(false);\
+  shm_init_main(hipc::typed_nullptr<TYPE_UNWRAP(TYPED_HEADER)>(),\
+                alloc,\
+                std::forward<Args>(args)...);\
+}\
+\
+/** Constructor. Initialize an already-allocated header. */\
+template<typename ...Args>\
+void shm_init(TYPE_UNWRAP(TYPED_HEADER) &header,\
+              hipc::Allocator *alloc, Args&& ...args) {\
+  shm_destroy(false);\
+  shm_init_main(&header, alloc, std::forward<Args>(args)...);\
+}\
+\
+/** Initialize the data structure's allocator */\
+inline void shm_init_allocator(hipc::Allocator *alloc) {\
+  if (IsValid()) { return; }\
+  if (alloc == nullptr) {\
+    alloc_ = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();\
+  } else {\
+    alloc_ = alloc;\
+  }\
+}\
+\
+/**\
+ * Initialize a data structure's header.\
+ * A container will never re-set or re-allocate its header once it has\
+ * been set the first time.\
+ * */\
+template<typename ...Args>\
+void shm_init_header(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                     Args&& ...args) {\
+  if (IsValid()) {\
+    header_->SetBits(SHM_CONTAINER_DATA_VALID);\
+  } else if (header == nullptr) {\
+    hipc::Pointer p;\
+    header_ = alloc_->template\
+      AllocateConstructObjs<TYPE_UNWRAP(TYPED_HEADER)>(\
+      1, p, std::forward<Args>(args)...);\
+    header_->SetBits(\
+      SHM_CONTAINER_DATA_VALID |\
+        SHM_CONTAINER_HEADER_DESTRUCTABLE);\
+    flags_.SetBits(\
+      SHM_CONTAINER_VALID |\
+        SHM_CONTAINER_DESTRUCTABLE);\
+  } else {\
+    hipc::Pointer header_ptr;\
+    header_ = header;\
+    hipc::Allocator::ConstructObj<TYPE_UNWRAP(TYPED_HEADER)>(\
+      *header_, std::forward<Args>(args)...);\
+    header_->SetBits(\
+      SHM_CONTAINER_DATA_VALID);\
+    flags_.SetBits(\
+      SHM_CONTAINER_VALID |\
+        SHM_CONTAINER_DESTRUCTABLE);\
+  }\
+}\
+\
+/**====================================\
+ * Serialization\
+ * ===================================*/\
+\
+/** Serialize into a Pointer */\
+void shm_serialize(hipc::TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+  ar = alloc_->template\
+    Convert<TYPE_UNWRAP(TYPED_HEADER), hipc::Pointer>(header_);\
+  shm_serialize_main();\
+}\
+\
+/** Serialize into an AtomicPointer */\
+void shm_serialize(hipc::TypedAtomicPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) const {\
+  ar = alloc_->template\
+    Convert<TYPE_UNWRAP(TYPED_HEADER), hipc::AtomicPointer>(header_);\
+  shm_serialize_main();\
+}\
+\
+/** Override << operators */\
+SHM_SERIALIZE_OPS((TYPE_UNWRAP(TYPED_CLASS)))\
+\
+/**====================================\
+ * Deserialization\
+ * ===================================*/\
+\
+/** Deserialize object from a raw pointer */\
+bool shm_deserialize(const hipc::TypedPointer<TYPE_UNWRAP(TYPED_CLASS)> &ar) {\
+  return shm_deserialize(\
+    HERMES_SHM_MEMORY_MANAGER->GetAllocator(ar.allocator_id_),\
+    ar.ToOffsetPointer()\
+  );\
+}\
+\
+/** Deserialize object from allocator + offset */\
+bool shm_deserialize(hipc::Allocator *alloc, hipc::OffsetPointer header_ptr) {\
+  if (header_ptr.IsNull()) { return false; }\
+  return shm_deserialize(alloc,\
+                         alloc->Convert<\
+                           TYPE_UNWRAP(TYPED_HEADER),\
+                           hipc::OffsetPointer>(header_ptr));\
+}\
+\
+/** Deserialize object from another object (weak copy) */\
+bool shm_deserialize(const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (other.IsNull()) { return false; }\
+  return shm_deserialize(other.GetAllocator(), other.header_);\
+}\
+\
+/** Deserialize object from allocator + header */\
+bool shm_deserialize(hipc::Allocator *alloc,\
+                     TYPE_UNWRAP(TYPED_HEADER) *header) {\
+  flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);\
+  alloc_ = alloc;\
+  header_ = header;\
+  flags_.SetBits(SHM_CONTAINER_VALID);\
+  shm_deserialize_main();\
+  return true;\
+}\
+\
+/** Constructor. Deserialize the object from the reference. */\
+template<typename ...Args>\
+void shm_init(hipc::ShmRef<TYPE_UNWRAP(TYPED_CLASS)> &obj) {\
+  shm_deserialize(obj->GetAllocator(), obj->header_);\
+}\
+\
+/** Override >> operators */\
+SHM_DESERIALIZE_OPS((TYPE_UNWRAP(TYPED_CLASS)))\
+\
+/**====================================\
+ * Destructors\
+ * ===================================*/\
+\
+/** Destructor */\
+~TYPE_UNWRAP(CLASS_NAME)() {\
+  if (IsDestructable()) {\
+    shm_destroy(true);\
+  }\
+}\
+\
+/** Shm Destructor */\
+void shm_destroy(bool destroy_header = true) {\
+  if (!IsValid()) { return; }\
+  if (IsDataValid()) {\
+    shm_destroy_main();\
+  }\
+  UnsetDataValid();\
+  if (destroy_header &&\
+    header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {\
+    alloc_->FreePtr<TYPE_UNWRAP(TYPED_HEADER)>(header_);\
+    UnsetValid();\
+  }\
+}\
+\
+/**====================================\
+ * Move Operations\
+ * ===================================*/\
+\
+/** Move constructor */\
+TYPE_UNWRAP(CLASS_NAME)(TYPE_UNWRAP(CLASS_NAME) &&other) noexcept {\
+shm_weak_move(\
+  hipc::typed_nullptr<TYPE_UNWRAP(TYPED_HEADER)>(),\
+  hipc::typed_nullptr<hipc::Allocator>(),\
+  other);\
+}\
+\
+/** Move assignment operator */\
+TYPE_UNWRAP(CLASS_NAME)& operator=(TYPE_UNWRAP(CLASS_NAME) &&other) noexcept {\
+if (this != &other) {\
+shm_weak_move(\
+  hipc::typed_nullptr<TYPE_UNWRAP(TYPED_HEADER)>(),\
+  hipc::typed_nullptr<hipc::Allocator>(),\
+  other);\
+}\
+return *this;\
+}\
+\
+/** Move shm_init constructor */\
+void shm_init_main(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   TYPE_UNWRAP(CLASS_NAME) &&other) noexcept {\
+  shm_weak_move(header, alloc, other);\
+}\
+\
+/** Move operation */\
+void shm_weak_move(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (other.IsNull()) { return; }\
+  if (IsValid() && other.GetAllocator() != GetAllocator()) {\
+    shm_strong_copy(header, alloc, other);\
+    other.shm_destroy(true);\
+    return;\
+  }\
+  shm_destroy(false);\
+  shm_weak_move_main(header, alloc, other);\
+  if (!other.IsDestructable()) {\
+    UnsetDestructable();\
+  }\
+  other.UnsetDataValid();\
+  other.shm_destroy(true);\
+}\
+\
+/**====================================\
+ * Copy Operations\
+ * ===================================*/\
+\
+/** Copy constructor */\
+TYPE_UNWRAP(CLASS_NAME)(const TYPE_UNWRAP(CLASS_NAME) &other) noexcept {\
+  shm_init(other);\
+}\
+\
+/** Copy assignment constructor */\
+TYPE_UNWRAP(CLASS_NAME)& operator=(const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (this != &other) {\
+    shm_strong_copy(\
+      hipc::typed_nullptr<TYPE_UNWRAP(TYPED_HEADER)>(),\
+      hipc::typed_nullptr<hipc::Allocator>(),\
+      other);\
+  }\
+  return *this;\
+}\
+\
+/** Copy shm_init constructor */\
+void shm_init_main(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                   hipc::Allocator *alloc,\
+                   const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  shm_strong_copy(header, alloc, other);\
+}\
+\
+/** Strong Copy operation */\
+void shm_strong_copy(TYPE_UNWRAP(TYPED_HEADER) *header,\
+                     hipc::Allocator *alloc,\
+                     const TYPE_UNWRAP(CLASS_NAME) &other) {\
+  if (other.IsNull()) { return; }\
+  shm_destroy(false);\
+  shm_strong_copy_main(header, alloc, other);\
+  SetDestructable();\
+}\
+\
+/**====================================\
+ * Container Flag Operations\
+ * ===================================*/\
+\
+/** Sets this object as destructable */\
+void SetDestructable() {\
+  flags_.SetBits(SHM_CONTAINER_DESTRUCTABLE);\
+}\
+\
+/** Sets this object as not destructable */\
+void UnsetDestructable() {\
+  flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);\
+}\
+\
+/** Check if this container is destructable */\
+bool IsDestructable() const {\
+  return flags_.OrBits(SHM_CONTAINER_DESTRUCTABLE);\
+}\
+\
+/** Check if container has a valid header */\
+bool IsValid() const {\
+  return flags_.OrBits(SHM_CONTAINER_VALID);\
+}\
+\
+/** Set container header invalid */\
+void UnsetValid() {\
+  flags_.UnsetBits(SHM_CONTAINER_VALID |\
+    SHM_CONTAINER_DESTRUCTABLE | SHM_CONTAINER_HEADER_DESTRUCTABLE);\
+}\
+\
+/**====================================\
+ * Header Flag Operations\
+ * ===================================*/\
+\
+/** Check if header's data is valid */\
+bool IsDataValid() const {\
+  return header_->OrBits(SHM_CONTAINER_DATA_VALID);\
+}\
+\
+/** Check if header's data is valid */\
+void UnsetDataValid() const {\
+  header_->UnsetBits(SHM_CONTAINER_DATA_VALID);\
+}\
+\
+/** Check if null */\
+bool IsNull() const {\
+  return !IsValid() || !IsDataValid();\
+}\
+\
+/** Get a typed pointer to the object */\
+template<typename POINTER_T>\
+POINTER_T GetShmPointer() const {\
+  return alloc_->Convert<TYPE_UNWRAP(TYPED_HEADER), POINTER_T>(header_);\
+}\
+\
+/**====================================\
+ * Query Operations\
+ * ===================================*/\
+\
+/** Get the allocator for this container */\
+hipc::Allocator* GetAllocator() {\
+  return alloc_;\
+}\
+\
+/** Get the allocator for this container */\
+hipc::Allocator* GetAllocator() const {\
+  return alloc_;\
+}\
+\
+/** Get the shared-memory allocator id */\
+hipc::allocator_id_t GetAllocatorId() const {\
+  return alloc_->GetId();\
+}\
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_MACRO_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_deserialize.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_deserialize.h
@@ -1,0 +1,92 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_DESERIALIZE_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_DESERIALIZE_H_
+
+#include "hermes_shm/memory/memory_manager.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * The parameters used to deserialize an object.
+ * */
+template<typename ContainerT>
+struct ShmDeserialize {
+ public:
+  typedef typename ContainerT::header_t header_t;
+  Allocator *alloc_;
+  header_t *header_;
+
+ public:
+  /** Default constructor */
+  ShmDeserialize() = default;
+
+  /** Construct from TypedPointer */
+  ShmDeserialize(const TypedPointer<ContainerT> &ar) {
+    alloc_ = HERMES_SHM_MEMORY_MANAGER->GetAllocator(ar.allocator_id_);
+    header_ = alloc_->Convert<
+      TypedPointer<ContainerT>,
+      OffsetPointer>(ar.ToOffsetPointer());
+  }
+
+  /** Construct from allocator + offset pointer */
+  ShmDeserialize(Allocator *alloc, TypedOffsetPointer<ContainerT> &ar) {
+    alloc_ = alloc;
+    header_ = alloc_->Convert<
+      TypedPointer<ContainerT>,
+      OffsetPointer>(ar.ToOffsetPointer());
+  }
+
+  /** Construct from allocator + offset pointer */
+  ShmDeserialize(Allocator *alloc, header_t *header) {
+    alloc_ = alloc;
+    header_ = header;
+  }
+
+  /** Copy constructor */
+  ShmDeserialize(const ShmDeserialize &other) {
+    shm_strong_copy(other);
+  }
+
+  /** Copy assign operator */
+  ShmDeserialize& operator=(const ShmDeserialize &other) {
+    shm_strong_copy(other);
+    return *this;
+  }
+
+  /** Copy operation */
+  void shm_strong_copy(const ShmDeserialize &other) {
+    alloc_ = other.alloc_;
+    header_ = other.header_;
+  }
+
+  /** Move constructor */
+  ShmDeserialize(ShmDeserialize &&other) {
+    shm_weak_move(other);
+  }
+
+  /** Move assign operator */
+  ShmDeserialize& operator=(ShmDeserialize &&other) {
+    shm_weak_move();
+    return *this;
+  }
+
+  /** Move operation */
+  void shm_weak_move(ShmDeserialize &other) {
+    shm_strong_copy(other);
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_DESERIALIZE_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_macros.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_macros.h
@@ -1,0 +1,80 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_SHM_MACROS_H_
+#define HERMES_SHM_MEMORY_SHM_MACROS_H_
+
+#include <hermes_shm/constants/macros.h>
+
+/**
+ * Determine whether or not \a T type is designed for shared memory
+ * */
+#define IS_SHM_ARCHIVEABLE(T) \
+  std::is_base_of<hermes_shm::ipc::ShmArchiveable, T>::value
+
+/**
+ * Determine whether or not \a T type is a SHM smart pointer
+ * */
+#define IS_SHM_SMART_POINTER(T) \
+  std::is_base_of<hermes_shm::ipc::ShmSmartPointer, T>::value
+
+/**
+ * SHM_X_OR_Y: X if T is SHM_SERIALIZEABLE, Y otherwise
+ * */
+#define SHM_X_OR_Y(T, X, Y) \
+  typename std::conditional<         \
+    IS_SHM_ARCHIVEABLE(T), \
+    X, Y>::type
+
+/**
+ * SHM_T_OR_PTR_T: Returns T if SHM_ARCHIVEABLE, and T* otherwise. Used
+ * internally by hipc::ShmRef<T>.
+ *
+ * @param T: The type being stored in the shmem data structure
+ * */
+#define SHM_T_OR_PTR_T(T) \
+  SHM_X_OR_Y(T, T, T*)
+
+/**
+ * ShmHeaderOrT: Returns TypedPointer<T> if SHM_ARCHIVEABLE, and T
+ * otherwise. Used to construct an hipc::ShmRef<T>.
+ *
+ * @param T The type being stored in the shmem data structure
+ * */
+#define SHM_ARCHIVE_OR_T(T) \
+  SHM_X_OR_Y(T, hipc::TypedPointer<T>, T)
+
+/**
+ * SHM_T_OR_SHM_STRUCT_T: Used by unique_ptr and manual_ptr to internally
+ * store either a shm-compatible type or a POD (piece of data) type.
+ *
+ * @param T: The type being stored in the shmem data structure
+ * */
+#define SHM_T_OR_SHM_STRUCT_T(T) \
+  SHM_X_OR_Y(T, T, ShmStruct<T>)
+
+/**
+ * SHM_T_OR_CONST_T: Determines whether or not an object should be
+ * a constant or not.
+ * */
+#define SHM_CONST_T_OR_T(T, IS_CONST) \
+  typename std::conditional<         \
+    IS_CONST, \
+    const T, T>::type
+
+/**
+ * SHM_ARCHIVE_OR_REF: Return value of shm_ar::internal_ref().
+ * */
+#define SHM_ARCHIVE_OR_REF(T)\
+  SHM_X_OR_Y(T, TypedPointer<T>, T&)
+
+#endif  // HERMES_SHM_MEMORY_SHM_MACROS_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_null_container.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_null_container.h
@@ -1,0 +1,127 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_NULL_CONTAINER_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_NULL_CONTAINER_H_
+
+#include "shm_container.h"
+#include <string>
+
+namespace hermes_shm::ipc {
+
+/** forward declaration for string */
+class NullContainer;
+
+/**
+ * MACROS used to simplify the string namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+#define CLASS_NAME NullContainer
+#define TYPED_CLASS NullContainer
+#define TYPED_HEADER ShmHeader<NullContainer>
+
+/** string shared-memory header */
+template<>
+struct ShmHeader<NullContainer> : public ShmBaseHeader {
+  /** Default constructor */
+  ShmHeader() = default;
+
+  /** Copy constructor */
+  ShmHeader(const ShmHeader &other) {
+    strong_copy(other);
+  }
+
+  /** Copy assignment operator */
+  ShmHeader& operator=(const ShmHeader &other) {
+    if (this != &other) {
+      strong_copy(other);
+    }
+    return *this;
+  }
+
+  /** Strong copy operation */
+  void strong_copy(const ShmHeader &other) {}
+
+  /** Move constructor */
+  ShmHeader(ShmHeader &&other) {
+    weak_move(other);
+  }
+
+  /** Move operator */
+  ShmHeader& operator=(ShmHeader &&other) {
+    if (this != &other) {
+      weak_move(other);
+    }
+    return *this;
+  }
+
+  /** Move operation */
+  void weak_move(ShmHeader &other) {
+    strong_copy(other);
+  }
+};
+
+/**
+ * A string of characters.
+ * */
+class NullContainer : public ShmContainer {
+ public:
+  SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+
+ public:
+  ////////////////////////////
+  /// SHM Overrides
+  ////////////////////////////
+
+  /** Default constructor */
+  NullContainer() = default;
+
+  /** Default shm constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+  }
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc,
+                          NullContainer &other) {}
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc,
+                            const NullContainer &other) {}
+
+  /**
+   * Destroy the shared-memory data.
+   * */
+  void shm_destroy_main() {}
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+};
+
+}  // namespace hermes_shm::ipc
+
+namespace std {
+
+}  // namespace std
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_NULL_CONTAINER_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_ref.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_ref.h
@@ -1,0 +1,201 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_ShmRef_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_ShmRef_H_
+
+#include "hermes_shm/constants/macros.h"
+#include "shm_macros.h"
+#include "shm_archive.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * A ShmReference to a shared-memory object
+ * */
+template<typename T>
+struct _ShmRefShm {
+  T obj_;
+
+  /** Default constructor */
+  _ShmRefShm() = default;
+
+  /** Destructor */
+  ~_ShmRefShm() {
+    obj_.UnsetDestructable();
+  }
+
+  /** Constructor. */
+  explicit _ShmRefShm(TypedPointer<T> other) {
+    obj_.shm_deserialize(other);
+  }
+
+  /** Copy constructor */
+  _ShmRefShm(const _ShmRefShm &other) {
+    obj_.shm_deserialize(other.obj_);
+  }
+
+  /** Move constructor */
+  _ShmRefShm(_ShmRefShm &&other) noexcept {
+    obj_.shm_deserialize(other.obj_);
+  }
+
+  /** Copy assign operator */
+  _ShmRefShm& operator=(const _ShmRefShm &other) {
+    if (this != &other) {
+      obj_.shm_deserialize(other.obj_);
+    }
+    return *this;
+  }
+
+  /** Move assign operator */
+  _ShmRefShm& operator=(_ShmRefShm &&other) noexcept {
+    if (this != &other) {
+      obj_.shm_deserialize(other.obj_);
+    }
+    return *this;
+  }
+
+  /** Get ShmReference to the internal data structure */
+  T& get_ref() {
+    return obj_;
+  }
+
+  /** Get a constant ShmReference */
+  const T& get_ref_const() const {
+    return obj_;
+  }
+};
+
+/**
+ * A ShmReference to a POD type stored in shared memory.
+ * */
+template<typename T>
+struct _ShmRefNoShm {
+  T *obj_;
+
+  /** Default constructor */
+  _ShmRefNoShm() = default;
+
+  /** Constructor. */
+  explicit _ShmRefNoShm(T &other) {
+    obj_ = &other;
+  }
+
+  /** Copy constructor */
+  _ShmRefNoShm(const _ShmRefNoShm &other) {
+    obj_ = other.obj_;
+  }
+
+  /** Move constructor */
+  _ShmRefNoShm(_ShmRefNoShm &&other) noexcept {
+    obj_ = other.obj_;
+  }
+
+  /** Copy assign operator */
+  _ShmRefNoShm& operator=(const _ShmRefNoShm &other) {
+    if (this != &other) {
+      obj_ = other.obj_;
+    }
+    return *this;
+  }
+
+  /** Move assign operator */
+  _ShmRefNoShm& operator=(_ShmRefNoShm &&other) noexcept {
+    if (this != &other) {
+      obj_ = other.obj_;
+    }
+    return *this;
+  }
+
+  /** Get ShmReference to the internal data structure */
+  T& get_ref() {
+    return *obj_;
+  }
+
+  /** Get a constant ShmReference */
+  const T& get_ref_const() const {
+    return *obj_;
+  }
+};
+
+/** Determine whether ShmRef stores _ShmRefShm or _ShmRefNoShm */
+#define CHOOSE_SHM_ShmRef_TYPE(T) SHM_X_OR_Y(T, _ShmRefShm<T>, _ShmRefNoShm<T>)
+
+/**
+ * A Reference to a shared-memory object or a simple object
+ * stored in shared-memory.
+ * */
+template<typename T>
+struct ShmRef {
+  typedef CHOOSE_SHM_ShmRef_TYPE(T) T_ShmRef;
+  T_ShmRef obj_;
+
+  /** Constructor. */
+  template<typename ...Args>
+  explicit ShmRef(Args&& ...args) : obj_(std::forward<Args>(args)...) {}
+
+  /** Default constructor */
+  ShmRef() = default;
+
+  /** Copy Constructor */
+  ShmRef(const ShmRef &other) : obj_(other.obj_) {}
+
+  /** Copy assign operator */
+  ShmRef& operator=(const ShmRef &other) {
+    obj_ = other.obj_;
+    return *this;
+  }
+
+  /** Move Constructor */
+  ShmRef(ShmRef &&other) noexcept : obj_(std::move(other.obj_)) {}
+
+  /** Move assign operator */
+  ShmRef& operator=(ShmRef &&other) noexcept {
+    obj_ = std::move(other.obj_);
+    return *this;
+  }
+
+  /** Get ShmReference to the internal data structure */
+  T& get_ref() {
+    return obj_.get_ref();
+  }
+
+  /** Get a constant ShmReference */
+  const T& get_ref_const() const {
+    return obj_.get_ref_const();
+  }
+
+  /** DeShmReference operator */
+  T& operator*() {
+    return get_ref();
+  }
+
+  /** Constant deShmReference operator */
+  const T& operator*() const {
+    return get_ref_const();
+  }
+
+  /** Pointer operator */
+  T* operator->() {
+    return &get_ref();
+  }
+
+  /** Constant pointer operator */
+  const T* operator->() const {
+    return &get_ref_const();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_ShmRef_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/shm_smart_ptr.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/shm_smart_ptr.h
@@ -1,0 +1,162 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_DATA_STRUCTURE_POINTER_H_
+#define HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_DATA_STRUCTURE_POINTER_H_
+
+#include "hermes_shm/memory/memory.h"
+#include "hermes_shm/memory/allocator/allocator.h"
+#include "hermes_shm/memory/memory_manager.h"
+#include "hermes_shm/data_structures/internal/shm_macros.h"
+#include <hermes_shm/constants/data_structure_singleton_macros.h>
+
+#include "hermes_shm/data_structures/internal/shm_archive.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * Indicates a data structure represents a memory paradigm for Shm.
+ * */
+class ShmSmartPointer : public ShmArchiveable {};
+
+/**
+ * A base class used for creating shared-memory pointer management
+ * classes (manual_ptr, unique_ptr, shared_ptr).
+ *
+ * Smart pointers are not stored directly in shared memory. They are
+ * wrappers around shared-memory objects which manage the construction
+ * and destruction of objects.
+ * */
+template<typename T>
+class ShmSmartPtr : public ShmSmartPointer {
+ public:
+  T obj_; /**< The stored shared-memory object */
+
+ public:
+  /** Default constructor */
+  ShmSmartPtr() = default;
+
+  /** Sets this pointer to NULL */
+  void SetNull() {
+    obj_.SetNull();
+  }
+
+  /** Checks if this pointer is null */
+  bool IsNull() const {
+    return obj_.IsNull();
+  }
+
+  /** Gets a pointer to the internal object */
+  T* get() {
+    return &obj_;
+  }
+
+  /** Gets a pointer to the internal object */
+  T* get() const {
+    return &obj_;
+  }
+
+  /** Gets a pointer to the internal object */
+  T* get_const() const {
+    return &obj_;
+  }
+
+  /** Gets a reference to the internal object */
+  T& get_ref() {
+    return obj_;
+  }
+
+  /** Gets a reference to the internal object */
+  T& get_ref() const {
+    return obj_;
+  }
+
+  /** Gets a reference to the internal object */
+  const T& get_ref_const() const {
+    return obj_;
+  }
+
+  /** Dereference operator */
+  T& operator*() {
+    return get_ref();
+  }
+
+  /** Constant dereference operator */
+  const T& operator*() const {
+    return get_ref_const();
+  }
+
+  /** Pointer operator */
+  T* operator->() {
+    return get();
+  }
+
+  /** Constant pointer operator */
+  const T* operator->() const {
+    return get_const();
+  }
+
+  /** Destroy the data allocated by this pointer */
+  void shm_destroy() {
+    obj_.shm_destroy();
+  }
+};
+
+
+
+}  // namespace hermes_shm::ipc
+
+/**
+ * Namespace simplification for a SHM data structure pointer
+ * */
+#define SHM_SMART_PTR_TEMPLATE(T) \
+  using ShmSmartPtr<T>::shm_destroy;\
+  using ShmSmartPtr<T>::obj_;\
+  using ShmSmartPtr<T>::get;\
+  using ShmSmartPtr<T>::get_ref;\
+  using ShmSmartPtr<T>::get_const;\
+  using ShmSmartPtr<T>::get_ref_const;\
+  using ShmSmartPtr<T>::SetNull;\
+  using ShmSmartPtr<T>::IsNull;
+
+/**
+ * A macro for defining shared memory serializations
+ * */
+#define SHM_SERIALIZE_WRAPPER(AR_TYPE)\
+  void shm_serialize(hipc::TypedPointer<TYPE_UNWRAP(AR_TYPE)> &type) const {\
+    obj_.shm_serialize(type);\
+  }\
+  void shm_serialize(hipc::TypedAtomicPointer<TYPE_UNWRAP(AR_TYPE)> &type) const {\
+    obj_.shm_serialize(type);\
+  }\
+  SHM_SERIALIZE_OPS(AR_TYPE)
+
+/**
+ * A macro for defining shared memory deserializations
+ * */
+#define SHM_DESERIALIZE_WRAPPER(AR_TYPE)\
+  void shm_deserialize(const hipc::TypedPointer<TYPE_UNWRAP(AR_TYPE)> &type) {\
+    obj_.shm_deserialize(type);\
+  }\
+  void shm_deserialize(const hipc::TypedAtomicPointer<TYPE_UNWRAP(AR_TYPE)> &type) {\
+    obj_.shm_deserialize(type);\
+  }\
+  SHM_DESERIALIZE_OPS(AR_TYPE)
+
+/**
+ * A macro for defining shared memory (de)serializations
+ * */
+#define SHM_SERIALIZE_DESERIALIZE_WRAPPER(AR_TYPE)\
+  SHM_SERIALIZE_WRAPPER(AR_TYPE)\
+  SHM_DESERIALIZE_WRAPPER(AR_TYPE)
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_DATA_STRUCTURE_POINTER_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_base_example.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_base_example.h
@@ -1,0 +1,422 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXAMPLE_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXAMPLE_H_
+
+#include "hermes_shm/data_structures/internal/shm_container.h"
+
+namespace honey {
+
+class ShmContainerExample;
+
+#define CLASS_NAME ShmContainerExample
+#define TYPED_CLASS ShmContainerExample
+#define TYPED_HEADER ShmHeader<ShmContainerExample>
+
+template<typename T>
+class ShmHeader;
+
+template<>
+ class ShmHeader<ShmContainerExample> : public hipc::ShmBaseHeader {
+};
+
+class ShmContainerExample {
+ public:
+  /**====================================
+   * Variables & Types
+   * ===================================*/
+
+  typedef TYPED_HEADER header_t; /** Header type query */
+  header_t *header_; /**< Header of the shared-memory data structure */
+  hipc::Allocator *alloc_; /**< hipc::Allocator used for this data structure */
+  hermes_shm::bitfield32_t flags_; /**< Flags used data structure status */
+
+ public:
+  /**====================================
+   * Shm Overrides
+   * ===================================*/
+
+  /** Default constructor */
+  CLASS_NAME() = default;
+
+  /** Default shm constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     hipc::Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+  }
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          hipc::Allocator *alloc,
+                          CLASS_NAME &other) {
+    shm_init_main(header, alloc);
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            hipc::Allocator *alloc,
+                            const CLASS_NAME &other) {
+    shm_init_main(header, alloc);
+  }
+
+  /** Destroy the shared-memory data. */
+  void shm_destroy_main() {}
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+
+  /**====================================
+   * Constructors
+   * ===================================*/
+
+  /** Constructor. Allocate header with default allocator. */
+  template<typename ...Args>
+  explicit CLASS_NAME(Args&& ...args) {
+    shm_init(std::forward<Args>(args)...);
+  }
+
+  /** Constructor. Allocate header with default allocator. */
+  template<typename ...Args>
+  void shm_init(Args&& ...args) {
+    shm_destroy(false);
+    shm_init_main(hipc::typed_nullptr<TYPED_HEADER>(),
+                  hipc::typed_nullptr<hipc::Allocator>(),
+                  std::forward<Args>(args)...);
+  }
+
+  /** Constructor. Allocate header with specific allocator. */
+  template<typename ...Args>
+  void shm_init(hipc::Allocator *alloc, Args&& ...args) {
+    shm_destroy(false);
+    shm_init_main(hipc::typed_nullptr<TYPED_HEADER>(),
+                  alloc,
+                  std::forward<Args>(args)...);
+  }
+
+  /** Constructor. Initialize an already-allocated header. */
+  template<typename ...Args>
+  void shm_init(TYPED_HEADER &header,
+                hipc::Allocator *alloc, Args&& ...args) {
+    shm_destroy(false);
+    shm_init_main(&header, alloc, std::forward<Args>(args)...);
+  }
+
+  /** Initialize the data structure's allocator */
+  inline void shm_init_allocator(hipc::Allocator *alloc) {
+    if (IsValid()) { return; }
+    if (alloc == nullptr) {
+      alloc_ = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();
+    } else {
+      alloc_ = alloc;
+    }
+  }
+
+  /**
+   * Initialize a data structure's header.
+   * A container will never re-set or re-allocate its header once it has
+   * been set the first time.
+   * */
+  template<typename ...Args>
+  void shm_init_header(TYPED_HEADER *header,
+                       Args&& ...args) {
+    if (IsValid()) {
+      header_->SetBits(SHM_CONTAINER_DATA_VALID);
+    } else if (header == nullptr) {
+      hipc::Pointer p;
+      header_ = alloc_->template
+        AllocateConstructObjs<TYPED_HEADER>(
+        1, p, std::forward<Args>(args)...);
+      header_->SetBits(
+        SHM_CONTAINER_DATA_VALID |
+          SHM_CONTAINER_HEADER_DESTRUCTABLE);
+      flags_.SetBits(
+        SHM_CONTAINER_VALID |
+          SHM_CONTAINER_DESTRUCTABLE);
+    } else {
+      hipc::Pointer header_ptr;
+      header_ = header;
+      hipc::Allocator::ConstructObj<TYPED_HEADER>(
+        *header_, std::forward<Args>(args)...);
+      header_->SetBits(
+        SHM_CONTAINER_DATA_VALID);
+      flags_.SetBits(
+        SHM_CONTAINER_VALID |
+          SHM_CONTAINER_DESTRUCTABLE);
+    }
+  }
+
+  /**====================================
+   * Serialization
+   * ===================================*/
+
+  /** Serialize into a Pointer */
+  void shm_serialize(hipc::TypedPointer<TYPED_CLASS> &ar) const {
+    ar = alloc_->template
+      Convert<TYPED_HEADER, hipc::Pointer>(header_);
+    shm_serialize_main();
+  }
+
+  /** Serialize into an AtomicPointer */
+  void shm_serialize(hipc::TypedAtomicPointer<TYPED_CLASS> &ar) const {
+    ar = alloc_->template
+      Convert<TYPED_HEADER, hipc::AtomicPointer>(header_);
+    shm_serialize_main();
+  }
+
+  /** Override << operators */
+  SHM_SERIALIZE_OPS((TYPED_CLASS))
+
+  /**====================================
+   * Deserialization
+   * ===================================*/
+
+  /** Deserialize object from a raw pointer */
+  bool shm_deserialize(const hipc::TypedPointer<TYPED_CLASS> &ar) {
+    return shm_deserialize(
+      HERMES_SHM_MEMORY_MANAGER->GetAllocator(ar.allocator_id_),
+      ar.ToOffsetPointer()
+    );
+  }
+
+  /** Deserialize object from allocator + offset */
+  bool shm_deserialize(hipc::Allocator *alloc, hipc::OffsetPointer header_ptr) {
+    if (header_ptr.IsNull()) { return false; }
+    return shm_deserialize(alloc,
+                           alloc->Convert<
+                             TYPED_HEADER,
+                             hipc::OffsetPointer>(header_ptr));
+  }
+
+  /** Deserialize object from another object (weak copy) */
+  bool shm_deserialize(const CLASS_NAME &other) {
+    if (other.IsNull()) { return false; }
+    return shm_deserialize(other.GetAllocator(), other.header_);
+  }
+
+  /** Deserialize object from allocator + header */
+  bool shm_deserialize(hipc::Allocator *alloc,
+                       TYPED_HEADER *header) {
+    flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);
+    alloc_ = alloc;
+    header_ = header;
+    flags_.SetBits(SHM_CONTAINER_VALID);
+    shm_deserialize_main();
+    return true;
+  }
+
+  /** Constructor. Deserialize the object from the reference. */
+  template<typename ...Args>
+  void shm_init(hipc::ShmRef<TYPED_CLASS> &obj) {
+    shm_deserialize(obj->GetAllocator(), obj->header_);
+  }
+
+  /** Override >> operators */
+  SHM_DESERIALIZE_OPS((TYPED_CLASS))
+
+  /**====================================
+   * Destructors
+   * ===================================*/
+
+  /** Destructor */
+  ~CLASS_NAME() {
+    if (IsDestructable()) {
+      shm_destroy(true);
+    }
+  }
+
+  /** Shm Destructor */
+  void shm_destroy(bool destroy_header = true) {
+    if (!IsValid()) { return; }
+    if (IsDataValid()) {
+      shm_destroy_main();
+    }
+    UnsetDataValid();
+    if (destroy_header &&
+      header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {
+      alloc_->FreePtr<TYPED_HEADER>(header_);
+      UnsetValid();
+    }
+  }
+
+  /**====================================
+   * Move Operations
+   * ===================================*/
+
+  /** Move constructor */
+  CLASS_NAME(CLASS_NAME &&other) noexcept {
+    shm_weak_move(
+      hipc::typed_nullptr<TYPED_HEADER>(),
+      hipc::typed_nullptr<hipc::Allocator>(),
+      other);
+  }
+
+  /** Move assignment operator */
+  CLASS_NAME& operator=(CLASS_NAME &&other) noexcept {
+    if (this != &other) {
+      shm_weak_move(
+        hipc::typed_nullptr<TYPED_HEADER>(),
+        hipc::typed_nullptr<hipc::Allocator>(),
+        other);
+    }
+    return *this;
+  }
+
+  /** Move shm_init constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     CLASS_NAME &&other) noexcept {
+    shm_weak_move(header, alloc, other);
+  }
+
+  /** Move operation */
+  void shm_weak_move(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     CLASS_NAME &other) {
+    if (other.IsNull()) { return; }
+    if (IsValid() && other.GetAllocator() != GetAllocator()) {
+      shm_strong_copy(header, alloc, other);
+      other.shm_destroy(true);
+      return;
+    }
+    shm_destroy(false);
+    shm_weak_move_main(header, alloc, other);
+    if (!other.IsDestructable()) {
+      UnsetDestructable();
+    }
+    other.UnsetDataValid();
+    other.shm_destroy(true);
+  }
+
+  /**====================================
+   * Copy Operations
+   * ===================================*/
+
+  /** Copy constructor */
+  CLASS_NAME(const CLASS_NAME &other) noexcept {
+    shm_init(other);
+  }
+
+  /** Copy assignment constructor */
+  CLASS_NAME& operator=(const CLASS_NAME &other) {
+    if (this != &other) {
+      shm_strong_copy(
+        hipc::typed_nullptr<TYPED_HEADER>(),
+        hipc::typed_nullptr<hipc::Allocator>(),
+        other);
+    }
+    return *this;
+  }
+
+  /** Copy shm_init constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     const CLASS_NAME &other) {
+    shm_strong_copy(header, alloc, other);
+  }
+
+  /** Strong Copy operation */
+  void shm_strong_copy(TYPED_HEADER *header,
+                       hipc::Allocator *alloc,
+                       const CLASS_NAME &other) {
+    if (other.IsNull()) { return; }
+    shm_destroy(false);
+    shm_strong_copy_main(header, alloc, other);
+    SetDestructable();
+  }
+
+  /**====================================
+   * Container Flag Operations
+   * ===================================*/
+
+  /** Sets this object as destructable */
+  void SetDestructable() {
+    flags_.SetBits(SHM_CONTAINER_DESTRUCTABLE);
+  }
+
+  /** Sets this object as not destructable */
+  void UnsetDestructable() {
+    flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);
+  }
+
+  /** Check if this container is destructable */
+  bool IsDestructable() const {
+    return flags_.OrBits(SHM_CONTAINER_DESTRUCTABLE);
+  }
+
+  /** Check if container has a valid header */
+  bool IsValid() const {
+    return flags_.OrBits(SHM_CONTAINER_VALID);
+  }
+
+  /** Set container header invalid */
+  void UnsetValid() {
+    flags_.UnsetBits(SHM_CONTAINER_VALID |
+      SHM_CONTAINER_DESTRUCTABLE | SHM_CONTAINER_HEADER_DESTRUCTABLE);
+  }
+
+  /**====================================
+   * Header Flag Operations
+   * ===================================*/
+
+  /** Check if header's data is valid */
+  bool IsDataValid() const {
+    return header_->OrBits(SHM_CONTAINER_DATA_VALID);
+  }
+
+  /** Check if header's data is valid */
+  void UnsetDataValid() const {
+    header_->UnsetBits(SHM_CONTAINER_DATA_VALID);
+  }
+
+  /** Check if null */
+  bool IsNull() const {
+    return !IsValid() || !IsDataValid();
+  }
+
+  /** Get a typed pointer to the object */
+  template<typename POINTER_T>
+  POINTER_T GetShmPointer() const {
+    return alloc_->Convert<TYPED_HEADER, POINTER_T>(header_);
+  }
+
+  /**====================================
+   * Query Operations
+   * ===================================*/
+
+  /** Get the allocator for this container */
+  hipc::Allocator* GetAllocator() {
+    return alloc_;
+  }
+
+  /** Get the allocator for this container */
+  hipc::Allocator* GetAllocator() const {
+    return alloc_;
+  }
+
+  /** Get the shared-memory allocator id */
+  hipc::allocator_id_t GetAllocatorId() const {
+    return alloc_->GetId();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_EXAMPLE_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_base_template.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_base_template.h
@@ -1,0 +1,355 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+public:
+/**====================================
+ * Variables & Types
+ * ===================================*/
+
+typedef TYPED_HEADER header_t; /** Header type query */
+header_t *header_; /**< Header of the shared-memory data structure */
+hipc::Allocator *alloc_; /**< hipc::Allocator used for this data structure */
+hermes_shm::bitfield32_t flags_; /**< Flags used data structure status */
+
+public:
+/**====================================
+ * Constructors
+ * ===================================*/
+
+/** Constructor. Allocate header with default allocator. */
+template<typename ...Args>
+explicit CLASS_NAME(Args&& ...args) {
+shm_init(std::forward<Args>(args)...);
+}
+
+/** Constructor. Allocate header with default allocator. */
+template<typename ...Args>
+void shm_init(Args&& ...args) {
+  shm_destroy(false);
+  shm_init_main(hipc::typed_nullptr<TYPED_HEADER>(),
+                hipc::typed_nullptr<hipc::Allocator>(),
+                std::forward<Args>(args)...);
+}
+
+/** Constructor. Allocate header with specific allocator. */
+template<typename ...Args>
+void shm_init(hipc::Allocator *alloc, Args&& ...args) {
+  shm_destroy(false);
+  shm_init_main(hipc::typed_nullptr<TYPED_HEADER>(),
+                alloc,
+                std::forward<Args>(args)...);
+}
+
+/** Constructor. Initialize an already-allocated header. */
+template<typename ...Args>
+void shm_init(TYPED_HEADER &header,
+              hipc::Allocator *alloc, Args&& ...args) {
+  shm_destroy(false);
+  shm_init_main(&header, alloc, std::forward<Args>(args)...);
+}
+
+/** Initialize the data structure's allocator */
+inline void shm_init_allocator(hipc::Allocator *alloc) {
+  if (IsValid()) { return; }
+  if (alloc == nullptr) {
+    alloc_ = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();
+  } else {
+    alloc_ = alloc;
+  }
+}
+
+/**
+ * Initialize a data structure's header.
+ * A container will never re-set or re-allocate its header once it has
+ * been set the first time.
+ * */
+template<typename ...Args>
+void shm_init_header(TYPED_HEADER *header,
+                     Args&& ...args) {
+  if (IsValid()) {
+    header_->SetBits(SHM_CONTAINER_DATA_VALID);
+  } else if (header == nullptr) {
+    hipc::Pointer p;
+    header_ = alloc_->template
+      AllocateConstructObjs<TYPED_HEADER>(
+      1, p, std::forward<Args>(args)...);
+    header_->SetBits(
+      SHM_CONTAINER_DATA_VALID |
+        SHM_CONTAINER_HEADER_DESTRUCTABLE);
+    flags_.SetBits(
+      SHM_CONTAINER_VALID |
+        SHM_CONTAINER_DESTRUCTABLE);
+  } else {
+    hipc::Pointer header_ptr;
+    header_ = header;
+    hipc::Allocator::ConstructObj<TYPED_HEADER>(
+      *header_, std::forward<Args>(args)...);
+    header_->SetBits(
+      SHM_CONTAINER_DATA_VALID);
+    flags_.SetBits(
+      SHM_CONTAINER_VALID |
+        SHM_CONTAINER_DESTRUCTABLE);
+  }
+}
+
+/**====================================
+ * Serialization
+ * ===================================*/
+
+/** Serialize into a Pointer */
+void shm_serialize(hipc::TypedPointer<TYPED_CLASS> &ar) const {
+  ar = alloc_->template
+    Convert<TYPED_HEADER, hipc::Pointer>(header_);
+  shm_serialize_main();
+}
+
+/** Serialize into an AtomicPointer */
+void shm_serialize(hipc::TypedAtomicPointer<TYPED_CLASS> &ar) const {
+  ar = alloc_->template
+    Convert<TYPED_HEADER, hipc::AtomicPointer>(header_);
+  shm_serialize_main();
+}
+
+/** Override << operators */
+SHM_SERIALIZE_OPS((TYPED_CLASS))
+
+/**====================================
+ * Deserialization
+ * ===================================*/
+
+/** Deserialize object from a raw pointer */
+bool shm_deserialize(const hipc::TypedPointer<TYPED_CLASS> &ar) {
+  return shm_deserialize(
+    HERMES_SHM_MEMORY_MANAGER->GetAllocator(ar.allocator_id_),
+    ar.ToOffsetPointer()
+  );
+}
+
+/** Deserialize object from allocator + offset */
+bool shm_deserialize(hipc::Allocator *alloc, hipc::OffsetPointer header_ptr) {
+  if (header_ptr.IsNull()) { return false; }
+  return shm_deserialize(alloc,
+                         alloc->Convert<
+                           TYPED_HEADER,
+                           hipc::OffsetPointer>(header_ptr));
+}
+
+/** Deserialize object from another object (weak copy) */
+bool shm_deserialize(const CLASS_NAME &other) {
+  if (other.IsNull()) { return false; }
+  return shm_deserialize(other.GetAllocator(), other.header_);
+}
+
+/** Deserialize object from allocator + header */
+bool shm_deserialize(hipc::Allocator *alloc,
+                     TYPED_HEADER *header) {
+  flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);
+  alloc_ = alloc;
+  header_ = header;
+  flags_.SetBits(SHM_CONTAINER_VALID);
+  shm_deserialize_main();
+  return true;
+}
+
+/** Constructor. Deserialize the object from the reference. */
+template<typename ...Args>
+void shm_init(hipc::ShmRef<TYPED_CLASS> &obj) {
+  shm_deserialize(obj->GetAllocator(), obj->header_);
+}
+
+/** Override >> operators */
+SHM_DESERIALIZE_OPS((TYPED_CLASS))
+
+/**====================================
+ * Destructors
+ * ===================================*/
+
+/** Destructor */
+~CLASS_NAME() {
+  if (IsDestructable()) {
+    shm_destroy(true);
+  }
+}
+
+/** Shm Destructor */
+void shm_destroy(bool destroy_header = true) {
+  if (!IsValid()) { return; }
+  if (IsDataValid()) {
+    shm_destroy_main();
+  }
+  UnsetDataValid();
+  if (destroy_header &&
+    header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {
+    alloc_->FreePtr<TYPED_HEADER>(header_);
+    UnsetValid();
+  }
+}
+
+/**====================================
+ * Move Operations
+ * ===================================*/
+
+/** Move constructor */
+CLASS_NAME(CLASS_NAME &&other) noexcept {
+shm_weak_move(
+  hipc::typed_nullptr<TYPED_HEADER>(),
+  hipc::typed_nullptr<hipc::Allocator>(),
+  other);
+}
+
+/** Move assignment operator */
+CLASS_NAME& operator=(CLASS_NAME &&other) noexcept {
+if (this != &other) {
+shm_weak_move(
+  hipc::typed_nullptr<TYPED_HEADER>(),
+  hipc::typed_nullptr<hipc::Allocator>(),
+  other);
+}
+return *this;
+}
+
+/** Move shm_init constructor */
+void shm_init_main(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   CLASS_NAME &&other) noexcept {
+  shm_weak_move(header, alloc, other);
+}
+
+/** Move operation */
+void shm_weak_move(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   CLASS_NAME &other) {
+  if (other.IsNull()) { return; }
+  if (IsValid() && other.GetAllocator() != GetAllocator()) {
+    shm_strong_copy(header, alloc, other);
+    other.shm_destroy(true);
+    return;
+  }
+  shm_destroy(false);
+  shm_weak_move_main(header, alloc, other);
+  if (!other.IsDestructable()) {
+    UnsetDestructable();
+  }
+  other.UnsetDataValid();
+  other.shm_destroy(true);
+}
+
+/**====================================
+ * Copy Operations
+ * ===================================*/
+
+/** Copy constructor */
+CLASS_NAME(const CLASS_NAME &other) noexcept {
+  shm_init(other);
+}
+
+/** Copy assignment constructor */
+CLASS_NAME& operator=(const CLASS_NAME &other) {
+  if (this != &other) {
+    shm_strong_copy(
+      hipc::typed_nullptr<TYPED_HEADER>(),
+      hipc::typed_nullptr<hipc::Allocator>(),
+      other);
+  }
+  return *this;
+}
+
+/** Copy shm_init constructor */
+void shm_init_main(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   const CLASS_NAME &other) {
+  shm_strong_copy(header, alloc, other);
+}
+
+/** Strong Copy operation */
+void shm_strong_copy(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     const CLASS_NAME &other) {
+  if (other.IsNull()) { return; }
+  shm_destroy(false);
+  shm_strong_copy_main(header, alloc, other);
+  SetDestructable();
+}
+
+/**====================================
+ * Container Flag Operations
+ * ===================================*/
+
+/** Sets this object as destructable */
+void SetDestructable() {
+  flags_.SetBits(SHM_CONTAINER_DESTRUCTABLE);
+}
+
+/** Sets this object as not destructable */
+void UnsetDestructable() {
+  flags_.UnsetBits(SHM_CONTAINER_DESTRUCTABLE);
+}
+
+/** Check if this container is destructable */
+bool IsDestructable() const {
+  return flags_.OrBits(SHM_CONTAINER_DESTRUCTABLE);
+}
+
+/** Check if container has a valid header */
+bool IsValid() const {
+  return flags_.OrBits(SHM_CONTAINER_VALID);
+}
+
+/** Set container header invalid */
+void UnsetValid() {
+  flags_.UnsetBits(SHM_CONTAINER_VALID |
+    SHM_CONTAINER_DESTRUCTABLE | SHM_CONTAINER_HEADER_DESTRUCTABLE);
+}
+
+/**====================================
+ * Header Flag Operations
+ * ===================================*/
+
+/** Check if header's data is valid */
+bool IsDataValid() const {
+  return header_->OrBits(SHM_CONTAINER_DATA_VALID);
+}
+
+/** Check if header's data is valid */
+void UnsetDataValid() const {
+  header_->UnsetBits(SHM_CONTAINER_DATA_VALID);
+}
+
+/** Check if null */
+bool IsNull() const {
+  return !IsValid() || !IsDataValid();
+}
+
+/** Get a typed pointer to the object */
+template<typename POINTER_T>
+POINTER_T GetShmPointer() const {
+  return alloc_->Convert<TYPED_HEADER, POINTER_T>(header_);
+}
+
+/**====================================
+ * Query Operations
+ * ===================================*/
+
+/** Get the allocator for this container */
+hipc::Allocator* GetAllocator() {
+  return alloc_;
+}
+
+/** Get the allocator for this container */
+hipc::Allocator* GetAllocator() const {
+  return alloc_;
+}
+
+/** Get the shared-memory allocator id */
+hipc::allocator_id_t GetAllocatorId() const {
+  return alloc_->GetId();
+}

--- a/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_extend_example.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_extend_example.h
@@ -1,0 +1,316 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/**
+ * Let's say we want a data structure
+ * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_INHERIT_EXAMPLE_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_INHERIT_EXAMPLE_H_
+
+#define CLASS_NAME ShmContainerExtendExample
+#define TYPED_CLASS ShmContainerExtendExample<ContainerT>
+#define TYPED_HEADER ShmHeader<ShmContainerExtendExample<ContainerT>>
+
+#include "hermes_shm/data_structures/internal/shm_container.h"
+
+namespace hermes_shm::ipc {
+
+template<typename ContainerT>
+class ShmContainerExtendExample;
+
+template<typename ContainerT>
+class ShmHeader<ShmContainerExtendExample<ContainerT>>
+: public ShmWrapperHeader {
+  typename ContainerT::header_t obj_;
+};
+
+template<typename ContainerT>
+class ShmContainerExtendExample : public ShmContainer {
+ public:
+  /**====================================
+   * Variables & Types
+   *===================================*/
+
+  typedef TYPED_HEADER header_t; /**< Required by all ShmContainers */
+  header_t *header_; /**< The shared-memory header for this container */
+  ContainerT obj_; /**< The object being wrapped around */
+
+ public:
+  /**====================================
+   * Shm Overrides
+   * ===================================*/
+
+  /** Default constructor */
+  CLASS_NAME() = default;
+
+  /** Default shm constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc) {
+  }
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, CLASS_NAME &other) {
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const CLASS_NAME &other) {
+  }
+
+  /** Destroy the shared-memory data. */
+  void shm_destroy_main() {}
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+
+  /**====================================
+   * Constructors
+   * ===================================*/
+
+  /** Constructor. Allocate header with default allocator. */
+  template<typename ...Args>
+  explicit CLASS_NAME(Args &&...args) {
+    shm_init(std::forward<Args>(args)...);
+  }
+
+  /** Constructor. Allocate header with default allocator. */
+  template<typename ...Args>
+  void shm_init(Args &&...args) {
+  }
+
+  /**====================================
+   * Serialization
+   * ===================================*/
+
+  /** Serialize into a Pointer */
+  void shm_serialize(TypedPointer<TYPED_CLASS> &ar) const {
+    obj_.shm_serialize(ar);
+  }
+
+  /** Serialize into an AtomicPointer */
+  void shm_serialize(TypedAtomicPointer<TYPED_CLASS> &ar) const {
+    obj_.shm_serialize(ar);
+  }
+
+  /** Override << operators */
+  SHM_SERIALIZE_OPS((TYPED_CLASS))
+
+  /**====================================
+   * Deserialization
+   * ===================================*/
+
+  /** Deserialize object from a raw pointer */
+  bool shm_deserialize(const TypedPointer<TYPED_CLASS> &ar) {
+    return obj_.shm_deserialize(ar);
+  }
+
+  /** Deserialize object from allocator + offset */
+  bool shm_deserialize(Allocator *alloc, OffsetPointer header_ptr) {
+    return obj_.shm_deserialize(alloc, header_ptr);
+  }
+
+  /** Deserialize object from another object (weak copy) */
+  bool shm_deserialize(const CLASS_NAME &other) {
+    return obj_.shm_deserialize(other);
+  }
+
+  /** Deserialize object from allocator + header */
+  bool shm_deserialize(Allocator *alloc,
+                       TYPED_HEADER *header) {
+    return obj_.shm_deserialize(alloc, header);
+  }
+
+  /** Constructor. Deserialize the object from the reference. */
+  template<typename ...Args>
+  void shm_init(hipc::ShmRef<TYPED_CLASS> &obj) {
+    shm_deserialize(obj->GetAllocator(), obj->header_);
+  }
+
+  /** Override >> operators */
+  SHM_DESERIALIZE_OPS ((TYPED_CLASS))
+
+  /**====================================
+   * Destructors
+   * ===================================*/
+
+  /** Destructor */
+  ~CLASS_NAME() {
+    obj_.shm_destroy(true);
+  }
+
+  /** Shm Destructor */
+  void shm_destroy(bool destroy_header = true) {
+    obj_.shm_destroy(false);
+    if (!IsValid()) { return; }
+    if (IsDataValid()) {
+      shm_destroy_main();
+    }
+    UnsetDataValid();
+    if (destroy_header &&
+      obj_.header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {
+      GetAllocator()->template
+        FreePtr<TYPED_HEADER>(header_);
+      UnsetValid();
+    }
+  }
+
+  /**====================================
+   * Move Operations
+   * ===================================*/
+
+  /** Move constructor */
+  CLASS_NAME(CLASS_NAME &&other) noexcept
+  : obj_(std::move(other)) {}
+
+  /** Move assignment operator */
+  CLASS_NAME& operator=(CLASS_NAME &&other) noexcept {
+    obj_ = std::move(other.obj_);
+    return *this;
+  }
+
+  /** Move shm_init constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     CLASS_NAME &&other) noexcept {
+    shm_weak_move(header, alloc, other);
+  }
+
+  /** Move operation */
+  void shm_weak_move(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     CLASS_NAME &other) {
+    obj_.shm_weak_move(header, alloc, other);
+  }
+
+  /**====================================
+   * Copy Operations
+   * ===================================*/
+
+  /** Copy constructor */
+  CLASS_NAME(const CLASS_NAME &other) noexcept {
+    shm_init(other);
+  }
+
+  /** Copy assignment constructor */
+  CLASS_NAME &operator=(const CLASS_NAME &other) {
+    if (this != &other) {
+      shm_strong_copy(
+        typed_nullptr<TYPED_HEADER >(),
+        typed_nullptr<Allocator>(),
+        other);
+    }
+    return *this;
+  }
+
+  /** Copy shm_init constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     hipc::Allocator *alloc,
+                     const CLASS_NAME &other) {
+    shm_strong_copy(header, alloc, other);
+  }
+
+  /** Strong Copy operation */
+  void shm_strong_copy(TYPED_HEADER *header, hipc::Allocator *alloc,
+                       const CLASS_NAME &other) {
+    if (other.IsNull()) { return; }
+    shm_destroy(false);
+    shm_strong_copy_main(header, alloc, other);
+    SetDestructable();
+  }
+
+  /**====================================
+   * Container Flag Operations
+   * ===================================*/
+
+  /** Sets this object as destructable */
+  void SetDestructable() {
+    obj_.SetDestructable();
+  }
+
+  /** Sets this object as not destructable */
+  void UnsetDestructable() {
+    obj_.UnsetDestructable();
+  }
+
+  /** Check if this container is destructable */
+  bool IsDestructable() const {
+    return obj_.IsDestructable();
+  }
+
+  /** Check if container has a valid header */
+  bool IsValid() const {
+    return obj_.IsValid();
+  }
+
+  /** Set container header invalid */
+  void UnsetValid() {
+    obj_.UnsetValid();
+  }
+
+  /**====================================
+   * Header Flag Operations
+   * ===================================*/
+
+  /** Check if header's data is valid */
+  bool IsDataValid() const {
+    return obj_.IsDataValid();
+  }
+
+  /** Check if header's data is valid */
+  void UnsetDataValid() const {
+    return obj_.UnsetDataValid();
+  }
+
+  /** Check if null */
+  bool IsNull() const {
+    return obj_.IsNull();
+  }
+
+  /** Get a typed pointer to the object */
+  template<typename POINTER_T>
+  POINTER_T GetShmPointer() const {
+    return GetAllocator()->template
+      Convert<TYPED_HEADER, POINTER_T>(header_);
+  }
+
+  /**====================================
+   * Query Operations
+   * ===================================*/
+
+  /** Get the allocator for this container */
+  Allocator* GetAllocator() {
+    return obj_.GetAllocator();
+  }
+
+  /** Get the allocator for this container */
+  Allocator* GetAllocator() const {
+    return obj_.GetAllocator();
+  }
+
+  /** Get the shared-memory allocator id */
+  allocator_id_t GetAllocatorId() const {
+    return GetAllocator()->GetId();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_INTERNAL_SHM_CONTAINER_INHERIT_EXAMPLE_H_

--- a/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_extend_template.h
+++ b/hermes_shm/include/hermes_shm/data_structures/internal/template/shm_container_extend_template.h
@@ -1,0 +1,250 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+public:
+/**====================================
+ * Variables & Types
+ *===================================*/
+
+typedef TYPED_HEADER header_t; /**< Required by all ShmContainers */
+header_t *header_; /**< The shared-memory header for this container */
+ContainerT obj_; /**< The object being wrapped around */
+
+public:
+/**====================================
+ * Constructors
+ * ===================================*/
+
+/** Constructor. Allocate header with default allocator. */
+template<typename ...Args>
+explicit CLASS_NAME(Args &&...args) {
+shm_init(std::forward<Args>(args)...);
+}
+
+/** Constructor. Allocate header with default allocator. */
+template<typename ...Args>
+void shm_init(Args &&...args) {
+}
+
+/**====================================
+ * Serialization
+ * ===================================*/
+
+/** Serialize into a Pointer */
+void shm_serialize(TypedPointer<TYPED_CLASS> &ar) const {
+  obj_.shm_serialize(ar);
+}
+
+/** Serialize into an AtomicPointer */
+void shm_serialize(TypedAtomicPointer<TYPED_CLASS> &ar) const {
+  obj_.shm_serialize(ar);
+}
+
+/** Override << operators */
+SHM_SERIALIZE_OPS((TYPED_CLASS))
+
+/**====================================
+ * Deserialization
+ * ===================================*/
+
+/** Deserialize object from a raw pointer */
+bool shm_deserialize(const TypedPointer<TYPED_CLASS> &ar) {
+  return obj_.shm_deserialize(ar);
+}
+
+/** Deserialize object from allocator + offset */
+bool shm_deserialize(Allocator *alloc, OffsetPointer header_ptr) {
+  return obj_.shm_deserialize(alloc, header_ptr);
+}
+
+/** Deserialize object from another object (weak copy) */
+bool shm_deserialize(const CLASS_NAME &other) {
+  return obj_.shm_deserialize(other);
+}
+
+/** Deserialize object from allocator + header */
+bool shm_deserialize(Allocator *alloc,
+                     TYPED_HEADER *header) {
+  return obj_.shm_deserialize(alloc, header);
+}
+
+/** Constructor. Deserialize the object from the reference. */
+template<typename ...Args>
+void shm_init(hipc::ShmRef<TYPED_CLASS> &obj) {
+  shm_deserialize(obj->GetAllocator(), obj->header_);
+}
+
+/** Override >> operators */
+SHM_DESERIALIZE_OPS ((TYPED_CLASS))
+
+/**====================================
+ * Destructors
+ * ===================================*/
+
+/** Destructor */
+~CLASS_NAME() {
+  obj_.shm_destroy(true);
+}
+
+/** Shm Destructor */
+void shm_destroy(bool destroy_header = true) {
+  obj_.shm_destroy(false);
+  if (!IsValid()) { return; }
+  if (IsDataValid()) {
+    shm_destroy_main();
+  }
+  UnsetDataValid();
+  if (destroy_header &&
+    obj_.header_->OrBits(SHM_CONTAINER_HEADER_DESTRUCTABLE)) {
+    GetAllocator()->template
+      FreePtr<TYPED_HEADER>(header_);
+    UnsetValid();
+  }
+}
+
+/**====================================
+ * Move Operations
+ * ===================================*/
+
+/** Move constructor */
+CLASS_NAME(CLASS_NAME &&other) noexcept
+: obj_(std::move(other)) {}
+
+/** Move assignment operator */
+CLASS_NAME& operator=(CLASS_NAME &&other) noexcept {
+obj_ = std::move(other.obj_);
+return *this;
+}
+
+/** Move shm_init constructor */
+void shm_init_main(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   CLASS_NAME &&other) noexcept {
+  shm_weak_move(header, alloc, other);
+}
+
+/** Move operation */
+void shm_weak_move(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   CLASS_NAME &other) {
+  obj_.shm_weak_move(header, alloc, other);
+}
+
+/**====================================
+ * Copy Operations
+ * ===================================*/
+
+/** Copy constructor */
+CLASS_NAME(const CLASS_NAME &other) noexcept {
+  shm_init(other);
+}
+
+/** Copy assignment constructor */
+CLASS_NAME &operator=(const CLASS_NAME &other) {
+  if (this != &other) {
+    shm_strong_copy(
+      typed_nullptr<TYPED_HEADER >(),
+      typed_nullptr<Allocator>(),
+      other);
+  }
+  return *this;
+}
+
+/** Copy shm_init constructor */
+void shm_init_main(TYPED_HEADER *header,
+                   hipc::Allocator *alloc,
+                   const CLASS_NAME &other) {
+  shm_strong_copy(header, alloc, other);
+}
+
+/** Strong Copy operation */
+void shm_strong_copy(TYPED_HEADER *header, hipc::Allocator *alloc,
+                     const CLASS_NAME &other) {
+  if (other.IsNull()) { return; }
+  shm_destroy(false);
+  shm_strong_copy_main(header, alloc, other);
+  SetDestructable();
+}
+
+/**====================================
+ * Container Flag Operations
+ * ===================================*/
+
+/** Sets this object as destructable */
+void SetDestructable() {
+  obj_.SetDestructable();
+}
+
+/** Sets this object as not destructable */
+void UnsetDestructable() {
+  obj_.UnsetDestructable();
+}
+
+/** Check if this container is destructable */
+bool IsDestructable() const {
+  return obj_.IsDestructable();
+}
+
+/** Check if container has a valid header */
+bool IsValid() const {
+  return obj_.IsValid();
+}
+
+/** Set container header invalid */
+void UnsetValid() {
+  obj_.UnsetValid();
+}
+
+/**====================================
+ * Header Flag Operations
+ * ===================================*/
+
+/** Check if header's data is valid */
+bool IsDataValid() const {
+  return obj_.IsDataValid();
+}
+
+/** Check if header's data is valid */
+void UnsetDataValid() const {
+  return obj_.UnsetDataValid();
+}
+
+/** Check if null */
+bool IsNull() const {
+  return obj_.IsNull();
+}
+
+/** Get a typed pointer to the object */
+template<typename POINTER_T>
+POINTER_T GetShmPointer() const {
+  return GetAllocator()->template
+    Convert<TYPED_HEADER, POINTER_T>(header_);
+}
+
+/**====================================
+ * Query Operations
+ * ===================================*/
+
+/** Get the allocator for this container */
+Allocator* GetAllocator() {
+  return obj_.GetAllocator();
+}
+
+/** Get the allocator for this container */
+Allocator* GetAllocator() const {
+  return obj_.GetAllocator();
+}
+
+/** Get the shared-memory allocator id */
+allocator_id_t GetAllocatorId() const {
+  return GetAllocator()->GetId();
+}

--- a/hermes_shm/include/hermes_shm/data_structures/pair.h
+++ b/hermes_shm/include/hermes_shm/data_structures/pair.h
@@ -1,0 +1,203 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_PAIR_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_PAIR_H_
+
+#include "data_structure.h"
+#include "internal/shm_archive_or_t.h"
+
+namespace hermes_shm::ipc {
+
+/** forward declaration for string */
+template<typename FirstT, typename SecondT>
+class pair;
+
+/**
+ * MACROS used to simplify the string namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+#define CLASS_NAME pair
+#define TYPED_CLASS pair<FirstT, SecondT>
+#define TYPED_HEADER ShmHeader<TYPED_CLASS>
+
+/** pair shared-memory header */
+template<typename FirstT, typename SecondT>
+struct ShmHeader<TYPED_CLASS> : public ShmBaseHeader {
+  ShmHeaderOrT<FirstT> first_;
+  ShmHeaderOrT<SecondT> second_;
+
+  /** Default constructor */
+  ShmHeader() = default;
+
+  /** Constructor. Default shm allocate. */
+  explicit ShmHeader(Allocator *alloc)
+  : first_(alloc), second_(alloc) {}
+
+  /** Piecewise constructor. */
+  template<typename FirstArgPackT, typename SecondArgPackT>
+  explicit ShmHeader(Allocator *alloc,
+                     PiecewiseConstruct &&hint,
+                     FirstArgPackT &&first,
+                     SecondArgPackT &&second) {
+    (void) hint;
+    first_.PiecewiseInit(alloc, std::forward<FirstArgPackT>(first));
+    second_.PiecewiseInit(alloc, std::forward<SecondArgPackT>(second));
+  }
+
+  /** Move constructor. */
+  explicit ShmHeader(Allocator *alloc,
+                     FirstT &&first,
+                     SecondT &&second)
+  : first_(alloc, std::forward<FirstT>(first)),
+    second_(alloc, std::forward<SecondT>(second)) {}
+
+  /** Copy constructor. */
+  explicit ShmHeader(Allocator *alloc,
+                     const FirstT &first,
+                     const SecondT &second)
+  : first_(alloc, first), second_(alloc, second) {}
+
+  /** Shm destructor */
+  void shm_destroy(Allocator *alloc) {
+    first_.shm_destroy(alloc);
+    second_.shm_destroy(alloc);
+  }
+};
+
+/**
+ * A string of characters.
+ * */
+template<typename FirstT, typename SecondT>
+class pair : public ShmContainer {
+ public:
+  SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+
+ public:
+  hipc::ShmRef<FirstT> first_;
+  hipc::ShmRef<SecondT> second_;
+
+  public:
+  /** Default constructor */
+  pair() = default;
+
+  /** Default shm constructor */
+  void shm_init_main(TYPED_HEADER *header, Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header, alloc);
+  }
+
+  /** Construct pair by moving parameters */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc,
+                     FirstT &&first, SecondT &&second) {
+    shm_init_allocator(alloc);
+    shm_init_header(header,
+                    alloc_,
+                    std::forward<FirstT>(first),
+                    std::forward<SecondT>(second));
+    first_ = hipc::ShmRef<FirstT>(header_->first_.internal_ref(alloc_));
+    second_ = hipc::ShmRef<SecondT>(header_->second_.internal_ref(alloc_));
+  }
+
+  /** Construct pair by copying parameters */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc,
+                     const FirstT &first, const SecondT &second) {
+    shm_init_allocator(alloc);
+    shm_init_header(header,
+                    alloc_, first, second);
+    first_ = hipc::ShmRef<FirstT>(header_->first_.internal_ref(alloc_));
+    second_ = hipc::ShmRef<SecondT>(header_->second_.internal_ref(alloc_));
+  }
+
+  /** Construct pair piecewise */
+  template<typename FirstArgPackT, typename SecondArgPackT>
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc,
+                     PiecewiseConstruct &&hint,
+                     FirstArgPackT &&first,
+                     SecondArgPackT &&second) {
+    shm_init_allocator(alloc);
+    shm_init_header(header,
+                    alloc_,
+                    std::forward<PiecewiseConstruct>(hint),
+                    std::forward<FirstArgPackT>(first),
+                    std::forward<SecondArgPackT>(second));
+    first_ = hipc::ShmRef<FirstT>(header_->first_.internal_ref(alloc_));
+    second_ = hipc::ShmRef<SecondT>(header_->second_.internal_ref(alloc_));
+  }
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, pair &other) {
+    shm_init_main(header,
+                  alloc,
+                  std::move(*other.first_),
+                  std::move(*other.second_));
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const pair &other) {
+    shm_init_main(header,
+                  alloc, *other.first_, *other.second_);
+  }
+
+  /**
+   * Destroy the shared-memory data.
+   * */
+  void shm_destroy_main() {
+    header_->shm_destroy(alloc_);
+  }
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {
+    first_ = hipc::ShmRef<FirstT>(header_->first_.internal_ref(alloc_));
+    second_ = hipc::ShmRef<SecondT>(header_->second_.internal_ref(alloc_));
+  }
+
+  /** Get the first object */
+  FirstT& GetFirst() { return *first_; }
+
+  /** Get the first object (const) */
+  FirstT& GetFirst() const { return *first_; }
+
+  /** Get the second object */
+  SecondT& GetSecond() { return *second_; }
+
+  /** Get the second object (const) */
+  SecondT& GetSecond() const { return *second_; }
+
+  /** Get the first object (treated as key) */
+  FirstT& GetKey() { return *first_; }
+
+  /** Get the first object (treated as key) (const) */
+  FirstT& GetKey() const { return *first_; }
+
+  /** Get the second object (treated as value) */
+  SecondT& GetVal() { return *second_; }
+
+  /** Get the second object (treated as value) (const) */
+  SecondT& GetVal() const { return *second_; }
+};
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+}  // namespace hermes_shm::ipc
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_PAIR_H_

--- a/hermes_shm/include/hermes_shm/data_structures/smart_ptr/manual_ptr.h
+++ b/hermes_shm/include/hermes_shm/data_structures/smart_ptr/manual_ptr.h
@@ -1,0 +1,112 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_PTR_H_
+#define HERMES_SHM_DATA_STRUCTURES_PTR_H_
+
+#include "hermes_shm/memory/memory.h"
+#include "hermes_shm/data_structures/data_structure.h"
+#include "hermes_shm/data_structures/internal/shm_archive_or_t.h"
+
+namespace hermes_shm::ipc {
+
+/**
+ * MACROS to simplify the ptr namespace
+ * */
+#define CLASS_NAME manual_ptr
+#define TYPED_CLASS manual_ptr<T>
+
+/**
+ * Creates a unique instance of a shared-memory data structure
+ * and deletes eventually.
+ * */
+template<typename T>
+class manual_ptr : public ShmSmartPtr<T> {
+ public:
+  SHM_SMART_PTR_TEMPLATE(T);
+
+ public:
+  /** Default constructor does nothing */
+  manual_ptr() = default;
+
+  /** Allocates + constructs an object in shared memory */
+  template<typename ...Args>
+  void shm_init(Args&& ...args) {
+    obj_.shm_init(std::forward<Args>(args)...);
+    obj_.UnsetDestructable();
+  }
+
+  /** Destructor. Does not free data. */
+  ~manual_ptr() {
+    obj_.UnsetDestructable();
+  }
+
+  /** Copy constructor */
+  manual_ptr(const manual_ptr &other) {
+    obj_.shm_deserialize(other.obj_);
+  }
+
+  /** Copy assignment operator */
+  manual_ptr<T>& operator=(const manual_ptr<T> &other) {
+    if (this != &other) {
+      obj_.shm_deserialize(other.obj_);
+    }
+    return *this;
+  }
+
+  /** Move constructor */
+  manual_ptr(manual_ptr&& other) noexcept {
+    obj_ = std::move(other.obj_);
+  }
+
+  /** Constructor. From a TypedPointer<T> */
+  explicit manual_ptr(const TypedPointer<TYPED_CLASS> &ar) {
+    obj_.shm_deserialize(ar);
+  }
+
+  /** Constructor. From a TypedAtomicPointer<T> */
+  explicit manual_ptr(const TypedAtomicPointer<TYPED_CLASS> &ar) {
+    obj_.shm_deserialize(ar);
+  }
+
+  /** (De)serialize the obj from a TypedPointer<T> */
+  SHM_SERIALIZE_DESERIALIZE_WRAPPER((T));
+};
+
+template<typename T>
+using mptr = manual_ptr<T>;
+
+template<typename T, typename ...Args>
+static mptr<T> make_mptr(Args&& ...args) {
+  mptr<T> ptr;
+  ptr.shm_init(std::forward<Args>(args)...);
+  return ptr;
+}
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+
+namespace std {
+
+/** Hash function for ptr */
+template<typename T>
+struct hash<hermes_shm::ipc::manual_ptr<T>> {
+  size_t operator()(const hermes_shm::ipc::manual_ptr<T> &obj) const {
+    return std::hash<T>{}(obj.get_ref_const());
+  }
+};
+
+}  // namespace std
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_PTR_H_

--- a/hermes_shm/include/hermes_shm/data_structures/string.h
+++ b/hermes_shm/include/hermes_shm/data_structures/string.h
@@ -1,0 +1,301 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_LOCKLESS_STRING_H_
+#define HERMES_SHM_DATA_STRUCTURES_LOCKLESS_STRING_H_
+
+#include "data_structure.h"
+#include <string>
+
+namespace hermes_shm::ipc {
+
+/** forward declaration for string */
+class string;
+
+/**
+ * MACROS used to simplify the string namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+#define CLASS_NAME string
+#define TYPED_CLASS string
+#define TYPED_HEADER ShmHeader<string>
+
+/** string shared-memory header */
+template<>
+struct ShmHeader<string> : public ShmBaseHeader {
+  size_t length_;
+  AtomicPointer text_;
+
+  /** Default constructor */
+  ShmHeader() = default;
+
+  /** Copy constructor */
+  ShmHeader(const ShmHeader &other) {
+    strong_copy(other);
+  }
+
+  /** Copy assignment operator */
+  ShmHeader& operator=(const ShmHeader &other) {
+    if (this != &other) {
+      strong_copy(other);
+    }
+    return *this;
+  }
+
+  /** Strong copy operation */
+  void strong_copy(const ShmHeader &other) {
+    length_ = other.length_;
+    text_ = other.text_;
+  }
+
+  /** Move constructor */
+  ShmHeader(ShmHeader &&other) {
+    weak_move(other);
+  }
+
+  /** Move operator */
+  ShmHeader& operator=(ShmHeader &&other) {
+    if (this != &other) {
+      weak_move(other);
+    }
+    return *this;
+  }
+
+  /** Move operation */
+  void weak_move(ShmHeader &other) {
+    strong_copy(other);
+  }
+};
+
+/**
+ * A string of characters.
+ * */
+class string : public ShmContainer {
+ public:
+  SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+
+ public:
+  char *text_;
+  size_t length_;
+
+ public:
+  ////////////////////////////
+  /// SHM Overrides
+  ////////////////////////////
+
+  /** Default constructor */
+  string() : length_(0) {}
+
+  /** Default shm constructor */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+  }
+
+  /** Construct from a C-style string with allocator in shared memory */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, const char *text) {
+    size_t length = strlen(text);
+    shm_init_main(header, alloc, length);
+    _create_str(text, length);
+  }
+
+  /** Construct for an std::string with allocator in shared-memory */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, const std::string &text) {
+    shm_init_main(header, alloc, text.size());
+    _create_str(text.data(), text.size());
+  }
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, string &other) {
+    shm_init_main(header, alloc);
+    header_->length_ = other.header_->length_;
+    header_->text_ = other.header_->text_;
+    shm_deserialize_main();
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const string &other) {
+    shm_init_main(header, alloc, other.size());
+    _create_str(other.data(), other.size());
+    shm_deserialize_main();
+  }
+
+  /** Construct by concatenating two string in shared-memory */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc,
+                     const string &text1, const string &text2) {
+    size_t length = text1.size() + text2.size();
+    shm_init_main(header, alloc, length);
+    memcpy(text_,
+           text1.data(), text1.size());
+    memcpy(text_ + text1.size(),
+           text2.data(), text2.size());
+    text_[length] = 0;
+  }
+
+  /**
+   * Construct a string of specific length and allocator in shared memory
+   * */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, size_t length) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    text_ = alloc_->template
+      AllocatePtr<char>(
+        length + 1,
+        header_->text_);
+    header_->length_ = length;
+    length_ = length;
+    text_[length] = 0;
+  }
+
+  /**
+   * Destroy the shared-memory data.
+   * */
+  void shm_destroy_main() {
+    if (length_) {
+      alloc_->Free(header_->text_);
+      length_ = 0;
+    }
+  }
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {
+    text_ = alloc_->template
+      Convert<char>(header_->text_);
+    length_ = header_->length_;
+  }
+
+  ////////////////////////////
+  /// String Operations
+  ////////////////////////////
+
+  /** Get character at index i in the string */
+  char& operator[](size_t i) const {
+    return text_[i];
+  }
+
+  /** Convert into a std::string */
+  std::string str() const {
+    return {text_, length_};
+  }
+
+  /** Add two strings together */
+  string operator+(const std::string &other) {
+    string tmp(other);
+    return string(GetAllocator(), *this, tmp);
+  }
+
+  /** Add two strings together */
+  string operator+(const string &other) {
+    return string(GetAllocator(), *this, other);
+  }
+
+  /** Get the size of the current string */
+  size_t size() const {
+    return length_;
+  }
+
+  /** Get a constant reference to the C-style string */
+  char* c_str() const {
+    return text_;
+  }
+
+  /** Get a constant reference to the C-style string */
+  char* data() const {
+    return text_;
+  }
+
+  /** Get a mutable reference to the C-style string */
+  char* data_mutable() {
+    return text_;
+  }
+
+  /**
+   * Comparison operators
+   * */
+
+  int _strncmp(const char *a, size_t len_a,
+               const char *b, size_t len_b) const {
+    if (len_a != len_b) {
+      return int((int64_t)len_a - (int64_t)len_b);
+    }
+    int sum = 0;
+    for (size_t i = 0; i < len_a; ++i) {
+      sum += a[i] - b[i];
+    }
+    return sum;
+  }
+
+#define HERMES_SHM_STR_CMP_OPERATOR(op) \
+  bool operator op(const char *other) const { \
+    return _strncmp(data(), size(), other, strlen(other)) op 0; \
+  } \
+  bool operator op(const std::string &other) const { \
+    return _strncmp(data(), size(), other.data(), other.size()) op 0; \
+  } \
+  bool operator op(const string &other) const { \
+    return _strncmp(data(), size(), other.data(), other.size()) op 0; \
+  }
+
+  HERMES_SHM_STR_CMP_OPERATOR(==)
+  HERMES_SHM_STR_CMP_OPERATOR(!=)
+  HERMES_SHM_STR_CMP_OPERATOR(<)
+  HERMES_SHM_STR_CMP_OPERATOR(>)
+  HERMES_SHM_STR_CMP_OPERATOR(<=)
+  HERMES_SHM_STR_CMP_OPERATOR(>=)
+
+#undef HERMES_SHM_STR_CMP_OPERATOR
+
+ private:
+  inline void _create_str(const char *text, size_t length) {
+    memcpy(text_, text, length);
+    text_[length] = 0;
+  }
+};
+
+/** Consider the string as an uniterpreted set of bytes */
+typedef string charbuf;
+
+}  // namespace hermes_shm::ipc
+
+namespace std {
+
+/** Hash function for string */
+template<>
+struct hash<hermes_shm::ipc::string> {
+  size_t operator()(const hermes_shm::ipc::string &text) const {
+    size_t sum = 0;
+    for (size_t i = 0; i < text.size(); ++i) {
+      auto shift = static_cast<size_t>(i % sizeof(size_t));
+      auto c = static_cast<size_t>((unsigned char)text[i]);
+      sum = 31*sum + (c << shift);
+    }
+    return sum;
+  }
+};
+
+}  // namespace std
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_LOCKLESS_STRING_H_

--- a/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/list.h
+++ b/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/list.h
@@ -1,0 +1,517 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_THREAD_UNSAFE_LIST_H_
+#define HERMES_SHM_DATA_STRUCTURES_THREAD_UNSAFE_LIST_H_
+
+#include "hermes_shm/data_structures/data_structure.h"
+#include "hermes_shm/data_structures/internal/shm_archive_or_t.h"
+
+#include <list>
+
+namespace hermes_shm::ipc {
+
+/** forward pointer for list */
+template<typename T>
+class list;
+
+/** represents an object within a list */
+template<typename T>
+struct list_entry {
+ public:
+  OffsetPointer next_ptr_, prior_ptr_;
+  ShmHeaderOrT<T> data_;
+
+  /** Constructor */
+  template<typename ...Args>
+  explicit list_entry(Allocator *alloc, Args ...args)
+  : data_(alloc, std::forward<Args>(args)...) {}
+
+  /** Destructor */
+  void shm_destroy(Allocator *alloc) {
+    data_.shm_destroy(alloc);
+  }
+
+  /** Returns the element stored in the list */
+  ShmRef<T> internal_ref(Allocator *alloc) {
+    return ShmRef<T>(data_.internal_ref(alloc));
+  }
+
+  /** Returns the element stored in the list */
+  ShmRef<T> internal_ref(Allocator *alloc) const {
+    return ShmRef<T>(data_.internal_ref(alloc));
+  }
+};
+
+/**
+ * The list iterator
+ * */
+template<typename T>
+struct list_iterator_templ {
+ public:
+  /**< A shm reference to the containing list object. */
+  hipc::ShmRef<list<T>> list_;
+  /**< A pointer to the entry in shared memory */
+  list_entry<T> *entry_;
+  /**< The offset of the entry in the shared-memory allocator */
+  OffsetPointer entry_ptr_;
+
+  /** Default constructor */
+  list_iterator_templ() = default;
+
+  /** End iterator */
+  explicit list_iterator_templ(bool)
+  : entry_(nullptr), entry_ptr_(OffsetPointer::GetNull()) {}
+
+  /** Construct an iterator  */
+  explicit list_iterator_templ(TypedPointer<list<T>> list)
+  : list_(list), entry_(nullptr), entry_ptr_(OffsetPointer::GetNull()) {}
+
+  /** Construct an iterator  */
+  explicit list_iterator_templ(TypedPointer<list<T>> list,
+                               list_entry<T> *entry,
+                               OffsetPointer entry_ptr)
+    : list_(list), entry_(entry), entry_ptr_(entry_ptr) {}
+
+  /** Copy constructor */
+  list_iterator_templ(const list_iterator_templ &other) {
+    list_ = other.list_;
+    entry_ = other.entry_;
+    entry_ptr_ = other.entry_ptr_;
+  }
+
+  /** Assign this iterator from another iterator */
+  list_iterator_templ& operator=(const list_iterator_templ &other) {
+    if (this != &other) {
+      list_ = other.list_;
+      entry_ = other.entry_;
+      entry_ptr_ = other.entry_ptr_;
+    }
+    return *this;
+  }
+
+  /** Get the object the iterator points to */
+  ShmRef<T> operator*() {
+    return entry_->internal_ref(list_->GetAllocator());
+  }
+
+  /** Get the object the iterator points to */
+  const ShmRef<T> operator*() const {
+    return entry_->internal_ref();
+  }
+
+  /** Get the next iterator (in place) */
+  list_iterator_templ& operator++() {
+    if (is_end()) { return *this; }
+    entry_ptr_ = entry_->next_ptr_;
+    entry_ = list_->alloc_->template
+      Convert<list_entry<T>>(entry_->next_ptr_);
+    return *this;
+  }
+
+  /** Get the prior iterator (in place) */
+  list_iterator_templ& operator--() {
+    if (is_end() || is_begin()) { return *this; }
+    entry_ptr_ = entry_->prior_ptr_;
+    entry_ = list_->alloc_->template
+      Convert<list_entry<T>>(entry_->prior_ptr_);
+    return *this;
+  }
+
+  /** Return the next iterator */
+  list_iterator_templ operator++(int) const {
+    list_iterator_templ next_iter(*this);
+    ++next_iter;
+    return next_iter;
+  }
+
+  /** Return the prior iterator */
+  list_iterator_templ operator--(int) const {
+    list_iterator_templ prior_iter(*this);
+    --prior_iter;
+    return prior_iter;
+  }
+
+  /** Return the iterator at count after this one */
+  list_iterator_templ operator+(size_t count) const {
+    list_iterator_templ pos(*this);
+    for (size_t i = 0; i < count; ++i) {
+      ++pos;
+    }
+    return pos;
+  }
+
+  /** Return the iterator at count before this one */
+  list_iterator_templ operator-(size_t count) const {
+    list_iterator_templ pos(*this);
+    for (size_t i = 0; i < count; ++i) {
+      --pos;
+    }
+    return pos;
+  }
+
+  /** Get the iterator at count after this one (in-place) */
+  void operator+=(size_t count) {
+    list_iterator_templ pos = (*this) + count;
+    entry_ = pos.entry_;
+    entry_ptr_ = pos.entry_ptr_;
+  }
+
+  /** Get the iterator at count before this one (in-place) */
+  void operator-=(size_t count) {
+    list_iterator_templ pos = (*this) - count;
+    entry_ = pos.entry_;
+    entry_ptr_ = pos.entry_ptr_;
+  }
+
+  /** Determine if two iterators are equal */
+  friend bool operator==(const list_iterator_templ &a,
+                         const list_iterator_templ &b) {
+    return (a.is_end() && b.is_end()) || (a.entry_ == b.entry_);
+  }
+
+  /** Determine if two iterators are inequal */
+  friend bool operator!=(const list_iterator_templ &a,
+                         const list_iterator_templ &b) {
+    return !(a.is_end() && b.is_end()) && (a.entry_ != b.entry_);
+  }
+
+  /** Create the end iterator */
+  static list_iterator_templ const end() {
+    const static list_iterator_templ end_iter(true);
+    return end_iter;
+  }
+
+  /** Determine whether this iterator is the end iterator */
+  bool is_end() const {
+    return entry_ == nullptr;
+  }
+
+  /** Determine whether this iterator is the begin iterator */
+  bool is_begin() const {
+    if (entry_) {
+      return entry_->prior_ptr_.IsNull();
+    } else {
+      return false;
+    }
+  }
+};
+
+/** forward iterator typedef */
+template<typename T>
+using list_iterator = list_iterator_templ<T>;
+
+/** const forward iterator typedef */
+template<typename T>
+using list_citerator = list_iterator_templ<T>;
+
+
+/**
+ * MACROS used to simplify the list namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+#define CLASS_NAME list
+#define TYPED_CLASS list<T>
+#define TYPED_HEADER ShmHeader<list<T>>
+
+/**
+ * The list shared-memory header
+ * */
+template<typename T>
+struct ShmHeader<list<T>> : public ShmBaseHeader {
+  OffsetPointer head_ptr_, tail_ptr_;
+  size_t length_;
+
+  /** Default constructor */
+  ShmHeader() = default;
+
+  /** Copy constructor */
+  ShmHeader(const ShmHeader &other) {
+    strong_copy(other);
+  }
+
+  /** Copy assignment operator */
+  ShmHeader& operator=(const ShmHeader &other) {
+    if (this != &other) {
+      strong_copy(other);
+    }
+    return *this;
+  }
+
+  /** Strong copy operation */
+  void strong_copy(const ShmHeader &other) {
+    head_ptr_ = other.head_ptr_;
+    tail_ptr_ = other.tail_ptr_;
+    length_ = other.length_;
+  }
+
+  /** Move constructor */
+  ShmHeader(ShmHeader &&other) {
+    weak_move(other);
+  }
+
+  /** Move operator */
+  ShmHeader& operator=(ShmHeader &&other) {
+    if (this != &other) {
+      weak_move(other);
+    }
+    return *this;
+  }
+
+  /** Move operation */
+  void weak_move(ShmHeader &other) {
+    strong_copy(other);
+  }
+};
+
+/**
+ * Doubly linked list implementation
+ * */
+template<typename T>
+class list : public ShmContainer {
+ public:
+  SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+
+ public:
+  ////////////////////////////
+  /// SHM Overrides
+  ////////////////////////////
+
+  /** Default constructor */
+  list() = default;
+
+  /** Initialize list in shared memory */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    header_->length_ = 0;
+    header_->head_ptr_.SetNull();
+    header_->tail_ptr_.SetNull();
+  }
+
+  /** Copy from std::list */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, std::list<T> &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    for (auto &entry : other) {
+      emplace_back(entry);
+    }
+  }
+
+  /** Destroy all shared memory allocated by the list */
+  void shm_destroy_main() {
+    clear();
+  }
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, list &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    *header_ = *(other.header_);
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const list &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    for (auto iter = other.cbegin(); iter != other.cend(); ++iter) {
+      emplace_back(**iter);
+    }
+  }
+
+  ////////////////////////////
+  /// List Methods
+  ////////////////////////////
+
+  /** Construct an element at the back of the list */
+  template<typename... Args>
+  void emplace_back(Args&&... args) {
+    emplace(end(), std::forward<Args>(args)...);
+  }
+
+  /** Construct an element at the beginning of the list */
+  template<typename... Args>
+  void emplace_front(Args&&... args) {
+    emplace(begin(), std::forward<Args>(args)...);
+  }
+
+  /** Construct an element at \a pos position in the list */
+  template<typename ...Args>
+  void emplace(list_iterator<T> pos, Args&&... args) {
+    OffsetPointer entry_ptr;
+    auto entry = _create_entry(entry_ptr, std::forward<Args>(args)...);
+    if (size() == 0) {
+      entry->prior_ptr_.SetNull();
+      entry->next_ptr_.SetNull();
+      header_->head_ptr_ = entry_ptr;
+      header_->tail_ptr_ = entry_ptr;
+    } else if (pos.is_begin()) {
+      entry->prior_ptr_.SetNull();
+      entry->next_ptr_ = header_->head_ptr_;
+      auto head = alloc_->template
+        Convert<list_entry<T>>(header_->tail_ptr_);
+      head->prior_ptr_ = entry_ptr;
+      header_->head_ptr_ = entry_ptr;
+    } else if (pos.is_end()) {
+      entry->prior_ptr_ = header_->tail_ptr_;
+      entry->next_ptr_.SetNull();
+      auto tail = alloc_->template
+        Convert<list_entry<T>>(header_->tail_ptr_);
+      tail->next_ptr_ = entry_ptr;
+      header_->tail_ptr_ = entry_ptr;
+    } else {
+      auto next = alloc_->template
+        Convert<list_entry<T>>(pos.entry_->next_ptr_);
+      auto prior = alloc_->template
+        Convert<list_entry<T>>(pos.entry_->prior_ptr_);
+      entry->next_ptr_ = pos.entry_->next_ptr_;
+      entry->prior_ptr_ = pos.entry_->prior_ptr_;
+      next->prior_ptr_ = entry_ptr;
+      prior->next_ptr_ = entry_ptr;
+    }
+    ++header_->length_;
+  }
+
+  /** Erase element with ID */
+  void erase(const T &entry) {
+    auto iter = find(entry);
+    erase(iter);
+  }
+
+  /** Erase the element at pos */
+  void erase(list_iterator<T> pos) {
+    erase(pos, pos+1);
+  }
+
+  /** Erase all elements between first and last */
+  void erase(list_iterator<T> first,
+             list_iterator<T> last) {
+    if (first.is_end()) { return; }
+    auto first_prior_ptr = first.entry_->prior_ptr_;
+    auto pos = first;
+    while (pos != last) {
+      auto next = pos + 1;
+      pos.entry_->shm_destroy(alloc_);
+      Allocator::DestructObj<list_entry<T>>(*pos.entry_);
+      alloc_->Free(pos.entry_ptr_);
+      --header_->length_;
+      pos = next;
+    }
+
+    if (first_prior_ptr.IsNull()) {
+      header_->head_ptr_ = last.entry_ptr_;
+    } else {
+      auto first_prior = alloc_->template
+        Convert<list_entry<T>>(first_prior_ptr);
+      first_prior->next_ptr_ = last.entry_ptr_;
+    }
+
+    if (last.entry_ptr_.IsNull()) {
+      header_->tail_ptr_ = first_prior_ptr;
+    } else {
+      last.entry_->prior_ptr_ = first_prior_ptr;
+    }
+  }
+
+  /** Destroy all elements in the list */
+  void clear() {
+    erase(begin(), end());
+  }
+
+  /** Get the object at the front of the list */
+  ShmRef<T> front() {
+    return *begin();
+  }
+
+  /** Get the object at the back of the list */
+  ShmRef<T> back() {
+    return *end();
+  }
+
+  /** Get the number of elements in the list */
+  size_t size() const {
+    if (!IsNull()) {
+      return header_->length_;
+    }
+    return 0;
+  }
+  
+  /** Find an element in this list */
+  list_iterator<T> find(const T &entry) {
+    for (auto iter = begin(); iter != end(); ++iter) {
+      hipc::ShmRef<T> ref = *iter;
+      if (*ref == entry) {
+        return iter;
+      }
+    }
+    return end();
+  }
+
+  /**
+   * ITERATORS
+   * */
+
+  /** Forward iterator begin */
+  list_iterator<T> begin() {
+    if (size() == 0) { return end(); }
+    auto head = alloc_->template
+      Convert<list_entry<T>>(header_->head_ptr_);
+    return list_iterator<T>(GetShmPointer<TypedPointer<list<T>>>(),
+      head, header_->head_ptr_);
+  }
+
+  /** Forward iterator end */
+  static list_iterator<T> const end() {
+    return list_iterator<T>::end();
+  }
+
+  /** Constant forward iterator begin */
+  list_citerator<T> cbegin() const {
+    if (size() == 0) { return cend(); }
+    auto head = alloc_->template
+      Convert<list_entry<T>>(header_->head_ptr_);
+    return list_citerator<T>(GetShmPointer<TypedPointer<list<T>>>(),
+      head, header_->head_ptr_);
+  }
+
+  /** Constant forward iterator end */
+  static list_citerator<T> const cend() {
+    return list_citerator<T>::end();
+  }
+
+ private:
+  template<typename ...Args>
+  list_entry<T>* _create_entry(OffsetPointer &p, Args&& ...args) {
+    auto entry = alloc_->template
+      AllocateConstructObjs<list_entry<T>>(
+        1, p, alloc_, std::forward<Args>(args)...);
+    return entry;
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_THREAD_UNSAFE_LIST_H_

--- a/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/unordered_map.h
+++ b/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/unordered_map.h
@@ -1,0 +1,540 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_UNORDERED_MAP_H_
+#define HERMES_SHM_DATA_STRUCTURES_UNORDERED_MAP_H_
+
+#include "hermes_shm/thread/thread_manager.h"
+#include "hermes_shm/data_structures/thread_unsafe/vector.h"
+#include "hermes_shm/data_structures/thread_unsafe/list.h"
+#include "hermes_shm/data_structures/pair.h"
+#include "hermes_shm/data_structures/data_structure.h"
+#include "hermes_shm/types/atomic.h"
+
+namespace hermes_shm::ipc {
+
+/** forward pointer for unordered_map */
+template<typename Key, typename T, class Hash = std::hash<Key>>
+class unordered_map;
+
+/**
+ * The unordered map iterator (bucket_iter, list_iter)
+ * */
+template<typename Key, typename T, class Hash>
+struct unordered_map_iterator {
+ public:
+  using COLLISION_T = hipc::pair<Key, T>;
+  using BUCKET_T = hipc::list<COLLISION_T>;
+
+ public:
+  hipc::ShmRef<unordered_map<Key, T, Hash>> map_;
+  vector_iterator<BUCKET_T> bucket_;
+  list_iterator<COLLISION_T> collision_;
+
+  /** Default constructor */
+  unordered_map_iterator() = default;
+
+  /** Construct the iterator  */
+  explicit unordered_map_iterator(TypedPointer<unordered_map<Key, T, Hash>> map)
+  : map_(map) {}
+
+  /** Copy constructor  */
+  unordered_map_iterator(const unordered_map_iterator &other) {
+    shm_strong_copy(other);
+  }
+
+  /** Assign one iterator into another */
+  unordered_map_iterator<Key, T, Hash>&
+  operator=(const unordered_map_iterator<Key, T, Hash> &other) {
+    if (this != &other) {
+      shm_strong_copy(other);
+    }
+    return *this;
+  }
+
+  /** Copy an iterator */
+  void shm_strong_copy(const unordered_map_iterator<Key, T, Hash> &other) {
+    map_ = other.map_;
+    bucket_ = other.bucket_;
+    collision_ = other.collision_;
+  }
+
+  /** Get the pointed object */
+  hipc::ShmRef<COLLISION_T> operator*() {
+    return *collision_;
+  }
+
+  /** Get the pointed object */
+  const hipc::ShmRef<COLLISION_T> operator*() const {
+    return *collision_;
+  }
+
+  /** Go to the next object */
+  unordered_map_iterator& operator++() {
+    ++collision_;
+    make_correct();
+    return *this;
+  }
+
+  /** Return the next iterator */
+  unordered_map_iterator operator++(int) const {
+    unordered_map_iterator next(*this);
+    ++next;
+    return next;
+  }
+
+  /**
+   * Shifts bucket and collision iterator until there is a valid element.
+   * Returns true if such an element is found, and false otherwise.
+   * */
+  bool make_correct() {
+    do {
+      if (bucket_.is_end()) {
+        return false;
+      }
+      BUCKET_T& bkt = (**bucket_);
+      list<COLLISION_T> &collisions = bkt;
+      if (collision_ != collisions.end()) {
+        return true;
+      } else {
+        ++bucket_;
+        if (bucket_.is_end()) {
+          return false;
+        }
+        BUCKET_T& new_bkt = (**bucket_);
+        list<COLLISION_T> &new_collisions = new_bkt;
+        collision_ = collisions.begin();
+      }
+    } while (true);
+  }
+
+  /** Check if two iterators are equal */
+  friend bool operator==(const unordered_map_iterator &a,
+                         const unordered_map_iterator &b) {
+    if (a.is_end() && b.is_end()) {
+      return true;
+    }
+    return (a.bucket_ == b.bucket_) && (a.collision_ == b.collision_);
+  }
+
+  /** Check if two iterators are inequal */
+  friend bool operator!=(const unordered_map_iterator &a,
+                         const unordered_map_iterator &b) {
+    if (a.is_end() && b.is_end()) {
+      return false;
+    }
+    return (a.bucket_ != b.bucket_) || (a.collision_ != b.collision_);
+  }
+
+  /** Determine whether this iterator is the end iterator */
+  bool is_end() const {
+    return bucket_.is_end();
+  }
+
+  /** Set this iterator to the end iterator */
+  void set_end() {
+    bucket_.set_end();
+  }
+};
+
+/**
+ * MACROS to simplify the unordered_map namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+
+#define CLASS_NAME unordered_map
+#define TYPED_CLASS unordered_map<Key, T, Hash>
+#define TYPED_HEADER ShmHeader<unordered_map<Key, T, Hash>>
+
+/**
+ * The unordered_map shared-memory header
+ * */
+template<typename Key, typename T, class Hash>
+struct ShmHeader<TYPED_CLASS> : public ShmBaseHeader {
+ public:
+  using COLLISION_T = hipc::pair<Key, T>;
+  using BUCKET_T = hipc::list<COLLISION_T>;
+
+ public:
+  ShmHeaderOrT<vector<BUCKET_T>> buckets_;
+  RealNumber max_capacity_;
+  RealNumber growth_;
+  hipc::atomic<size_t> length_;
+
+  /** Default constructor. */
+  ShmHeader() = default;
+
+  /** Constructor. Initialize header. */
+  explicit ShmHeader(Allocator *alloc,
+                     int num_buckets,
+                     RealNumber max_capacity,
+                     RealNumber growth) : buckets_(alloc, num_buckets) {
+    max_capacity_ = max_capacity;
+    growth_ = growth;
+    length_ = 0;
+  }
+
+  /** Copy constructor */
+  ShmHeader(const ShmHeader &other) = delete;
+
+  /** Move constructor */
+  ShmHeader(ShmHeader &&other) = delete;
+
+  /** True move constructor. */
+  explicit ShmHeader(Allocator *alloc,
+                     ShmHeader &&other, Allocator *other_alloc) {
+    (*GetBuckets(alloc)) = std::move(*other.GetBuckets(other_alloc));
+    max_capacity_ = other.max_capacity_;
+    growth_ = other.growth_;
+    length_ = other.length_.load();/**/
+  }
+
+  /** Get a reference to the buckets */
+  hipc::ShmRef<vector<BUCKET_T>> GetBuckets(Allocator *alloc) {
+    return hipc::ShmRef<vector<BUCKET_T>>(buckets_.internal_ref(alloc));
+  }
+};
+
+/**
+ * The unordered map implementation
+ * */
+template<typename Key, typename T, class Hash>
+class unordered_map : public ShmContainer {
+ public:
+  SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+  friend unordered_map_iterator<Key, T, Hash>;
+
+ public:
+  using COLLISION_T = hipc::pair<Key, T>;
+  using BUCKET_T = hipc::list<COLLISION_T>;
+
+ public:
+  ////////////////////////////
+  /// SHM Overrides
+  ////////////////////////////
+
+  /** Default constructor */
+  unordered_map() = default;
+
+  /**
+   * Initialize unordered map
+   *
+   * @param alloc the shared-memory allocator
+   * @param num_buckets the number of buckets to create
+   * @param max_capacity the maximum number of elements before a growth is
+   * triggered
+   * @param growth the multiplier to grow the bucket vector size
+   * */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc,
+                     int num_buckets = 20,
+                     RealNumber max_capacity = RealNumber(4,5),
+                     RealNumber growth = RealNumber(5, 4)) {
+    shm_init_allocator(alloc);
+    shm_init_header(header, alloc_, num_buckets, max_capacity, growth);
+  }
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, unordered_map &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header,
+                    alloc_,
+                    std::move(*other.header_),
+                    other.GetAllocator());
+  }
+
+  /** Copy constructor */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const unordered_map &other) {
+    auto num_buckets = other.get_num_buckets();
+    auto max_capacity = other.header_->max_capacity_;
+    auto growth = other.header_->growth_;
+    shm_init_allocator(alloc);
+    shm_init_header(header, alloc_, num_buckets, max_capacity, growth);
+    for (auto entry : other) {
+      emplace_templ<false, true>(
+        entry->GetKey(), entry->GetVal());
+    }
+  }
+
+  /** Destroy the unordered_map buckets */
+  void shm_destroy_main() {
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    buckets->shm_destroy();
+  }
+
+  ////////////////////////////
+  /// Map Operations
+  ////////////////////////////
+
+  /**
+   * Construct an object directly in the map. Overrides the object if
+   * key already exists.
+   *
+   * @param key the key to future index the map
+   * @param args the arguments to construct the object
+   * @return None
+   * */
+  template<typename ...Args>
+  bool emplace(const Key &key, Args&&... args) {
+    return emplace_templ<true, true>(key, std::forward<Args>(args)...);
+  }
+
+  /**
+   * Construct an object directly in the map. Does not modify the key
+   * if it already exists.
+   *
+   * @param key the key to future index the map
+   * @param args the arguments to construct the object
+   * @return None
+   * */
+  template<typename ...Args>
+  bool try_emplace(const Key &key, Args&&... args) {
+    return emplace_templ<true, false>(key, std::forward<Args>(args)...);
+  }
+
+  /**
+   * Erase an object indexable by \a key key
+   * */
+  void erase(const Key &key) {
+    if (header_ == nullptr) { shm_init(); }
+    // Get the bucket the key belongs to
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    size_t bkt_id = Hash{}(key) % buckets->size();
+    hipc::ShmRef<BUCKET_T> bkt = (*buckets)[bkt_id];
+
+    // Find and remove key from collision list
+    list<COLLISION_T> &collisions = *bkt;
+    auto iter = find_collision(key, collisions);
+    if (iter.is_end()) {
+      return;
+    }
+    collisions.erase(iter);
+
+    // Decrement the size of the map
+    --header_->length_;
+  }
+
+  /**
+   * Erase an object at the iterator
+   * */
+  void erase(unordered_map_iterator<Key, T, Hash> &iter) {
+    if (iter == end()) return;
+    // Acquire the bucket lock for a write (modifying collisions)
+    hipc::ShmRef<BUCKET_T> bkt = *iter.bucket_;
+    
+    // Erase the element from the collision list
+    list<COLLISION_T> &collisions = bkt;
+    collisions.erase(iter.collision_);
+
+    // Decrement the size of the map
+    --header_->length_;
+  }
+
+  /**
+   * Erase the entire map
+   * */
+  void clear() {
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    size_t num_buckets = buckets->size();
+    buckets->clear();
+    buckets->resize(num_buckets);
+    header_->length_ = 0;
+  }
+
+  /**
+   * Locate an entry in the unordered_map
+   *
+   * @return the object pointed by key
+   * @exception UNORDERED_MAP_CANT_FIND the key was not in the map
+   * */
+  ShmRef<T> operator[](const Key &key) {
+    auto iter = find(key);
+    if (iter != end()) {
+      return (*iter)->second_;
+    }
+    throw UNORDERED_MAP_CANT_FIND.format();
+  }
+
+  /**
+   * Find an object in the unordered_map
+   * */
+  unordered_map_iterator<Key, T, Hash> find(const Key &key) {
+    unordered_map_iterator<Key, T, Hash> iter(
+      GetShmPointer<TypedPointer<unordered_map_iterator<Key, T, Hash>>>());
+
+    // Determine the bucket corresponding to the key
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    size_t bkt_id = Hash{}(key) % buckets->size();
+    iter.bucket_ = buckets->begin() + bkt_id;
+    hipc::ShmRef<BUCKET_T> bkt = (*iter.bucket_);
+    list<COLLISION_T> &collisions = *bkt;
+
+    // Get the specific collision iterator
+    iter.collision_ = find_collision(key, collisions);
+    if (iter.collision_.is_end()) {
+      iter.set_end();
+    }
+    return iter;
+  }
+
+  /** The number of entries in the map */
+  size_t size() const {
+    if (header_ == nullptr) {
+      return 0;
+    }
+    return header_->length_.load();
+  }
+
+  /** The number of buckets in the map */
+  size_t get_num_buckets() const {
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    return buckets->size();
+  }
+
+ private:
+  /**
+   * Find a key in the collision list
+   * */
+  list_iterator<COLLISION_T>
+  find_collision(const Key &key, list<COLLISION_T> &collisions) {
+    auto iter = collisions.begin();
+    auto iter_end = collisions.end();
+    for (; iter != iter_end; ++iter) {
+      COLLISION_T entry(alloc_, **iter);
+      if (entry.GetKey() == key) {
+        return iter;
+      }
+    }
+    return iter_end;
+  }
+
+  /**
+   * Construct an object directly in the map
+   *
+   * @param key the key to future index the map
+   * @param args the arguments to construct the object
+   * @return None
+   * */
+  template<bool growth, bool modify_existing, typename ...Args>
+  bool emplace_templ(const Key &key, Args&&... args) {
+    COLLISION_T entry(alloc_,
+                      PiecewiseConstruct(),
+                      make_argpack(key),
+                      make_argpack(std::forward<Args>(args)...));
+    return insert_templ<growth, modify_existing>(entry);
+  }
+
+  /**
+   * Insert a serialized (key, value) pair in the map
+   *
+   * @param growth whether or not to grow the unordered map on collision
+   * @param modify_existing whether or not to override an existing entry
+   * @param entry the (key,value) pair shared-memory serialized
+   * @return None
+   * */
+  template<bool growth, bool modify_existing>
+  bool insert_templ(COLLISION_T &entry) {
+    if (header_ == nullptr) { shm_init(); }
+    Key &key = entry.GetKey();
+
+    // Hash the key to a bucket
+    hipc::ShmRef<vector<BUCKET_T>> buckets = GetBuckets();
+    size_t bkt_id = Hash{}(key) % buckets->size();
+    hipc::ShmRef<BUCKET_T> bkt = (*buckets)[bkt_id];
+
+    // Insert into the map
+    list<COLLISION_T> &collisions = *bkt;
+    auto has_key = find_collision(key, collisions);
+    if (has_key != collisions.end()) {
+      if constexpr(!modify_existing) {
+        return false;
+      } else {
+        collisions.erase(has_key);
+        collisions.emplace_back(std::move(entry));
+        return true;
+      }
+    }
+    collisions.emplace_back(std::move(entry));
+
+    // Increment the size of the map
+    ++header_->length_;
+    return true;
+  }
+
+  bool insert_simple(COLLISION_T &&entry,
+                     vector<BUCKET_T> &buckets) {
+    if (header_ == nullptr) { shm_init(); }
+    Key &key = entry.GetKey();
+    size_t bkt_id = Hash{}(key) % buckets.size();
+    hipc::ShmRef<BUCKET_T> bkt = buckets[bkt_id];
+    list<COLLISION_T>& collisions = bkt;
+    collisions.emplace_back(std::move(entry));
+    return true;
+  }
+
+
+ public:
+  ////////////////////////////
+  /// Iterators
+  ////////////////////////////
+
+  /** Forward iterator begin */
+  inline unordered_map_iterator<Key, T, Hash> begin() const {
+    unordered_map_iterator<Key, T, Hash> iter(
+      GetShmPointer<TypedPointer<unordered_map_iterator<Key, T, Hash>>>());
+    hipc::ShmRef<vector<BUCKET_T>> buckets(GetBuckets());
+    if (buckets->size() == 0) {
+      return iter;
+    }
+    hipc::ShmRef<BUCKET_T> bkt = (*buckets)[0];
+    list<COLLISION_T> &list = *bkt;
+    iter.bucket_ = buckets->cbegin();
+    iter.collision_ = list.begin();
+    iter.make_correct();
+    return iter;
+  }
+
+  /** Forward iterator end */
+  inline unordered_map_iterator<Key, T, Hash> end() const {
+    unordered_map_iterator<Key, T, Hash> iter(
+      GetShmPointer<TypedPointer<unordered_map_iterator<Key, T, Hash>>>());
+    hipc::ShmRef<vector<BUCKET_T>> buckets(GetBuckets());
+    iter.bucket_ = buckets->cend();
+    return iter;
+  }
+
+  /** Get the buckets */
+  hipc::ShmRef<vector<BUCKET_T>> GetBuckets() {
+    return header_->GetBuckets(alloc_);
+  }
+
+  /** Get the buckets (const) */
+  hipc::ShmRef<vector<BUCKET_T>> GetBuckets() const {
+    return header_->GetBuckets(alloc_);
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_UNORDERED_MAP_H_

--- a/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/vector.h
+++ b/hermes_shm/include/hermes_shm/data_structures/thread_unsafe/vector.h
@@ -1,0 +1,767 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DATA_STRUCTURES_LOCKLESS_VECTOR_H_
+#define HERMES_SHM_DATA_STRUCTURES_LOCKLESS_VECTOR_H_
+
+#include "hermes_shm/data_structures/data_structure.h"
+#include "hermes_shm/data_structures/internal/shm_archive_or_t.h"
+
+#include <vector>
+
+namespace hermes_shm::ipc {
+
+/** forward pointer for vector */
+template<typename T>
+class vector;
+
+/**
+ * The vector iterator implementation
+ * */
+template<typename T, bool FORWARD_ITER>
+struct vector_iterator_templ {
+ public:
+  hipc::ShmRef<vector<T>> vec_;
+  off64_t i_;
+
+  /** Default constructor */
+  vector_iterator_templ() = default;
+
+  /** Construct an iterator */
+  inline explicit vector_iterator_templ(TypedPointer<vector<T>> vec)
+  : vec_(vec) {}
+
+  /** Construct end iterator */
+  inline explicit vector_iterator_templ(size_t i)
+  : i_(static_cast<off64_t>(i)) {}
+
+  /** Construct an iterator at \a i offset */
+  inline explicit vector_iterator_templ(TypedPointer<vector<T>> vec, size_t i)
+  : vec_(vec), i_(static_cast<off64_t>(i)) {}
+
+  /** Construct an iterator at \a i offset */
+  inline explicit vector_iterator_templ(const hipc::ShmRef<vector<T>> &vec,
+                                        size_t i)
+  : vec_(vec), i_(static_cast<off64_t>(i)) {}
+
+  /** Copy constructor */
+  inline vector_iterator_templ(const vector_iterator_templ &other)
+  : vec_(other.vec_), i_(other.i_) {}
+
+  /** Copy assignment operator  */
+  inline vector_iterator_templ&
+  operator=(const vector_iterator_templ &other) {
+    if (this != &other) {
+      vec_ = other.vec_;
+      i_ = other.i_;
+    }
+    return *this;
+  }
+
+  /** Move constructor */
+  inline vector_iterator_templ(vector_iterator_templ &&other) {
+    vec_ = other.vec_;
+    i_ = other.i_;
+  }
+
+  /** Move assignment operator  */
+  inline vector_iterator_templ&
+  operator=(vector_iterator_templ &&other) {
+    if (this != &other) {
+      vec_ = other.vec_;
+      i_ = other.i_;
+    }
+    return *this;
+  }
+
+  /** Dereference the iterator */
+  inline ShmRef<T> operator*() {
+    return ShmRef<T>(vec_->data_ar()[i_].internal_ref(
+      vec_->GetAllocator()));
+  }
+
+  /** Dereference the iterator */
+  inline const ShmRef<T> operator*() const {
+    return ShmRef<T>(vec_->data_ar_const()[i_].internal_ref(
+      vec_->GetAllocator()));
+  }
+
+  /** Increment iterator in-place */
+  inline vector_iterator_templ& operator++() {
+    if (is_end()) { return *this; }
+    if constexpr(FORWARD_ITER) {
+      ++i_;
+      if (i_ >= vec_->size()) {
+        set_end();
+      }
+    } else {
+      if (i_ == 0) {
+        set_end();
+      } else {
+        --i_;
+      }
+    }
+    return *this;
+  }
+
+  /** Decrement iterator in-place */
+  inline vector_iterator_templ& operator--() {
+    if (is_begin() || is_end()) { return *this; }
+    if constexpr(FORWARD_ITER) {
+      --i_;
+    } else {
+      ++i_;
+    }
+    return *this;
+  }
+
+  /** Create the next iterator */
+  inline vector_iterator_templ operator++(int) const {
+    vector_iterator_templ next_iter(*this);
+    ++next_iter;
+    return next_iter;
+  }
+
+  /** Create the prior iterator */
+  inline vector_iterator_templ operator--(int) const {
+    vector_iterator_templ prior_iter(*this);
+    --prior_iter;
+    return prior_iter;
+  }
+
+  /** Increment iterator by \a count and return */
+  inline vector_iterator_templ operator+(size_t count) const {
+    if (is_end()) { return end(); }
+    if constexpr(FORWARD_ITER) {
+      if (i_ + count > vec_->size()) {
+        return end();
+      }
+      return vector_iterator_templ(vec_, i_ + count);
+    } else {
+      if (i_ < count - 1) {
+        return end();
+      }
+      return vector_iterator_templ(vec_, i_ - count);
+    }
+  }
+
+  /** Decrement iterator by \a count and return */
+  inline vector_iterator_templ operator-(size_t count) const {
+    if (is_end()) { return end(); }
+    if constexpr(FORWARD_ITER) {
+      if (i_ < count) {
+        return begin();
+      }
+      return vector_iterator_templ(vec_, i_ - count);
+    } else {
+      if (i_ + count > vec_->size() - 1) {
+        return begin();
+      }
+      return vector_iterator_templ(vec_, i_ + count);
+    }
+  }
+
+  /** Increment iterator by \a count in-place */
+  inline void operator+=(size_t count) {
+    if (is_end()) { return end(); }
+    if constexpr(FORWARD_ITER) {
+      if (i_ + count > vec_->size()) {
+        set_end();
+        return;
+      }
+      i_ += count;
+      return;
+    } else {
+      if (i_ < count - 1) {
+        set_end();
+        return;
+      }
+      i_ -= count;
+      return;
+    }
+  }
+
+  /** Decrement iterator by \a count in-place */
+  inline void operator-=(size_t count) {
+    if (is_end()) { return end(); }
+    if constexpr(FORWARD_ITER) {
+      if (i_ < count) {
+        set_begin();
+        return;
+      }
+      i_ -= count;
+      return;
+    } else {
+      if (i_ + count > vec_->size() - 1) {
+        set_begin();
+        return;
+      }
+      i_ += count;
+      return;
+    }
+  }
+
+  /** Check if two iterators are equal */
+  inline friend bool operator==(const vector_iterator_templ &a,
+                         const vector_iterator_templ &b) {
+    return (a.i_ == b.i_);
+  }
+
+  /** Check if two iterators are inequal */
+  inline friend bool operator!=(const vector_iterator_templ &a,
+                         const vector_iterator_templ &b) {
+    return (a.i_ != b.i_);
+  }
+
+  /** Create the begin iterator */
+  inline vector_iterator_templ const begin() {
+    if constexpr(FORWARD_ITER) {
+      return vector_iterator_templ(vec_, 0);
+    } else {
+      return vector_iterator_templ(vec_, vec_->size() - 1);
+    }
+  }
+
+  /** Create the end iterator */
+  inline static vector_iterator_templ const end() {
+    static vector_iterator_templ end_iter(-1);
+    return end_iter;
+  }
+
+  /** Set this iterator to end */
+  inline void set_end() {
+    i_ = -1;
+  }
+
+  /** Set this iterator to begin */
+  inline void set_begin() {
+    if constexpr(FORWARD_ITER) {
+      if (vec_->size() > 0) {
+        i_ = 0;
+      } else {
+        set_end();
+      }
+    } else {
+      i_ = vec_->size() - 1;
+    }
+  }
+
+  /** Determine whether this iterator is the begin iterator */
+  inline bool is_begin() const {
+    if constexpr(FORWARD_ITER) {
+      return (i_ == 0);
+    } else {
+      return (i_ == vec_->size() - 1);
+    }
+  }
+
+  /** Determine whether this iterator is the end iterator */
+  inline bool is_end() const {
+    return i_ < 0;
+  }
+};
+
+/** Forward iterator typedef */
+template<typename T>
+using vector_iterator = vector_iterator_templ<T, true>;
+
+/** Backward iterator typedef */
+template<typename T>
+using vector_riterator = vector_iterator_templ<T, false>;
+
+/** Constant forward iterator typedef */
+template<typename T>
+using vector_citerator = vector_iterator_templ<T, true>;
+
+/** Backward iterator typedef */
+template<typename T>
+using vector_criterator = vector_iterator_templ<T, false>;
+
+/**
+ * MACROS used to simplify the vector namespace
+ * Used as inputs to the SHM_CONTAINER_TEMPLATE
+ * */
+#define CLASS_NAME vector
+#define TYPED_CLASS vector<T>
+#define TYPED_HEADER ShmHeader<vector<T>>
+
+/**
+ * The vector shared-memory header
+ * */
+template<typename T>
+struct ShmHeader<TYPED_CLASS> : public ShmBaseHeader {
+  AtomicPointer vec_ptr_;
+  size_t max_length_, length_;
+
+  /** Default constructor */
+  ShmHeader() = default;
+
+  /** Copy constructor */
+  ShmHeader(const ShmHeader &other) {
+    strong_copy(other);
+  }
+
+  /** Copy assignment operator */
+  ShmHeader& operator=(const ShmHeader &other) {
+    if (this != &other) {
+      strong_copy(other);
+    }
+    return *this;
+  }
+
+  /** Strong copy operation */
+  void strong_copy(const ShmHeader &other) {
+    vec_ptr_ = other.vec_ptr_;
+    max_length_ = other.max_length_;
+    length_ = other.length_;
+  }
+
+  /** Move constructor */
+  ShmHeader(ShmHeader &&other) {
+    weak_move(other);
+  }
+
+  /** Move operator */
+  ShmHeader& operator=(ShmHeader &&other) {
+    if (this != &other) {
+      weak_move(other);
+    }
+    return *this;
+  }
+
+  /** Move operation */
+  void weak_move(ShmHeader &other) {
+    strong_copy(other);
+  }
+};
+
+/**
+ * The vector class
+ * */
+template<typename T>
+class vector : public ShmContainer {
+ public:
+ SHM_CONTAINER_TEMPLATE((CLASS_NAME), (TYPED_CLASS), (TYPED_HEADER))
+
+ public:
+  ////////////////////////////
+  /// SHM Overrides
+  ////////////////////////////
+
+  /** Default constructor */
+  vector() = default;
+
+  /** Construct the vector in shared memory */
+  template<typename ...Args>
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, size_t length, Args&& ...args) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    resize(length, std::forward<Args>(args)...);
+  }
+
+  /** Construct the vector in shared memory */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    header_->length_ = 0;
+    header_->max_length_ = 0;
+    header_->vec_ptr_.SetNull();
+  }
+
+  /** Copy from std::vector */
+  void shm_init_main(TYPED_HEADER *header,
+                     Allocator *alloc, std::vector<T> &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    reserve(other.size());
+    for (auto &entry : other) {
+      emplace_back(entry);
+    }
+  }
+
+  /** Destroy all shared memory allocated by the vector */
+  void shm_destroy_main() {
+    erase(begin(), end());
+    if (!header_->vec_ptr_.IsNull()) {
+      alloc_->Free(header_->vec_ptr_);
+    }
+  }
+
+  /** Store into shared memory */
+  void shm_serialize_main() const {}
+
+  /** Load from shared memory */
+  void shm_deserialize_main() {}
+
+  /** Move constructor */
+  void shm_weak_move_main(TYPED_HEADER *header,
+                          Allocator *alloc, vector &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    *header_ = *(other.header_);
+    other.header_->length_ = 0;
+  }
+
+  /** Copy a vector */
+  void shm_strong_copy_main(TYPED_HEADER *header,
+                            Allocator *alloc, const vector &other) {
+    shm_init_allocator(alloc);
+    shm_init_header(header);
+    reserve(other.size());
+    for (auto iter = other.cbegin(); iter != other.cend(); ++iter) {
+      emplace_back((**iter));
+    }
+  }
+
+  ////////////////////////////
+  /// Vector Operations
+  ////////////////////////////
+
+  /**
+   * Convert to std::vector
+   * */
+  std::vector<T> vec() {
+    std::vector<T> v;
+    v.reserve(size());
+    for (hipc::ShmRef<T> entry : *this) {
+      v.emplace_back(*entry);
+    }
+    return v;
+  }
+
+  /**
+   * Reserve space in the vector to emplace elements. Does not
+   * change the size of the list.
+   *
+   * @param length the maximum size the vector can get before a growth occurs
+   * @param args the arguments to construct
+   * */
+  template<typename ...Args>
+  void reserve(size_t length, Args&& ...args) {
+    if (IsNull()) { shm_init(); }
+    if (length == 0) { return; }
+    grow_vector(data_ar(), length, false, std::forward<Args>(args)...);
+  }
+
+  /**
+   * Reserve space in the vector to emplace elements. Changes the
+   * size of the list.
+   *
+   * @param length the maximum size the vector can get before a growth occurs
+   * @param args the arguments used to construct the vector elements
+   * */
+  template<typename ...Args>
+  void resize(size_t length, Args&& ...args) {
+    if (IsNull()) { shm_init(); }
+    if (length == 0) { return; }
+    grow_vector(data_ar(), length, true, std::forward<Args>(args)...);
+    header_->length_ = length;
+  }
+
+  /** Index the vector at position i */
+  hipc::ShmRef<T> operator[](const size_t i) {
+    ShmHeaderOrT<T> *vec = data_ar();
+    return hipc::ShmRef<T>(vec[i].internal_ref(alloc_));
+  }
+
+  /** Get first element of vector */
+  hipc::ShmRef<T> front() {
+    return (*this)[0];
+  }
+
+  /** Get last element of vector */
+  hipc::ShmRef<T> back() {
+    return (*this)[size() - 1];
+  }
+
+  /** Index the vector at position i */
+  const hipc::ShmRef<T> operator[](const size_t i) const {
+    ShmHeaderOrT<T> *vec = data_ar_const();
+    return hipc::ShmRef<T>(vec[i].internal_ref(alloc_));
+  }
+
+  /** Construct an element at the back of the vector */
+  template<typename... Args>
+  void emplace_back(Args&& ...args) {
+    ShmHeaderOrT<T> *vec = data_ar();
+    if (header_->length_ == header_->max_length_) {
+      vec = grow_vector(vec, 0, false);
+    }
+    Allocator::ConstructObj<ShmHeaderOrT<T>>(
+      *(vec + header_->length_),
+      alloc_, std::forward<Args>(args)...);
+    ++header_->length_;
+  }
+
+  /** Construct an element in the front of the vector */
+  template<typename ...Args>
+  void emplace_front(Args&& ...args) {
+    emplace(begin(), std::forward<Args>(args)...);
+  }
+
+  /** Construct an element at an arbitrary position in the vector */
+  template<typename ...Args>
+  void emplace(vector_iterator<T> pos, Args&&... args) {
+    if (pos.is_end()) {
+      emplace_back(std::forward<Args>(args)...);
+      return;
+    }
+    ShmHeaderOrT<T> *vec = data_ar();
+    if (header_->length_ == header_->max_length_) {
+      vec = grow_vector(vec, 0, false);
+    }
+    shift_right(pos);
+    Allocator::ConstructObj<ShmHeaderOrT<T>>(
+      *(vec + pos.i_),
+      alloc_, std::forward<Args>(args)...);
+    ++header_->length_;
+  }
+
+  /** Delete the element at \a pos position */
+  void erase(vector_iterator<T> pos) {
+    if (pos.is_end()) return;
+    shift_left(pos, 1);
+    header_->length_ -= 1;
+  }
+
+  /** Delete elements between first and last  */
+  void erase(vector_iterator<T> first, vector_iterator<T> last) {
+    size_t last_i;
+    if (first.is_end()) return;
+    if (last.is_end()) {
+      last_i = size();
+    } else {
+      last_i = last.i_;
+    }
+    size_t count = last_i - first.i_;
+    if (count == 0) return;
+    shift_left(first, count);
+    header_->length_ -= count;
+  }
+
+  /** Delete all elements from the vector */
+  void clear() {
+    erase(begin(), end());
+  }
+
+  /** Get the size of the vector */
+  size_t size() const {
+    if (header_ == nullptr) {
+      return 0;
+    }
+    return header_->length_;
+  }
+
+  /** Get the data in the vector */
+  void* data() {
+    if (header_ == nullptr) {
+      return nullptr;
+    }
+    return alloc_->template
+      Convert<void>(header_->vec_ptr_);
+  }
+
+  /** Get constant pointer to the data */
+  void* data_const() const {
+    if (header_ == nullptr) {
+      return nullptr;
+    }
+    return alloc_->template
+      Convert<void>(header_->vec_ptr_);
+  }
+
+  /**
+   * Retreives a pointer to the array from the process-independent pointer.
+   * */
+  ShmHeaderOrT<T>* data_ar() {
+    return alloc_->template
+      Convert<ShmHeaderOrT<T>>(header_->vec_ptr_);
+  }
+
+  /**
+   * Retreives a pointer to the array from the process-independent pointer.
+   * */
+  ShmHeaderOrT<T>* data_ar_const() const {
+    return alloc_->template
+      Convert<ShmHeaderOrT<T>>(header_->vec_ptr_);
+  }
+
+ private:
+  /**
+   * Grow a vector to a new size.
+   *
+   * @param vec the C-style array of elements to grow
+   * @param max_length the new length of the vector. If 0, the current size
+   * of the vector will be multiplied by a constant.
+   * @param args the arguments used to construct the elements of the vector
+   * */
+  template<typename ...Args>
+  ShmHeaderOrT<T>* grow_vector(ShmHeaderOrT<T> *vec, size_t max_length,
+                                   bool resize, Args&& ...args) {
+    // Grow vector by 25%
+    if (max_length == 0) {
+      max_length = 5 * header_->max_length_ / 4;
+      if (max_length <= header_->max_length_ + 10) {
+        max_length += 10;
+      }
+    }
+    if (max_length < header_->max_length_) {
+      return nullptr;
+    }
+
+    // Allocate new shared-memory vec
+    ShmHeaderOrT<T> *new_vec;
+    if constexpr(std::is_pod<T>() || IS_SHM_ARCHIVEABLE(T)) {
+      // Use reallocate for well-behaved objects
+      new_vec = alloc_->template
+        ReallocateObjs<ShmHeaderOrT<T>>(header_->vec_ptr_, max_length);
+    } else {
+      // Use std::move for unpredictable objects
+      Pointer new_p;
+      new_vec = alloc_->template
+        AllocateObjs<ShmHeaderOrT<T>>(max_length, new_p);
+      for (size_t i = 0; i < header_->length_; ++i) {
+        hipc::ShmRef<T> old = (*this)[i];
+        Allocator::ConstructObj<ShmHeaderOrT<T>>(
+          *(new_vec + i),
+          alloc_, std::move(*old));
+      }
+      if (!header_->vec_ptr_.IsNull()) {
+        alloc_->Free(header_->vec_ptr_);
+      }
+      header_->vec_ptr_ = new_p;
+    }
+    if (new_vec == nullptr) {
+      throw OUT_OF_MEMORY.format("vector::emplace_back",
+                                 max_length*sizeof(ShmHeaderOrT<T>));
+    }
+    if (resize) {
+      for (size_t i = header_->length_; i < max_length; ++i) {
+        Allocator::ConstructObj<ShmHeaderOrT<T>>(
+          *(new_vec + i),
+          alloc_, std::forward<Args>(args)...);
+      }
+    }
+
+    // Update vector header
+    header_->max_length_ = max_length;
+
+    return new_vec;
+  }
+
+  /**
+   * Shift every element starting at "pos" to the left by count. Any element
+   * who would be shifted before "pos" will be deleted.
+   *
+   * @param pos the starting position
+   * @param count the amount to shift left by
+   * */
+  void shift_left(const vector_iterator<T> pos, int count = 1) {
+    ShmHeaderOrT<T> *vec = data_ar();
+    for (int i = 0; i < count; ++i) {
+      auto &vec_i = *(vec + pos.i_ + i);
+      vec_i.shm_destroy(alloc_);
+      Allocator::DestructObj<ShmHeaderOrT<T>>(vec_i);
+    }
+    auto dst = vec + pos.i_;
+    auto src = dst + count;
+    for (auto i = pos.i_ + count; i < size(); ++i) {
+      memcpy(dst, src, sizeof(ShmHeaderOrT<T>));
+      dst += 1; src += 1;
+    }
+  }
+
+  /**
+   * Shift every element starting at "pos" to the right by count. Increases
+   * the total number of elements of the vector by "count". Does not modify
+   * the size parameter of the vector, this is done elsewhere.
+   *
+   * @param pos the starting position
+   * @param count the amount to shift right by
+   * */
+  void shift_right(const vector_iterator<T> pos, int count = 1) {
+    auto src = data_ar() + size() - 1;
+    auto dst = src + count;
+    auto sz = static_cast<off64_t>(size());
+    for (auto i = sz - 1; i >= pos.i_; --i) {
+      memcpy(dst, src, sizeof(ShmHeaderOrT<T>));
+      dst -= 1; src -= 1;
+    }
+  }
+
+  ////////////////////////////
+  /// Iterators
+  ////////////////////////////
+
+ public:
+  /** Beginning of the forward iterator */
+  vector_iterator<T> begin() {
+    if (size() == 0) { return end(); }
+    vector_iterator<T> iter(GetShmPointer<TypedPointer<vector<T>>>());
+    iter.set_begin();
+    return iter;
+  }
+
+  /** End of the forward iterator */
+  static vector_iterator<T> const end() {
+    return vector_iterator<T>::end();
+  }
+
+  /** Beginning of the constant forward iterator */
+  vector_citerator<T> cbegin() const {
+    if (size() == 0) { return cend(); }
+    vector_citerator<T> iter(GetShmPointer<TypedPointer<vector<T>>>());
+    iter.set_begin();
+    return iter;
+  }
+
+  /** End of the forward iterator */
+  static const vector_citerator<T> cend() {
+    return vector_citerator<T>::end();
+  }
+
+  /** Beginning of the reverse iterator */
+  vector_riterator<T> rbegin() {
+    if (size() == 0) { return rend(); }
+    vector_riterator<T> iter(GetShmPointer<TypedPointer<vector<T>>>());
+    iter.set_begin();
+    return iter;
+  }
+
+  /** End of the reverse iterator */
+  static vector_riterator<T> const rend() {
+    return vector_riterator<T>::end();
+  }
+
+  /** Beginning of the constant reverse iterator */
+  vector_criterator<T> crbegin() {
+    if (size() == 0) { return rend(); }
+    vector_criterator<T> iter(GetShmPointer<TypedPointer<vector<T>>>());
+    iter.set_begin();
+    return iter;
+  }
+
+  /** End of the constant reverse iterator */
+  static vector_criterator<T> const crend() {
+    return vector_criterator<T>::end();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#undef CLASS_NAME
+#undef TYPED_CLASS
+#undef TYPED_HEADER
+
+#endif  // HERMES_SHM_DATA_STRUCTURES_LOCKLESS_VECTOR_H_

--- a/hermes_shm/include/hermes_shm/introspect/system_info.h
+++ b/hermes_shm/include/hermes_shm/introspect/system_info.h
@@ -1,0 +1,39 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_SYSINFO_INFO_H_
+#define HERMES_SHM_SYSINFO_INFO_H_
+
+#include <unistd.h>
+#include <sys/sysinfo.h>
+
+namespace hermes_shm {
+
+struct SystemInfo {
+  int pid_;
+  int ncpu_;
+  int page_size_;
+  size_t ram_size_;
+
+  SystemInfo() {
+    pid_ = getpid();
+    ncpu_ = get_nprocs_conf();
+    page_size_ = getpagesize();
+    struct sysinfo info;
+    sysinfo(&info);
+    ram_size_ = info.totalram;
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_SYSINFO_INFO_H_

--- a/hermes_shm/include/hermes_shm/memory/allocator/allocator.h
+++ b/hermes_shm/include/hermes_shm/memory/allocator/allocator.h
@@ -1,0 +1,496 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_H_
+#define HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_H_
+
+#include <cstdint>
+#include <hermes_shm/memory/backend/memory_backend_factory.h>
+#include <hermes_shm/memory/memory.h>
+
+namespace hermes_shm::ipc {
+
+/**
+ * The allocator type.
+ * Used to reconstruct allocator from shared memory
+ * */
+enum class AllocatorType {
+  kPageAllocator,
+  kMultiPageAllocator,
+  kStackAllocator,
+  kMallocAllocator,
+};
+
+/**
+ * The basic shared-memory allocator header.
+ * Allocators inherit from this.
+ * */
+struct AllocatorHeader {
+  int allocator_type_;
+  allocator_id_t allocator_id_;
+  size_t custom_header_size_;
+
+  AllocatorHeader() = default;
+
+  void Configure(allocator_id_t allocator_id,
+                 AllocatorType type,
+                 size_t custom_header_size) {
+    allocator_type_ = static_cast<int>(type);
+    allocator_id_ = allocator_id;
+    custom_header_size_ = custom_header_size;
+  }
+};
+
+/**
+ * The allocator base class.
+ * */
+class Allocator {
+ protected:
+  MemoryBackend *backend_;
+  char *custom_header_;
+
+ public:
+  /**
+   * Constructor
+   * */
+  Allocator() : custom_header_(nullptr) {}
+
+  /**
+   * Destructor
+   * */
+  virtual ~Allocator() = default;
+
+  /**
+   * Create the shared-memory allocator with \a id unique allocator id over
+   * the particular slot of a memory backend.
+   *
+   * The shm_init function is required, but cannot be marked virtual as
+   * each allocator has its own arguments to this method. Though each
+   * allocator must have "id" as its first argument.
+   * */
+  // virtual void shm_init(MemoryBackend *backend,
+  //                       allocator_id_t id, Args ...args) = 0;
+
+  /**
+   * Attach the allocator to the slot and backend passed in the constructor.
+   * */
+  virtual void shm_deserialize(MemoryBackend *backend) = 0;
+
+  /**
+   * Allocate a region of memory of \a size size
+   * */
+  virtual OffsetPointer AllocateOffset(size_t size) = 0;
+
+  /**
+   * Allocate a region of memory to a specific pointer type
+   * */
+  template<typename POINTER_T=Pointer>
+  POINTER_T Allocate(size_t size) {
+    return POINTER_T(GetId(), AllocateOffset(size).load());
+  }
+
+  /**
+   * Allocate a region of memory of \a size size
+   * and \a alignment alignment. Assumes that
+   * alignment is not 0.
+   * */
+  virtual OffsetPointer AlignedAllocateOffset(size_t size,
+                                              size_t alignment) = 0;
+
+  /**
+   * Allocate a region of memory to a specific pointer type
+   * */
+  template<typename POINTER_T=Pointer>
+  POINTER_T AlignedAllocate(size_t size, size_t alignment) {
+    return POINTER_T(GetId(), AlignedAllocateOffset(size, alignment).load());
+  }
+
+  /**
+   * Allocate a region of \a size size and \a alignment
+   * alignment. Will fall back to regular Allocate if
+   * alignmnet is 0.
+   * */
+  template<typename POINTER_T=Pointer>
+  inline POINTER_T Allocate(size_t size, size_t alignment) {
+    if (alignment == 0) {
+      return Allocate<POINTER_T>(size);
+    } else {
+      return AlignedAllocate<POINTER_T>(size, alignment);
+    }
+  }
+
+  /**
+   * Reallocate \a pointer to \a new_size new size
+   * If p is kNullPointer, will internally call Allocate.
+   *
+   * @return true if p was modified.
+   * */
+  template<typename POINTER_T=Pointer>
+  inline bool Reallocate(POINTER_T &p, size_t new_size) {
+    if (p.IsNull()) {
+      p = Allocate<POINTER_T>(new_size);
+      return true;
+    }
+    auto new_p = ReallocateOffsetNoNullCheck(p.ToOffsetPointer(),
+                                             new_size);
+    bool ret = new_p == p.ToOffsetPointer();
+    p.off_ = new_p.load();
+    return ret;
+  }
+
+  /**
+   * Reallocate \a pointer to \a new_size new size.
+   * Assumes that p is not kNullPointer.
+   *
+   * @return true if p was modified.
+   * */
+  virtual OffsetPointer ReallocateOffsetNoNullCheck(OffsetPointer p,
+                                                    size_t new_size) = 0;
+
+  /**
+   * Free the memory pointed to by \a ptr Pointer
+   * */
+  template<typename T=void>
+  inline void FreePtr(T *ptr) {
+    if (ptr == nullptr) {
+      throw INVALID_FREE.format();
+    }
+    FreeOffsetNoNullCheck(Convert<T, OffsetPointer>(ptr));
+  }
+
+  /**
+   * Free the memory pointed to by \a p Pointer
+   * */
+  template<typename POINTER_T=Pointer>
+  inline void Free(POINTER_T &p) {
+    if (p.IsNull()) {
+      throw INVALID_FREE.format();
+    }
+    FreeOffsetNoNullCheck(OffsetPointer(p.off_.load()));
+  }
+
+  /**
+   * Free the memory pointed to by \a ptr Pointer
+   * */
+  virtual void FreeOffsetNoNullCheck(OffsetPointer p) = 0;
+
+  /**
+   * Get the allocator identifier
+   * */
+  virtual allocator_id_t GetId() = 0;
+
+  /**
+   * Get the amount of memory that was allocated, but not yet freed.
+   * Useful for memory leak checks.
+   * */
+  virtual size_t GetCurrentlyAllocatedSize() = 0;
+
+
+  ///////////////////////////////////////
+  /////////// POINTER ALLOCATORS
+  ///////////////////////////////////////
+
+  /**
+   * Allocate a pointer of \a size size and return \a p process-independent
+   * pointer and a process-specific pointer.
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* AllocatePtr(size_t size, POINTER_T &p, size_t alignment = 0) {
+    p = Allocate<POINTER_T>(size, alignment);
+    if (p.IsNull()) { return nullptr; }
+    return reinterpret_cast<T*>(backend_->data_ + p.off_.load());
+  }
+
+  /**
+   * Allocate a pointer of \a size size
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* AllocatePtr(size_t size, size_t alignment = 0) {
+    POINTER_T p;
+    return AllocatePtr<T, POINTER_T>(size, p, alignment);
+  }
+
+  /**
+   * Allocate a pointer of \a size size
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ClearAllocatePtr(size_t size, size_t alignment = 0) {
+    POINTER_T p;
+    return ClearAllocatePtr<T, POINTER_T>(size, p, alignment);
+  }
+
+  /**
+   * Allocate a pointer of \a size size and return \a p process-independent
+   * pointer and a process-specific pointer.
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ClearAllocatePtr(size_t size, POINTER_T &p, size_t alignment = 0) {
+    p = Allocate<POINTER_T>(size, alignment);
+    if (p.IsNull()) { return nullptr; }
+    auto ptr = reinterpret_cast<T*>(backend_->data_ + p.off_.load());
+    if (ptr) {
+      memset(ptr, 0, size);
+    }
+    return ptr;
+  }
+
+  /**
+   * Reallocate a pointer to a new size
+   *
+   * @param p process-independent pointer (input & output)
+   * @param new_size the new size to allocate
+   * @param modified whether or not p was modified (output)
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ReallocatePtr(POINTER_T &p, size_t new_size, bool &modified) {
+    modified = Reallocate<POINTER_T>(p, new_size);
+    return Convert<T>(p);
+  }
+
+  /**
+   * Reallocate a pointer to a new size
+   *
+   * @param p process-independent pointer (input & output)
+   * @param new_size the new size to allocate
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ReallocatePtr(POINTER_T &p, size_t new_size) {
+    Reallocate<POINTER_T>(p, new_size);
+    return Convert<T>(p);
+  }
+
+  /**
+   * Reallocate a pointer to a new size
+   *
+   * @param old_ptr process-specific pointer to reallocate
+   * @param new_size the new size to allocate
+   * @return A process-specific pointer
+   * */
+  template<typename T>
+  inline T* ReallocatePtr(T *old_ptr, size_t new_size) {
+    OffsetPointer p = Convert<T, OffsetPointer>(old_ptr);
+    return ReallocatePtr<T, OffsetPointer>(p, new_size);
+  }
+
+  ///////////////////////////////////////
+  ///////////OBJECT ALLOCATORS
+  ///////////////////////////////////////
+
+  /**
+   * Allocate an array of objects (but don't construct).
+   *
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* AllocateObjs(size_t count) {
+    POINTER_T p;
+    return AllocateObjs<T>(count, p);
+  }
+
+  /**
+   * Allocate an array of objects (but don't construct).
+   *
+   * @param count the number of objects to allocate
+   * @param p process-independent pointer (output)
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* AllocateObjs(size_t count, POINTER_T &p) {
+    return AllocatePtr<T>(count * sizeof(T), p);
+  }
+
+  /**
+   * Allocate an array of objects and memset to 0.
+   *
+   * @param count the number of objects to allocate
+   * @param p process-independent pointer (output)
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ClearAllocateObjs(size_t count, POINTER_T &p) {
+    return ClearAllocatePtr<T>(count * sizeof(T), p);
+  }
+
+  /**
+   * Allocate and construct an array of objects
+   *
+   * @param count the number of objects to allocate
+   * @param p process-independent pointer (output)
+   * @param args parameters to construct object of type T
+   * @return A process-specific pointer
+   * */
+  template<
+    typename T,
+    typename POINTER_T=Pointer,
+    typename ...Args>
+  inline T* AllocateConstructObjs(size_t count, POINTER_T &p, Args&& ...args) {
+    T *ptr = AllocateObjs<T>(count, p);
+    ConstructObjs<T>(ptr, 0, count, std::forward<Args>(args)...);
+    return ptr;
+  }
+
+  /**
+   * Reallocate a pointer of objects to a new size.
+   *
+   * @param p process-independent pointer (input & output)
+   * @param old_count the original number of objects (avoids reconstruction)
+   * @param new_count the new number of objects
+   *
+   * @return A process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* ReallocateObjs(POINTER_T &p, size_t new_count) {
+    T *ptr = ReallocatePtr<T>(p, new_count*sizeof(T));
+    return ptr;
+  }
+
+  /**
+   * Reallocate a pointer of objects to a new size and construct the
+   * new elements in-place.
+   *
+   * @param p process-independent pointer (input & output)
+   * @param old_count the original number of objects (avoids reconstruction)
+   * @param new_count the new number of objects
+   * @param args parameters to construct object of type T
+   *
+   * @return A process-specific pointer
+   * */
+  template<
+    typename T,
+    typename POINTER_T=Pointer,
+    typename ...Args>
+  inline T* ReallocateConstructObjs(POINTER_T &p,
+                                    size_t old_count,
+                                    size_t new_count,
+                                    Args&& ...args) {
+    T *ptr = ReallocatePtr<T>(p, new_count*sizeof(T));
+    ConstructObjs<T>(ptr, old_count, new_count, std::forward<Args>(args)...);
+    return ptr;
+  }
+
+  /**
+   * Construct each object in an array of objects.
+   *
+   * @param ptr the array of objects (potentially archived)
+   * @param old_count the original size of the ptr
+   * @param new_count the new size of the ptr
+   * @param args parameters to construct object of type T
+   * @return None
+   * */
+  template<
+    typename T,
+    typename ...Args>
+  inline static void ConstructObjs(T *ptr,
+                            size_t old_count,
+                            size_t new_count, Args&& ...args) {
+    if (ptr == nullptr) { return; }
+    for (size_t i = old_count; i < new_count; ++i) {
+      ConstructObj<T>(*(ptr + i), std::forward<Args>(args)...);
+    }
+  }
+
+  /**
+   * Construct an object.
+   *
+   * @param ptr the object to construct (potentially archived)
+   * @param args parameters to construct object of type T
+   * @return None
+   * */
+  template<
+    typename T,
+    typename ...Args>
+  inline static void ConstructObj(T &obj, Args&& ...args) {
+    new (&obj) T(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Destruct an array of objects
+   *
+   * @param ptr the object to destruct (potentially archived)
+   * @param count the length of the object array
+   * @return None
+   * */
+  template<typename T>
+  inline static void DestructObjs(T *ptr, size_t count) {
+    if (ptr == nullptr) { return; }
+    for (size_t i = 0; i < count; ++i) {
+      DestructObj<T>((ptr + i));
+    }
+  }
+
+  /**
+   * Destruct an object
+   *
+   * @param ptr the object to destruct (potentially archived)
+   * @param count the length of the object array
+   * @return None
+   * */
+  template<typename T>
+  inline static void DestructObj(T &obj) {
+    obj.~T();
+  }
+
+  /**
+   * Get the custom header of the shared-memory allocator
+   *
+   * @return Custom header pointer
+   * */
+  template<typename HEADER_T>
+  inline HEADER_T* GetCustomHeader() {
+    return reinterpret_cast<HEADER_T*>(custom_header_);
+  }
+
+  /**
+   * Convert a process-independent pointer into a process-specific pointer
+   *
+   * @param p process-independent pointer
+   * @return a process-specific pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline T* Convert(const POINTER_T &p) {
+    if (p.IsNull()) { return nullptr; }
+    return reinterpret_cast<T*>(backend_->data_ + p.off_.load());
+  }
+
+  /**
+   * Convert a process-specific pointer into a process-independent pointer
+   *
+   * @param ptr process-specific pointer
+   * @return a process-independent pointer
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  inline POINTER_T Convert(T *ptr) {
+    if (ptr == nullptr) { return POINTER_T::GetNull(); }
+    return POINTER_T(GetId(),
+                     reinterpret_cast<size_t>(ptr) -
+                     reinterpret_cast<size_t>(backend_->data_));
+  }
+
+  /**
+   * Determine whether or not this allocator contains a process-specific
+   * pointer
+   *
+   * @param ptr process-specific pointer
+   * @return True or false
+   * */
+  template<typename T = void>
+  inline bool ContainsPtr(T *ptr) {
+    return  reinterpret_cast<size_t>(ptr) >=
+            reinterpret_cast<size_t>(backend_->data_);
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_H_

--- a/hermes_shm/include/hermes_shm/memory/allocator/allocator_factory.h
+++ b/hermes_shm/include/hermes_shm/memory/allocator/allocator_factory.h
@@ -1,0 +1,79 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_FACTORY_H_
+#define HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_FACTORY_H_
+
+#include "allocator.h"
+#include "stack_allocator.h"
+#include "malloc_allocator.h"
+
+namespace hermes_shm::ipc {
+
+class AllocatorFactory {
+ public:
+  /**
+   * Create a new memory allocator
+   * */
+  template<typename AllocT, typename ...Args>
+  static std::unique_ptr<Allocator> shm_init(MemoryBackend *backend,
+                                             allocator_id_t alloc_id,
+                                             size_t custom_header_size,
+                                             Args&& ...args) {
+    if constexpr(std::is_same_v<StackAllocator, AllocT>) {
+      // StackAllocator
+      auto alloc = std::make_unique<StackAllocator>();
+      alloc->shm_init(backend,
+                      alloc_id,
+                      custom_header_size,
+                      std::forward<Args>(args)...);
+      return alloc;
+    } else if constexpr(std::is_same_v<MallocAllocator, AllocT>) {
+      // Malloc Allocator
+      auto alloc = std::make_unique<MallocAllocator>();
+      alloc->shm_init(backend,
+                      alloc_id,
+                      custom_header_size,
+                      std::forward<Args>(args)...);
+      return alloc;
+    } else {
+      // Default
+      throw std::logic_error("Not a valid allocator");
+    }
+  }
+
+  /**
+   * Deserialize the allocator managing this backend.
+   * */
+  static std::unique_ptr<Allocator> shm_deserialize(MemoryBackend *backend) {
+    auto header_ = reinterpret_cast<AllocatorHeader*>(backend->data_);
+    switch (static_cast<AllocatorType>(header_->allocator_type_)) {
+      // Stack Allocator
+      case AllocatorType::kStackAllocator: {
+        auto alloc = std::make_unique<StackAllocator>();
+        alloc->shm_deserialize(backend);
+        return alloc;
+      }
+      // Malloc Allocator
+      case AllocatorType::kMallocAllocator: {
+        auto alloc = std::make_unique<MallocAllocator>();
+        alloc->shm_deserialize(backend);
+        return alloc;
+      }
+      default: return nullptr;
+    }
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_ALLOCATOR_ALLOCATOR_FACTORY_H_

--- a/hermes_shm/include/hermes_shm/memory/allocator/malloc_allocator.h
+++ b/hermes_shm/include/hermes_shm/memory/allocator/malloc_allocator.h
@@ -1,0 +1,98 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_ALLOCATOR_MALLOC_ALLOCATOR_H_
+#define HERMES_SHM_MEMORY_ALLOCATOR_MALLOC_ALLOCATOR_H_
+
+#include "allocator.h"
+#include "hermes_shm/thread/lock.h"
+
+namespace hermes_shm::ipc {
+
+struct MallocAllocatorHeader : public AllocatorHeader {
+  std::atomic<size_t> total_alloc_size_;
+
+  MallocAllocatorHeader() = default;
+
+  void Configure(allocator_id_t alloc_id,
+                 size_t custom_header_size) {
+    AllocatorHeader::Configure(alloc_id, AllocatorType::kStackAllocator,
+                               custom_header_size);
+    total_alloc_size_ = 0;
+  }
+};
+
+class MallocAllocator : public Allocator {
+ private:
+  MallocAllocatorHeader *header_;
+
+ public:
+  /**
+   * Allocator constructor
+   * */
+  MallocAllocator()
+  : header_(nullptr) {}
+
+  /**
+   * Get the ID of this allocator from shared memory
+   * */
+  allocator_id_t GetId() override {
+    return header_->allocator_id_;
+  }
+
+  /**
+   * Initialize the allocator in shared memory
+   * */
+  void shm_init(MemoryBackend *backend,
+                allocator_id_t id,
+                size_t custom_header_size);
+
+  /**
+   * Attach an existing allocator from shared memory
+   * */
+  void shm_deserialize(MemoryBackend *backend) override;
+
+  /**
+   * Allocate a memory of \a size size. The page allocator cannot allocate
+   * memory larger than the page size.
+   * */
+  OffsetPointer AllocateOffset(size_t size) override;
+
+  /**
+   * Allocate a memory of \a size size, which is aligned to \a
+   * alignment.
+   * */
+  OffsetPointer AlignedAllocateOffset(size_t size, size_t alignment) override;
+
+  /**
+   * Reallocate \a p pointer to \a new_size new size.
+   *
+   * @return whether or not the pointer p was changed
+   * */
+  OffsetPointer ReallocateOffsetNoNullCheck(OffsetPointer p,
+                                            size_t new_size) override;
+
+  /**
+   * Free \a ptr pointer. Null check is performed elsewhere.
+   * */
+  void FreeOffsetNoNullCheck(OffsetPointer p) override;
+
+  /**
+   * Get the current amount of data allocated. Can be used for leak
+   * checking.
+   * */
+  size_t GetCurrentlyAllocatedSize() override;
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_ALLOCATOR_MALLOC_ALLOCATOR_H_

--- a/hermes_shm/include/hermes_shm/memory/allocator/mp_page.h
+++ b/hermes_shm/include/hermes_shm/memory/allocator/mp_page.h
@@ -1,0 +1,39 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_ALLOCATOR_MP_PAGE_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_ALLOCATOR_MP_PAGE_H_
+
+namespace hermes_shm::ipc {
+
+struct MpPage {
+  int flags_;           /**< Page flags (e.g., is_allocated?) */
+  size_t page_size_;    /**< The size of the page allocated */
+  uint32_t off_;        /**< The offset within the page */
+  uint32_t page_idx_;   /**< The id of the page in the mp free list */
+
+  void SetAllocated() {
+    flags_ = 0x1;
+  }
+
+  void UnsetAllocated() {
+    flags_ = 0;
+  }
+
+  bool IsAllocated() const {
+    return flags_ & 0x1;
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_ALLOCATOR_MP_PAGE_H_

--- a/hermes_shm/include/hermes_shm/memory/allocator/stack_allocator.h
+++ b/hermes_shm/include/hermes_shm/memory/allocator/stack_allocator.h
@@ -1,0 +1,104 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_ALLOCATOR_STACK_ALLOCATOR_H_
+#define HERMES_SHM_MEMORY_ALLOCATOR_STACK_ALLOCATOR_H_
+
+#include "allocator.h"
+#include "hermes_shm/thread/lock.h"
+
+namespace hermes_shm::ipc {
+
+struct StackAllocatorHeader : public AllocatorHeader {
+  std::atomic<size_t> region_off_;
+  std::atomic<size_t> region_size_;
+  std::atomic<size_t> total_alloc_;
+
+  StackAllocatorHeader() = default;
+
+  void Configure(allocator_id_t alloc_id,
+                 size_t custom_header_size,
+                 size_t region_off,
+                 size_t region_size) {
+    AllocatorHeader::Configure(alloc_id, AllocatorType::kStackAllocator,
+                               custom_header_size);
+    region_off_ = region_off;
+    region_size_ = region_size;
+    total_alloc_ = 0;
+  }
+};
+
+class StackAllocator : public Allocator {
+ private:
+  StackAllocatorHeader *header_;
+
+ public:
+  /**
+   * Allocator constructor
+   * */
+  StackAllocator()
+  : header_(nullptr) {}
+
+  /**
+   * Get the ID of this allocator from shared memory
+   * */
+  allocator_id_t GetId() override {
+    return header_->allocator_id_;
+  }
+
+  /**
+   * Initialize the allocator in shared memory
+   * */
+  void shm_init(MemoryBackend *backend,
+                allocator_id_t id,
+                size_t custom_header_size);
+
+  /**
+   * Attach an existing allocator from shared memory
+   * */
+  void shm_deserialize(MemoryBackend *backend) override;
+
+  /**
+   * Allocate a memory of \a size size. The page allocator cannot allocate
+   * memory larger than the page size.
+   * */
+  OffsetPointer AllocateOffset(size_t size) override;
+
+  /**
+   * Allocate a memory of \a size size, which is aligned to \a
+   * alignment.
+   * */
+  OffsetPointer AlignedAllocateOffset(size_t size, size_t alignment) override;
+
+  /**
+   * Reallocate \a p pointer to \a new_size new size.
+   *
+   * @return whether or not the pointer p was changed
+   * */
+  OffsetPointer ReallocateOffsetNoNullCheck(
+    OffsetPointer p, size_t new_size) override;
+
+  /**
+   * Free \a ptr pointer. Null check is performed elsewhere.
+   * */
+  void FreeOffsetNoNullCheck(OffsetPointer p) override;
+
+  /**
+   * Get the current amount of data allocated. Can be used for leak
+   * checking.
+   * */
+  size_t GetCurrentlyAllocatedSize() override;
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_ALLOCATOR_STACK_ALLOCATOR_H_

--- a/hermes_shm/include/hermes_shm/memory/backend/array_backend.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/array_backend.h
@@ -1,0 +1,65 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_ARRAY_BACKEND_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_ARRAY_BACKEND_H_
+
+#include "memory_backend.h"
+#include <string>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/shm.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <hermes_shm/util/errors.h>
+#include <hermes_shm/constants/macros.h>
+#include <hermes_shm/introspect/system_info.h>
+
+namespace hermes_shm::ipc {
+
+class ArrayBackend : public MemoryBackend {
+ public:
+  ArrayBackend() = default;
+
+  ~ArrayBackend() override {}
+
+  bool shm_init(size_t size, char *region) {
+    if (size < sizeof(MemoryBackendHeader)) {
+      throw SHMEM_CREATE_FAILED.format();
+    }
+    SetInitialized();
+    Own();
+    header_ = reinterpret_cast<MemoryBackendHeader *>(region);
+    header_->data_size_ = size - sizeof(MemoryBackendHeader);
+    data_size_ = header_->data_size_;
+    data_ = region + sizeof(MemoryBackendHeader);
+    return true;
+  }
+
+  bool shm_deserialize(std::string url) override {
+    (void) url;
+    throw SHMEM_NOT_SUPPORTED.format();
+  }
+
+  void shm_detach() override {}
+
+  void shm_destroy() override {}
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_ARRAY_BACKEND_H_

--- a/hermes_shm/include/hermes_shm/memory/backend/memory_backend.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/memory_backend.h
@@ -1,0 +1,90 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_H
+#define HERMES_SHM_MEMORY_H
+
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <hermes_shm/memory/memory.h>
+#include "hermes_shm/constants/macros.h"
+#include <limits>
+
+namespace hermes_shm::ipc {
+
+struct MemoryBackendHeader {
+  size_t data_size_;
+};
+
+enum class MemoryBackendType {
+  kPosixShmMmap,
+  kNullBackend,
+  kArrayBackend,
+  kPosixMmap,
+};
+
+#define MEMORY_BACKEND_INITIALIZED 0x1
+#define MEMORY_BACKEND_OWNED 0x2
+
+class MemoryBackend {
+ public:
+  MemoryBackendHeader *header_;
+  char *data_;
+  size_t data_size_;
+  bitfield32_t flags_;
+
+ public:
+  MemoryBackend() = default;
+
+  virtual ~MemoryBackend() = default;
+
+  /** Mark data as valid */
+  void SetInitialized() {
+    flags_.SetBits(MEMORY_BACKEND_INITIALIZED);
+  }
+
+  /** Check if data is valid */
+  bool IsInitialized() {
+    return flags_.OrBits(MEMORY_BACKEND_INITIALIZED);
+  }
+
+  /** Mark data as invalid */
+  void UnsetInitialized() {
+    flags_.UnsetBits(MEMORY_BACKEND_INITIALIZED);
+  }
+
+  /** This is the process which destroys the backend */
+  void Own() {
+    flags_.SetBits(MEMORY_BACKEND_OWNED);
+  }
+
+  /** This is owned */
+  bool IsOwned() {
+    return flags_.OrBits(MEMORY_BACKEND_OWNED);
+  }
+
+  /** This is not the process which destroys the backend */
+  void Disown() {
+    flags_.UnsetBits(MEMORY_BACKEND_OWNED);
+  }
+
+  /// Each allocator must define its own shm_init.
+  // virtual bool shm_init(size_t size, ...) = 0;
+  virtual bool shm_deserialize(std::string url) = 0;
+  virtual void shm_detach() = 0;
+  virtual void shm_destroy() = 0;
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_H

--- a/hermes_shm/include/hermes_shm/memory/backend/memory_backend_factory.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/memory_backend_factory.h
@@ -1,0 +1,103 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_BACKEND_MEMORY_BACKEND_FACTORY_H_
+#define HERMES_SHM_MEMORY_BACKEND_MEMORY_BACKEND_FACTORY_H_
+
+#include "memory_backend.h"
+#include "posix_mmap.h"
+#include "posix_shm_mmap.h"
+#include "null_backend.h"
+#include "array_backend.h"
+
+namespace hermes_shm::ipc {
+
+class MemoryBackendFactory {
+ public:
+  /** Initialize a new backend */
+  template<typename BackendT, typename ...Args>
+  static std::unique_ptr<MemoryBackend> shm_init(
+    size_t size, const std::string &url, Args ...args) {
+    if constexpr(std::is_same_v<PosixShmMmap, BackendT>) {
+      // PosixShmMmap
+      auto backend = std::make_unique<PosixShmMmap>();
+      backend->shm_init(size, url, std::forward<args>(args)...);
+      return backend;
+    } else if constexpr(std::is_same_v<PosixMmap, BackendT>) {
+      // PosixMmap
+      auto backend = std::make_unique<PosixMmap>();
+      backend->shm_init(size, url, std::forward<args>(args)...);
+      return backend;
+    } else if constexpr(std::is_same_v<NullBackend, BackendT>) {
+      // NullBackend
+      auto backend = std::make_unique<NullBackend>();
+      backend->shm_init(size, url, std::forward<args>(args)...);
+      return backend;
+    } else if constexpr(std::is_same_v<ArrayBackend, BackendT>) {
+      // ArrayBackend
+      auto backend = std::make_unique<ArrayBackend>();
+      backend->shm_init(size, url, std::forward<args>(args)...);
+      return backend;
+    } else {
+      throw MEMORY_BACKEND_NOT_FOUND.format();
+    }
+  }
+
+  /** Deserialize an existing backend */
+  static std::unique_ptr<MemoryBackend> shm_deserialize(
+    MemoryBackendType type, const std::string &url) {
+    switch (type) {
+      // PosixShmMmap
+      case MemoryBackendType::kPosixShmMmap: {
+        auto backend = std::make_unique<PosixShmMmap>();
+        if (!backend->shm_deserialize(url)) {
+          throw MEMORY_BACKEND_NOT_FOUND.format();
+        }
+        return backend;
+      }
+
+      // PosixMmap
+      case MemoryBackendType::kPosixMmap: {
+        auto backend = std::make_unique<PosixMmap>();
+        if (!backend->shm_deserialize(url)) {
+          throw MEMORY_BACKEND_NOT_FOUND.format();
+        }
+        return backend;
+      }
+
+      // NullBackend
+      case MemoryBackendType::kNullBackend: {
+        auto backend = std::make_unique<NullBackend>();
+        if (!backend->shm_deserialize(url)) {
+          throw MEMORY_BACKEND_NOT_FOUND.format();
+        }
+        return backend;
+      }
+
+      // ArrayBackend
+      case MemoryBackendType::kArrayBackend: {
+        auto backend = std::make_unique<ArrayBackend>();
+        if (!backend->shm_deserialize(url)) {
+          throw MEMORY_BACKEND_NOT_FOUND.format();
+        }
+        return backend;
+      }
+
+      // Default
+      default: return nullptr;
+    }
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_BACKEND_MEMORY_BACKEND_FACTORY_H_

--- a/hermes_shm/include/hermes_shm/memory/backend/null_backend.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/null_backend.h
@@ -1,0 +1,81 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_NULL_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_NULL_H_
+
+#include "memory_backend.h"
+#include <string>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/shm.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <hermes_shm/util/errors.h>
+#include <hermes_shm/constants/macros.h>
+#include <hermes_shm/introspect/system_info.h>
+
+namespace hermes_shm::ipc {
+
+class NullBackend : public MemoryBackend {
+ private:
+  size_t total_size_;
+
+ public:
+  NullBackend() = default;
+
+  ~NullBackend() override {}
+
+  bool shm_init(size_t size, const std::string &url) {
+    (void) url;
+    SetInitialized();
+    Own();
+    total_size_ = sizeof(MemoryBackendHeader) + size;
+    char *ptr = (char*)malloc(sizeof(MemoryBackendHeader));
+    header_ = reinterpret_cast<MemoryBackendHeader*>(ptr);
+    header_->data_size_ = size;
+    data_size_ = size;
+    data_ = nullptr;
+    return true;
+  }
+
+  bool shm_deserialize(std::string url) override {
+    (void) url;
+    throw SHMEM_NOT_SUPPORTED.format();
+  }
+
+  void shm_detach() override {
+    _Detach();
+  }
+
+  void shm_destroy() override {
+    _Destroy();
+  }
+
+ protected:
+  void _Detach() {
+    free(header_);
+  }
+
+  void _Destroy() {
+    free(header_);
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_MEMORY_BACKEND_NULL_H_

--- a/hermes_shm/include/hermes_shm/memory/backend/posix_mmap.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/posix_mmap.h
@@ -1,0 +1,111 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_MMAP_H
+#define HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_MMAP_H
+
+#include "memory_backend.h"
+#include <string>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/shm.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <hermes_shm/util/errors.h>
+#include <hermes_shm/constants/macros.h>
+#include <hermes_shm/introspect/system_info.h>
+
+namespace hermes_shm::ipc {
+
+class PosixMmap : public MemoryBackend {
+ private:
+  size_t total_size_;
+
+ public:
+  /** Constructor */
+  PosixMmap() = default;
+
+  /** Destructor */
+  ~PosixMmap() override {
+    if (IsOwned()) {
+      _Destroy();
+    } else {
+      _Detach();
+    }
+  }
+
+  /** Initialize backend */
+  bool shm_init(size_t size) {
+    SetInitialized();
+    Own();
+    total_size_ = sizeof(MemoryBackendHeader) + size;
+    char *ptr = _Map(total_size_);
+    header_ = reinterpret_cast<MemoryBackendHeader*>(ptr);
+    header_->data_size_ = size;
+    data_size_ = size;
+    data_ = reinterpret_cast<char*>(header_ + 1);
+    return true;
+  }
+
+  /** Deserialize the backend */
+  bool shm_deserialize(std::string url) override {
+    (void) url;
+    throw SHMEM_NOT_SUPPORTED.format();
+  }
+
+  /** Detach the mapped memory */
+  void shm_detach() override {
+    _Detach();
+  }
+
+  /** Destroy the mapped memory */
+  void shm_destroy() override {
+    _Destroy();
+  }
+
+ protected:
+  /** Map shared memory */
+  template<typename T=char>
+  T* _Map(size_t size) {
+    T *ptr = reinterpret_cast<T*>(
+      mmap64(nullptr, NextPageSizeMultiple(size), PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (ptr == MAP_FAILED) {
+      perror("map failed");
+      throw SHMEM_CREATE_FAILED.format();
+    }
+    return ptr;
+  }
+
+  /** Unmap shared memory */
+  void _Detach() {
+    if (!IsInitialized()) { return; }
+    munmap(reinterpret_cast<void*>(header_), total_size_);
+    UnsetInitialized();
+  }
+
+  /** Destroy shared memory */
+  void _Destroy() {
+    if (!IsInitialized()) { return; }
+    _Detach();
+    UnsetInitialized();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_MMAP_H

--- a/hermes_shm/include/hermes_shm/memory/backend/posix_shm_mmap.h
+++ b/hermes_shm/include/hermes_shm/memory/backend/posix_shm_mmap.h
@@ -1,0 +1,136 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_SHM_MMAP_H
+#define HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_SHM_MMAP_H
+
+#include "memory_backend.h"
+#include <string>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/shm.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <hermes_shm/util/errors.h>
+#include <hermes_shm/constants/macros.h>
+#include <hermes_shm/introspect/system_info.h>
+
+namespace hermes_shm::ipc {
+
+class PosixShmMmap : public MemoryBackend {
+ private:
+  std::string url_;
+  int fd_;
+
+ public:
+  /** Constructor */
+  PosixShmMmap() : fd_(-1) {}
+
+  /** Destructor */
+  ~PosixShmMmap() override {
+    if (IsOwned()) {
+      _Destroy();
+    } else {
+      _Detach();
+    }
+  }
+
+  /** Initialize backend */
+  bool shm_init(size_t size, std::string url) {
+    SetInitialized();
+    Own();
+    url_ = std::move(url);
+    shm_unlink(url_.c_str());
+    fd_ = shm_open(url_.c_str(), O_CREAT | O_RDWR, 0666);
+    if (fd_ < 0) {
+      return false;
+    }
+    _Reserve(size);
+    header_ = _Map<MemoryBackendHeader>(HERMES_SHM_SYSTEM_INFO->page_size_, 0);
+    header_->data_size_ = size;
+    data_size_ = size;
+    data_ = _Map(size, HERMES_SHM_SYSTEM_INFO->page_size_);
+    return true;
+  }
+
+  /** Deserialize the backend */
+  bool shm_deserialize(std::string url) override {
+    SetInitialized();
+    Disown();
+    url_ = std::move(url);
+    fd_ = shm_open(url_.c_str(), O_RDWR, 0666);
+    if (fd_ < 0) {
+      return false;
+    }
+    header_ = _Map<MemoryBackendHeader>(HERMES_SHM_SYSTEM_INFO->page_size_, 0);
+    data_size_ = header_->data_size_;
+    data_ = _Map(data_size_, HERMES_SHM_SYSTEM_INFO->page_size_);
+    return true;
+  }
+
+  /** Detach the mapped memory */
+  void shm_detach() override {
+    _Detach();
+  }
+
+  /** Destroy the mapped memory */
+  void shm_destroy() override {
+    _Destroy();
+  }
+
+ protected:
+  /** Reserve shared memory */
+  void _Reserve(size_t size) {
+    int ret = ftruncate64(fd_, static_cast<off64_t>(size));
+    if (ret < 0) {
+      throw SHMEM_RESERVE_FAILED.format();
+    }
+  }
+
+  /** Map shared memory */
+  template<typename T=char>
+  T* _Map(size_t size, off64_t off) {
+    T *ptr = reinterpret_cast<T*>(
+      mmap64(nullptr, size, PROT_READ | PROT_WRITE,
+             MAP_SHARED, fd_, off));
+    if (ptr == MAP_FAILED) {
+      throw SHMEM_CREATE_FAILED.format();
+    }
+    return ptr;
+  }
+
+  /** Unmap shared memory */
+  void _Detach() {
+    if (!IsInitialized()) { return; }
+    munmap(data_, data_size_);
+    munmap(header_, HERMES_SHM_SYSTEM_INFO->page_size_);
+    close(fd_);
+    UnsetInitialized();
+  }
+
+  /** Destroy shared memory */
+  void _Destroy() {
+    if (!IsInitialized()) { return; }
+    _Detach();
+    shm_unlink(url_.c_str());
+    UnsetInitialized();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_INCLUDE_MEMORY_BACKEND_POSIX_SHM_MMAP_H

--- a/hermes_shm/include/hermes_shm/memory/memory.h
+++ b/hermes_shm/include/hermes_shm/memory/memory.h
@@ -1,0 +1,383 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_MEMORY_H_
+#define HERMES_SHM_MEMORY_MEMORY_H_
+
+#include <hermes_shm/types/basic.h>
+#include <hermes_shm/constants/data_structure_singleton_macros.h>
+#include <hermes_shm/introspect/system_info.h>
+#include <hermes_shm/types/bitfield.h>
+#include <hermes_shm/types/atomic.h>
+
+namespace hermes_shm::ipc {
+
+/**
+ * The identifier for an allocator
+ * */
+union allocator_id_t {
+  struct {
+    uint32_t major_;  // Typically some sort of process id
+    uint32_t minor_;  // Typically a process-local id
+  } bits_;
+  uint64_t int_;
+
+  /**
+   * Null allocator ID is -1 (for now)
+   * */
+  allocator_id_t() : int_(0) {}
+
+  /**
+   * Constructor which sets major & minor
+   * */
+  explicit allocator_id_t(uint32_t major, uint32_t minor) {
+    bits_.major_ = major;
+    bits_.minor_ = minor;
+  }
+
+  /**
+   * Set this allocator to null
+   * */
+  void SetNull() {
+    int_ = 0;
+  }
+
+  /**
+   * Check if this is the null allocator
+   * */
+  bool IsNull() const { return int_ == 0; }
+
+  /** Equality check */
+  bool operator==(const allocator_id_t &other) const {
+    return other.int_ == int_;
+  }
+
+  /** Inequality check */
+  bool operator!=(const allocator_id_t &other) const {
+    return other.int_ != int_;
+  }
+
+  /** Get the null allocator */
+  static allocator_id_t GetNull() {
+    static allocator_id_t alloc(0, 0);
+    return alloc;
+  }
+};
+
+typedef uint32_t slot_id_t;  // Uniquely ids a MemoryBackend slot
+
+/**
+ * Stores an offset into a memory region. Assumes the developer knows
+ * which allocator the pointer comes from.
+ * */
+template<bool ATOMIC=false>
+struct OffsetPointerBase {
+  typedef typename std::conditional<ATOMIC,
+    atomic<size_t>, nonatomic<size_t>>::type atomic_t;
+  atomic_t off_; /**< Offset within the allocator's slot */
+
+  /** Default constructor */
+  OffsetPointerBase() = default;
+
+  /** Full constructor */
+  explicit OffsetPointerBase(size_t off) : off_(off) {}
+
+  /** Full constructor */
+  explicit OffsetPointerBase(atomic_t off) : off_(off.load()) {}
+
+  /** Pointer constructor */
+  explicit OffsetPointerBase(allocator_id_t alloc_id, size_t off) : off_(off) {
+    (void) alloc_id;
+  }
+
+  /** Copy constructor */
+  OffsetPointerBase(const OffsetPointerBase &other)
+  : off_(other.off_.load()) {}
+
+  /** Other copy constructor */
+  OffsetPointerBase(const OffsetPointerBase<!ATOMIC> &other)
+  : off_(other.off_.load()) {}
+
+  /** Move constructor */
+  OffsetPointerBase(OffsetPointerBase &&other) noexcept
+    : off_(other.off_.load()) {
+    other.SetNull();
+  }
+
+  /** Get the offset pointer */
+  OffsetPointerBase<false> ToOffsetPointer() {
+    return OffsetPointerBase<false>(off_.load());
+  }
+
+  /** Set to null */
+  void SetNull() {
+    off_ = -1;
+  }
+
+  /** Check if null */
+  bool IsNull() const {
+    return off_ == -1;
+  }
+
+  /** Get the null pointer */
+  static OffsetPointerBase GetNull() {
+    const static OffsetPointerBase p(-1);
+    return p;
+  }
+
+  /** Atomic load wrapper */
+  inline size_t load(
+    std::memory_order order = std::memory_order_seq_cst) const {
+    return off_.load(order);
+  }
+
+  /** Atomic exchange wrapper */
+  inline void exchange(
+    size_t count, std::memory_order order = std::memory_order_seq_cst) {
+    off_.exchange(count, order);
+  }
+
+  /** Atomic compare exchange weak wrapper */
+  inline bool compare_exchange_weak(size_t& expected, size_t desired,
+                                    std::memory_order order =
+                                    std::memory_order_seq_cst) {
+    return off_.compare_exchange_weak(expected, desired, order);
+  }
+
+  /** Atomic compare exchange strong wrapper */
+  inline bool compare_exchange_strong(size_t& expected, size_t desired,
+                                      std::memory_order order =
+                                      std::memory_order_seq_cst) {
+    return off_.compare_exchange_weak(expected, desired, order);
+  }
+
+  /** Atomic add operator */
+  inline OffsetPointerBase operator+(size_t count) const {
+    return OffsetPointerBase(off_ + count);
+  }
+
+  /** Atomic subtract operator */
+  inline OffsetPointerBase operator-(size_t count) const {
+    return OffsetPointerBase(off_ - count);
+  }
+
+  /** Atomic add assign operator */
+  inline OffsetPointerBase& operator+=(size_t count) {
+    off_ += count;
+    return *this;
+  }
+
+  /** Atomic subtract assign operator */
+  inline OffsetPointerBase& operator-=(size_t count) {
+    off_ -= count;
+    return *this;
+  }
+
+  /** Atomic assign operator */
+  inline OffsetPointerBase& operator=(size_t count) {
+    off_ = count;
+    return *this;
+  }
+
+  /** Atomic copy assign operator */
+  inline OffsetPointerBase& operator=(const OffsetPointerBase &count) {
+    off_ = count.load();
+    return *this;
+  }
+
+  /** Equality check */
+  bool operator==(const OffsetPointerBase &other) const {
+    return off_ == other.off_;
+  }
+
+  /** Inequality check */
+  bool operator!=(const OffsetPointerBase &other) const {
+    return off_ != other.off_;
+  }
+};
+
+/** Non-atomic offset */
+typedef OffsetPointerBase<false> OffsetPointer;
+
+/** Atomic offset */
+typedef OffsetPointerBase<true> AtomicOffsetPointer;
+
+/** Typed offset pointer */
+template<typename T>
+using TypedOffsetPointer = OffsetPointer;
+
+/** Typed atomic pointer */
+template<typename T>
+using TypedAtomicOffsetPointer = AtomicOffsetPointer;
+
+/**
+ * A process-independent pointer, which stores both the allocator's
+ * information and the offset within the allocator's region
+ * */
+template<bool ATOMIC=false>
+struct PointerBase {
+  allocator_id_t allocator_id_;     /// Allocator the pointer comes from
+  OffsetPointerBase<ATOMIC> off_;   /// Offset within the allocator's slot
+
+  /** Default constructor */
+  PointerBase() = default;
+
+  /** Full constructor */
+  explicit PointerBase(allocator_id_t id, size_t off) :
+    allocator_id_(id), off_(off) {}
+
+  /** Full constructor using offset pointer */
+  explicit PointerBase(allocator_id_t id, OffsetPointer off) :
+    allocator_id_(id), off_(off) {}
+
+  /** Copy constructor */
+  PointerBase(const PointerBase &other)
+  : allocator_id_(other.allocator_id_), off_(other.off_) {}
+
+  /** Other copy constructor */
+  PointerBase(const PointerBase<!ATOMIC> &other)
+  : allocator_id_(other.allocator_id_), off_(other.off_.load()) {}
+
+  /** Move constructor */
+  PointerBase(PointerBase &&other) noexcept
+  : allocator_id_(other.allocator_id_), off_(other.off_) {
+    other.SetNull();
+  }
+
+  /** Get the offset pointer */
+  OffsetPointerBase<false> ToOffsetPointer() const {
+    return OffsetPointerBase<false>(off_.load());
+  }
+
+  /** Set to null */
+  void SetNull() {
+    allocator_id_.SetNull();
+  }
+
+  /** Check if null */
+  bool IsNull() const {
+    return allocator_id_.IsNull();
+  }
+
+  /** Get the null pointer */
+  static PointerBase GetNull() {
+    const static PointerBase p(allocator_id_t::GetNull(),
+                               OffsetPointer::GetNull());
+    return p;
+  }
+
+  /** Copy assignment operator */
+  PointerBase& operator=(const PointerBase &other) {
+    if (this != &other) {
+      allocator_id_ = other.allocator_id_;
+      off_ = other.off_;
+    }
+    return *this;
+  }
+
+  /** Move assignment operator */
+  PointerBase& operator=(PointerBase &&other) {
+    if (this != &other) {
+      allocator_id_ = other.allocator_id_;
+      off_.exchange(other.off_.load());
+      other.SetNull();
+    }
+    return *this;
+  }
+
+  /** Addition operator */
+  PointerBase operator+(size_t size) const {
+    PointerBase p;
+    p.allocator_id_ = allocator_id_;
+    p.off_ = off_ + size;
+    return p;
+  }
+
+  /** Subtraction operator */
+  PointerBase operator-(size_t size) const {
+    PointerBase p;
+    p.allocator_id_ = allocator_id_;
+    p.off_ = off_ - size;
+    return p;
+  }
+
+  /** Addition assignment operator */
+  PointerBase& operator+=(size_t size) {
+    off_ += size;
+    return *this;
+  }
+
+  /** Subtraction assignment operator */
+  PointerBase& operator-=(size_t size) {
+    off_ -= size;
+    return *this;
+  }
+
+  /** Equality check */
+  bool operator==(const PointerBase &other) const {
+    return (other.allocator_id_ == allocator_id_ && other.off_ == off_);
+  }
+
+  /** Inequality check */
+  bool operator!=(const PointerBase &other) const {
+    return (other.allocator_id_ != allocator_id_ || other.off_ != off_);
+  }
+};
+
+/** Non-atomic pointer */
+typedef PointerBase<false> Pointer;
+
+/** Atomic pointer */
+typedef PointerBase<true> AtomicPointer;
+
+/** Typed pointer */
+template<typename T>
+using TypedPointer = Pointer;
+
+/** Typed atomic pointer */
+template<typename T>
+using TypedAtomicPointer = AtomicPointer;
+
+/** Round up to the nearest multiple of the alignment */
+static size_t NextAlignmentMultiple(size_t alignment, size_t size) {
+  auto page_size = HERMES_SHM_SYSTEM_INFO->page_size_;
+  size_t new_size = size;
+  size_t page_off = size % alignment;
+  if (page_off) {
+    new_size = size + page_size - page_off;
+  }
+  return new_size;
+}
+
+/** Round up to the nearest multiple of page size */
+static size_t NextPageSizeMultiple(size_t size) {
+  auto page_size = HERMES_SHM_SYSTEM_INFO->page_size_;
+  size_t new_size = NextAlignmentMultiple(page_size, size);
+  return new_size;
+}
+
+}  // namespace hermes_shm::ipc
+
+namespace std {
+
+/** Allocator ID hash */
+template <>
+struct hash<hermes_shm::ipc::allocator_id_t> {
+  std::size_t operator()(const hermes_shm::ipc::allocator_id_t &key) const {
+    return std::hash<uint64_t>{}(key.int_);
+  }
+};
+
+}  // namespace std
+
+
+#endif  // HERMES_SHM_MEMORY_MEMORY_H_

--- a/hermes_shm/include/hermes_shm/memory/memory_manager.h
+++ b/hermes_shm/include/hermes_shm/memory/memory_manager.h
@@ -1,0 +1,204 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MEMORY_MEMORY_MANAGER_H_
+#define HERMES_SHM_MEMORY_MEMORY_MANAGER_H_
+
+#include "hermes_shm/memory/allocator/allocator.h"
+#include "backend/memory_backend.h"
+#include "hermes_shm/memory/allocator/allocator_factory.h"
+#include <hermes_shm/constants/data_structure_singleton_macros.h>
+
+namespace hipc = hermes_shm::ipc;
+
+namespace hermes_shm::ipc {
+
+class MemoryManager {
+ private:
+  allocator_id_t root_allocator_id_;
+  PosixMmap root_backend_;
+  StackAllocator root_allocator_;
+  std::unordered_map<std::string, std::unique_ptr<MemoryBackend>> backends_;
+  std::unordered_map<allocator_id_t, std::unique_ptr<Allocator>> allocators_;
+  Allocator *default_allocator_;
+
+ public:
+  /** The default amount of memory a single allocator manages */
+  static const size_t kDefaultBackendSize = GIGABYTES(64);
+
+  /**
+   * Constructor. Create the root allocator and backend, which is used
+   * until the user specifies a new default. The root allocator stores
+   * only private memory.
+   * */
+  MemoryManager() {
+    root_allocator_id_.bits_.major_ = 0;
+    root_allocator_id_.bits_.minor_ = -1;
+    root_backend_.shm_init(HERMES_SHM_SYSTEM_INFO->ram_size_);
+    root_backend_.Own();
+    root_allocator_.shm_init(&root_backend_, root_allocator_id_, 0);
+    default_allocator_ = &root_allocator_;
+  }
+
+  /**
+   * Create a memory backend. Memory backends are divided into slots.
+   * Each slot corresponds directly with a single allocator.
+   * There can be multiple slots per-backend, enabling multiple allocation
+   * policies over a single memory region.
+   * */
+  template<typename BackendT, typename ...Args>
+  MemoryBackend* CreateBackend(size_t size,
+                               const std::string &url,
+                               Args&& ...args) {
+    backends_.emplace(url,
+                      MemoryBackendFactory::shm_init<BackendT>(size, url),
+                      std::forward<Args>(args)...);
+    auto backend = backends_[url].get();
+    backend->Own();
+    return backend;
+  }
+
+  /**
+   * Attaches to an existing memory backend located at \a url url.
+   * */
+  MemoryBackend* AttachBackend(MemoryBackendType type,
+                               const std::string &url) {
+    backends_.emplace(url, MemoryBackendFactory::shm_deserialize(type, url));
+    auto backend = backends_[url].get();
+    ScanBackends();
+    backend->Disown();
+    return backend;
+  }
+
+  /**
+   * Returns a pointer to a backend that has already been attached.
+   * */
+  MemoryBackend* GetBackend(const std::string &url);
+
+  /**
+   * Destroys the memory allocated by the entire backend.
+   * */
+  void DestroyBackend(const std::string &url);
+
+  /**
+   * Scans all attached backends for new memory allocators.
+   * */
+  void ScanBackends();
+
+  /**
+   * Registers an allocator. Used internally by ScanBackends, but may
+   * also be used externally.
+   * */
+  void RegisterAllocator(std::unique_ptr<Allocator> &alloc);
+
+  /**
+   * Create and register a memory allocator for a particular backend.
+   * */
+  template<typename AllocT, typename ...Args>
+  Allocator* CreateAllocator(const std::string &url,
+                             allocator_id_t alloc_id,
+                             size_t custom_header_size,
+                             Args&& ...args) {
+    auto backend = GetBackend(url);
+    if (alloc_id.IsNull()) {
+      alloc_id = allocator_id_t(HERMES_SHM_SYSTEM_INFO->pid_,
+                                allocators_.size());
+    }
+    auto alloc = AllocatorFactory::shm_init<AllocT>(
+      backend, alloc_id, custom_header_size, std::forward<Args>(args)...);
+    RegisterAllocator(alloc);
+    return GetAllocator(alloc_id);
+  }
+
+  /**
+   * Locates an allocator of a particular id
+   * */
+  Allocator* GetAllocator(allocator_id_t alloc_id) {
+    if (alloc_id.IsNull()) { return nullptr; }
+    if (alloc_id == root_allocator_.GetId()) {
+      return &root_allocator_;
+    }
+    auto iter = allocators_.find(alloc_id);
+    if (iter == allocators_.end()) {
+      ScanBackends();
+    }
+    return reinterpret_cast<Allocator*>(allocators_[alloc_id].get());
+  }
+
+  /**
+   * Gets the allocator used for initializing other allocators.
+   * */
+  Allocator* GetRootAllocator() {
+    return &root_allocator_;
+  }
+
+  /**
+   * Gets the allocator used by default when no allocator is
+   * used to construct an object.
+   * */
+  Allocator* GetDefaultAllocator() {
+    return default_allocator_;
+  }
+
+  /**
+   * Sets the allocator used by default when no allocator is
+   * used to construct an object.
+   * */
+  void SetDefaultAllocator(Allocator *alloc) {
+    default_allocator_ = alloc;
+  }
+
+  /**
+   * Convert a process-independent pointer into a process-specific pointer.
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  T* Convert(const POINTER_T &p) {
+    if (p.IsNull()) {
+      return nullptr;
+    }
+    return GetAllocator(p.allocator_id_)->template
+      Convert<T, POINTER_T>(p);
+  }
+
+  /**
+   * Convert a process-specific pointer into a process-independent pointer
+   *
+   * @param allocator_id the allocator the pointer belongs to
+   * @param ptr the pointer to convert
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  POINTER_T Convert(allocator_id_t allocator_id, T *ptr) {
+    return GetAllocator(allocator_id)->template
+      Convert<T, POINTER_T>(ptr);
+  }
+
+  /**
+   * Convert a process-specific pointer into a process-independent pointer when
+   * the allocator is unkown.
+   *
+   * @param ptr the pointer to convert
+   * */
+  template<typename T, typename POINTER_T=Pointer>
+  POINTER_T Convert(T *ptr) {
+    for (auto &[alloc_id, alloc] : allocators_) {
+      if (alloc->ContainsPtr(ptr)) {
+        return alloc->template
+          Convert<T, POINTER_T>(ptr);
+      }
+    }
+    return Pointer::GetNull();
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif  // HERMES_SHM_MEMORY_MEMORY_MANAGER_H_

--- a/hermes_shm/include/hermes_shm/thread/lock.h
+++ b/hermes_shm/include/hermes_shm/thread/lock.h
@@ -1,0 +1,20 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_LOCK_H_
+#define HERMES_SHM_THREAD_LOCK_H_
+
+#include "lock/mutex.h"
+#include "lock/rwlock.h"
+#include "thread_manager.h"
+
+#endif  // HERMES_SHM_THREAD_LOCK_H_

--- a/hermes_shm/include/hermes_shm/thread/lock/mutex.h
+++ b/hermes_shm/include/hermes_shm/thread/lock/mutex.h
@@ -1,0 +1,47 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_MUTEX_H_
+#define HERMES_SHM_THREAD_MUTEX_H_
+
+#include <atomic>
+
+namespace hermes_shm {
+
+struct Mutex {
+  std::atomic<uint32_t> lock_;
+
+  Mutex() : lock_(0) {}
+
+  void Init() {
+    lock_ = 0;
+  }
+  void Lock();
+  bool TryLock();
+  void Unlock();
+};
+
+struct ScopedMutex {
+  Mutex &lock_;
+  bool is_locked_;
+
+  explicit ScopedMutex(Mutex &lock);
+  ~ScopedMutex();
+
+  void Lock();
+  bool TryLock();
+  void Unlock();
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_MUTEX_H_

--- a/hermes_shm/include/hermes_shm/thread/lock/rwlock.h
+++ b/hermes_shm/include/hermes_shm/thread/lock/rwlock.h
@@ -1,0 +1,99 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_RWLOCK_H_
+#define HERMES_SHM_THREAD_RWLOCK_H_
+
+#include <atomic>
+
+namespace hermes_shm {
+
+union RwLockPayload {
+  struct {
+    uint32_t r_;
+    uint32_t w_;
+  } bits_;
+  uint64_t as_int_;
+
+  RwLockPayload() = default;
+
+  RwLockPayload(const RwLockPayload &other) {
+    as_int_ = other.as_int_;
+  }
+
+  RwLockPayload(uint64_t other) {
+    as_int_ = other;
+  }
+
+  bool IsWriteLocked() const {
+    return bits_.w_ > 0;
+  }
+
+  bool IsReadLocked() const {
+    return bits_.r_ > 0;
+  }
+};
+
+struct RwLock {
+  std::atomic<uint64_t> payload_;
+
+  RwLock() : payload_(0) {}
+
+  void Init() {
+    payload_ = 0;
+  }
+
+  RwLock(const RwLock &other) = delete;
+
+  RwLock(RwLock &&other) noexcept
+  : payload_(other.payload_.load()) {}
+
+  RwLock& operator=(RwLock &&other) {
+    payload_ = other.payload_.load();
+    return (*this);
+  }
+
+  void ReadLock();
+  void ReadUnlock();
+
+  void WriteLock();
+  void WriteUnlock();
+
+  void assert_r_refcnt(int ref);
+  void assert_w_refcnt(int ref);
+};
+
+struct ScopedRwReadLock {
+  RwLock &lock_;
+  bool is_locked_;
+
+  explicit ScopedRwReadLock(RwLock &lock);
+  ~ScopedRwReadLock();
+
+  void Lock();
+  void Unlock();
+};
+
+struct ScopedRwWriteLock {
+  RwLock &lock_;
+  bool is_locked_;
+
+  explicit ScopedRwWriteLock(RwLock &lock);
+  ~ScopedRwWriteLock();
+
+  void Lock();
+  void Unlock();
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_RWLOCK_H_

--- a/hermes_shm/include/hermes_shm/thread/pthread.h
+++ b/hermes_shm/include/hermes_shm/thread/pthread.h
@@ -1,0 +1,100 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_PTHREAD_H_
+#define HERMES_SHM_THREAD_PTHREAD_H_
+
+#include "thread.h"
+#include <errno.h>
+#include <hermes_shm/util/errors.h>
+
+namespace hermes_shm {
+
+template<typename BIND> class Pthread;
+
+template<typename BIND>
+struct PthreadParams {
+  BIND bind_;
+  Pthread<BIND> *pthread_;
+
+  PthreadParams(Pthread<BIND> *pthread, BIND bind) :
+    bind_(bind),
+    pthread_(pthread) {}
+};
+
+template<typename BIND>
+class Pthread : public Thread {
+ private:
+  pthread_t pthread_;
+
+ public:
+  bool started_;
+
+ public:
+  Pthread() = default;
+  explicit Pthread(BIND bind) : started_(false), pthread_(-1) {
+    PthreadParams<BIND> params(this, bind);
+    int ret = pthread_create(&pthread_, nullptr,
+                             DoWork,
+                             &params);
+    if (ret != 0) {
+      throw PTHREAD_CREATE_FAILED.format();
+    }
+    while (!started_) {}
+  }
+
+  void Pause() override {}
+
+  void Resume() override {}
+
+  void Join() override {
+    void *ret;
+    pthread_join(pthread_, &ret);
+  }
+
+  void SetAffinity(int cpu_start, int count) override {
+    /*cpu_set_t cpus[n_cpu_];
+    CPU_ZERO(cpus);
+    CPU_SET(cpu_id, cpus);
+    pthread_setaffinity_np_safe(n_cpu_, cpus);*/
+  }
+
+ private:
+  static void* DoWork(void *void_params) {
+    auto params = (*reinterpret_cast<PthreadParams<BIND>*>(void_params));
+    params.pthread_->started_ = true;
+    params.bind_();
+    return nullptr;
+  }
+
+  inline void pthread_setaffinity_np_safe(int n_cpu, cpu_set_t *cpus) {
+    int ret = pthread_setaffinity_np(pthread_, n_cpu, cpus);
+    if (ret != 0) {
+      throw INVALID_AFFINITY.format(strerror(ret));
+    }
+  }
+};
+
+class PthreadStatic : public ThreadStatic {
+ public:
+  void Yield() override {
+    pthread_yield();
+  }
+
+  tid_t GetTid() override {
+    return static_cast<tid_t>(pthread_self());
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_PTHREAD_H_

--- a/hermes_shm/include/hermes_shm/thread/thread.h
+++ b/hermes_shm/include/hermes_shm/thread/thread.h
@@ -1,0 +1,47 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_THREAD_H_
+#define HERMES_SHM_THREAD_THREAD_H_
+
+#include <vector>
+#include <cstdint>
+#include <memory>
+#include <atomic>
+
+namespace hermes_shm {
+
+typedef uint32_t tid_t;
+
+enum class ThreadType {
+  kPthread
+};
+
+class Thread {
+ public:
+  virtual void Pause() = 0;
+  virtual void Resume() = 0;
+  virtual void Join() = 0;
+  void SetAffinity(int cpu_id) { SetAffinity(cpu_id, 1); }
+  virtual void SetAffinity(int cpu_start, int count) = 0;
+};
+
+class ThreadStatic {
+ public:
+  virtual ~ThreadStatic() = default;
+  virtual void Yield() = 0;
+  virtual tid_t GetTid() = 0;
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_THREAD_H_

--- a/hermes_shm/include/hermes_shm/thread/thread_factory.h
+++ b/hermes_shm/include/hermes_shm/thread/thread_factory.h
@@ -1,0 +1,51 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_THREAD_FACTORY_H_
+#define HERMES_SHM_THREAD_THREAD_FACTORY_H_
+
+#include "thread.h"
+#include "pthread.h"
+
+namespace hermes_shm {
+
+template<typename BIND>
+class ThreadFactory {
+ private:
+  ThreadType type_;
+  BIND bind_;
+
+ public:
+  explicit ThreadFactory(ThreadType type, BIND bind)
+  : type_(type), bind_(bind) {}
+
+  std::unique_ptr<Thread> Get() {
+    switch (type_) {
+      case ThreadType::kPthread: return std::make_unique<Pthread<BIND>>(bind_);
+      default: return nullptr;
+    }
+  }
+};
+
+class ThreadStaticFactory {
+ public:
+  static std::unique_ptr<ThreadStatic> Get(ThreadType type) {
+    switch (type) {
+      case ThreadType::kPthread: return std::make_unique<PthreadStatic>();
+      default: return nullptr;
+    }
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_THREAD_FACTORY_H_

--- a/hermes_shm/include/hermes_shm/thread/thread_manager.h
+++ b/hermes_shm/include/hermes_shm/thread/thread_manager.h
@@ -1,0 +1,43 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_THREAD_THREAD_MANAGER_H_
+#define HERMES_SHM_THREAD_THREAD_MANAGER_H_
+
+#include "thread.h"
+#include "thread_factory.h"
+#include <hermes_shm/constants/data_structure_singleton_macros.h>
+
+namespace hermes_shm {
+
+class ThreadManager {
+ public:
+  ThreadType type_;
+  std::unique_ptr<ThreadStatic> thread_static_;
+
+  ThreadManager() : type_(ThreadType::kPthread) {}
+
+  void SetThreadType(ThreadType type) {
+    type_ = type;
+  }
+
+  ThreadStatic* GetThreadStatic() {
+    if (!thread_static_) {
+      thread_static_ = ThreadStaticFactory::Get(type_);
+    }
+    return thread_static_.get();
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_THREAD_THREAD_MANAGER_H_

--- a/hermes_shm/include/hermes_shm/types/argpack.h
+++ b/hermes_shm/include/hermes_shm/types/argpack.h
@@ -1,0 +1,234 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ARGPACK_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ARGPACK_H_
+
+#include "basic.h"
+#include  <functional>
+
+namespace hermes_shm {
+
+/** Type which indicates that a constructor takes ArgPacks as input */
+struct PiecewiseConstruct {};
+
+/** Type which ends template recurrence */
+struct EndTemplateRecurrence {};
+
+/** Recurrence used to create argument pack */
+template<
+  size_t idx,
+  typename T=EndTemplateRecurrence,
+  typename ...Args>
+struct ArgPackRecur {
+  constexpr static bool is_rval = std::is_rvalue_reference<T>();
+  typedef typename std::conditional<is_rval, T&&, T&>::type ElementT;
+
+  ElementT arg_; /**< The element stored */
+  ArgPackRecur<idx + 1, Args...>
+    recur_; /**< Remaining args */
+
+  /** Default constructor */
+  ArgPackRecur() = default;
+
+  /** Constructor. Rvalue reference. */
+  explicit ArgPackRecur(T arg, Args&& ...args)
+  : arg_(std::forward<T>(arg)), recur_(std::forward<Args>(args)...) {}
+
+  /** Forward an rvalue reference (only if argpack) */
+  template<size_t i>
+  constexpr decltype(auto) Forward() const {
+    if constexpr(i == idx) {
+      if constexpr(is_rval) {
+        return std::forward<T>(arg_);
+      } else {
+        return arg_;
+      }
+    } else {
+      return recur_.template
+        Forward<i>();
+    }
+  }
+};
+
+/** Terminator of the ArgPack recurrence */
+template<size_t idx>
+struct ArgPackRecur<idx, EndTemplateRecurrence> {
+  /** Default constructor */
+  ArgPackRecur() = default;
+
+  /** Forward an rvalue reference (only if argpack) */
+  template<size_t i>
+  constexpr void Forward() const {
+    throw std::logic_error("(Forward) ArgPack index outside of range");
+  }
+};
+
+/** Used to semantically pack arguments */
+template<typename ...Args>
+struct ArgPack {
+  /** Variable argument pack */
+  ArgPackRecur<0, Args...> recur_;
+  /** Size of the argpack */
+  constexpr const static size_t size_ = sizeof...(Args);
+
+  /** General Constructor. */
+  ArgPack(Args&& ...args)
+  : recur_(std::forward<Args>(args)...) {}
+
+  /** Get forward reference */
+  template<size_t idx>
+  constexpr decltype(auto) Forward() const {
+    return recur_.template Forward<idx>();
+  }
+
+  /** Size */
+  constexpr static size_t Size() {
+    return size_;
+  }
+};
+
+/** Make an argpack */
+template<typename ...Args>
+ArgPack<Args&&...> make_argpack(Args&& ...args) {
+  return ArgPack<Args&&...>(std::forward<Args>(args)...);
+}
+
+/** Get the type + reference of the forward for \a pack pack at \a index i */
+#define FORWARD_ARGPACK_FULL_TYPE(pack, i)\
+  decltype(pack.template Forward<i>())
+
+/** Get type of the forward for \a pack pack at \a index i */
+#define FORWARD_ARGPACK_BASE_TYPE(pack, i)\
+  std::remove_reference<FORWARD_ARGPACK_FULL_TYPE(pack, i)>
+
+/** Forward the param for \a pack pack at \a index i */
+#define FORWARD_ARGPACK_PARAM(pack, i)\
+  std::forward<FORWARD_ARGPACK_FULL_TYPE(pack, i)>(\
+    pack.template Forward<i>())
+
+/** Used to pass an argument pack to a function or class method */
+class PassArgPack {
+ public:
+  /** Call function with ArgPack */
+  template<typename ArgPackT, typename F>
+  constexpr static decltype(auto) Call(ArgPackT &&pack, F &&f) {
+    return _CallRecur<0, ArgPackT, F>(
+      std::forward<ArgPackT>(pack), std::forward<F>(f));
+  }
+
+ private:
+  /** Unpacks the ArgPack and passes it to the function */
+  template<size_t i, typename ArgPackT,
+    typename F, typename ...CurArgs>
+  constexpr static decltype(auto) _CallRecur(ArgPackT &&pack,
+                                             F &&f,
+                                             CurArgs&& ...args) {
+    if constexpr(i < ArgPackT::Size()) {
+      return _CallRecur<i + 1, ArgPackT, F>(
+        std::forward<ArgPackT>(pack),
+        std::forward<F>(f),
+        std::forward<CurArgs>(args)...,
+        FORWARD_ARGPACK_PARAM(pack, i));
+    } else {
+      return std::__invoke(f, std::forward<CurArgs>(args)...);
+    }
+  }
+};
+
+/** Combine multiple argpacks into a single argpack */
+class MergeArgPacks {
+ public:
+  /** Call function with ArgPack */
+  template<typename ...ArgPacks>
+  constexpr static decltype(auto) Merge(ArgPacks&& ...packs) {
+    return _MergePacksRecur<0>(make_argpack(std::forward<ArgPacks>(packs)...));
+  }
+
+ private:
+  /** Unpacks the C++ parameter pack of ArgPacks */
+  template<size_t cur_pack, typename ArgPacksT,
+    typename ...CurArgs>
+  constexpr static decltype(auto) _MergePacksRecur(ArgPacksT &&packs,
+                                         CurArgs&& ...args) {
+    if constexpr(cur_pack < ArgPacksT::Size()) {
+      return _MergeRecur<
+        cur_pack, ArgPacksT, 0>(
+        // End template parameters
+        std::forward<ArgPacksT>(packs),
+        FORWARD_ARGPACK_PARAM(packs, cur_pack),
+        std::forward<CurArgs>(args)...
+      );
+    } else {
+      return make_argpack(std::forward<CurArgs>(args)...);
+    }
+  }
+
+  /** Unpacks the C++ parameter pack of ArgPacks */
+  template<
+    size_t cur_pack, typename ArgPacksT,
+    size_t i, typename ArgPackT,
+    typename ...CurArgs>
+  constexpr static decltype(auto) _MergeRecur(ArgPacksT &&packs,
+                                    ArgPackT &&pack,
+                                    CurArgs&& ...args) {
+    if constexpr(i < ArgPackT::Size()) {
+      return _MergeRecur<cur_pack, ArgPacksT, i + 1, ArgPackT>(
+        std::forward<ArgPacksT>(packs),
+        std::forward<ArgPackT>(pack),
+        std::forward<CurArgs>(args)..., FORWARD_ARGPACK_PARAM(pack, i));
+    } else {
+      return _MergePacksRecur<cur_pack + 1, ArgPacksT>(
+        std::forward<ArgPacksT>(packs),
+        std::forward<CurArgs>(args)...);
+    }
+  }
+};
+
+/** Insert an argpack at the head of each pack in a set of ArgPacks */
+class ProductArgPacks {
+ public:
+  /** The product function */
+  template<typename ProductPackT, typename ...ArgPacks>
+  constexpr static decltype(auto) Product(ProductPackT &&prod_pack,
+                                ArgPacks&& ...packs) {
+    return _ProductPacksRecur<0>(
+      std::forward<ProductPackT>(prod_pack),
+      make_argpack(std::forward<ArgPacks>(packs)...));
+  }
+
+ private:
+  /** Prepend \a ArgPack prod_pack to every ArgPack in orig_packs */
+  template<
+    size_t cur_pack,
+    typename ProductPackT,
+    typename OrigPacksT,
+    typename ...NewPacks>
+  constexpr static decltype(auto) _ProductPacksRecur(ProductPackT &&prod_pack,
+                                           OrigPacksT &&orig_packs,
+                                           NewPacks&& ...packs) {
+    if constexpr(cur_pack < OrigPacksT::Size()) {
+      return _ProductPacksRecur<cur_pack + 1>(
+        std::forward<ProductPackT>(prod_pack),
+        std::forward<OrigPacksT>(orig_packs),
+        std::forward<NewPacks>(packs)...,
+        std::forward<ProductPackT>(prod_pack),
+        FORWARD_ARGPACK_PARAM(orig_packs, cur_pack));
+    } else {
+      return make_argpack(std::forward<NewPacks>(packs)...);
+    }
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ARGPACK_H_

--- a/hermes_shm/include/hermes_shm/types/atomic.h
+++ b/hermes_shm/include/hermes_shm/types/atomic.h
@@ -1,0 +1,252 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ATOMIC_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ATOMIC_H_
+
+#include <atomic>
+
+namespace hermes_shm::ipc {
+
+/** Provides the API of an atomic, without being atomic */
+template<typename T>
+struct nonatomic {
+  T x;
+
+  /** Constructor */
+  inline nonatomic() = default;
+
+  /** Full constructor */
+  inline nonatomic(T def) : x(def) {}
+
+  /** Atomic fetch_add wrapper*/
+  inline T fetch_add(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    (void) order;
+    x += count;
+    return x;
+  }
+
+  /** Atomic fetch_sub wrapper*/
+  inline T fetch_sub(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    (void) order;
+    x -= count;
+    return x;
+  }
+
+  /** Atomic load wrapper */
+  inline T load(
+    std::memory_order order = std::memory_order_seq_cst) const {
+    (void) order;
+    return x;
+  }
+
+  /** Atomic exchange wrapper */
+  inline void exchange(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    (void) order;
+    x = count;
+  }
+
+  /** Atomic compare exchange weak wrapper */
+  inline bool compare_exchange_weak(T& expected, T desired,
+                                    std::memory_order order =
+                                    std::memory_order_seq_cst) {
+    (void) expected; (void) order;
+    x = desired;
+    return true;
+  }
+
+  /** Atomic compare exchange strong wrapper */
+  inline bool compare_exchange_strong(T& expected, T desired,
+                                      std::memory_order order =
+                                      std::memory_order_seq_cst) {
+    (void) expected; (void) order;
+    x = desired;
+    return true;
+  }
+
+  /** Atomic pre-increment operator */
+  inline nonatomic& operator++() {
+    ++x;
+    return *this;
+  }
+
+  /** Atomic post-increment operator */
+  inline nonatomic operator++(int) {
+    return atomic(x+1);
+  }
+
+  /** Atomic pre-decrement operator */
+  inline nonatomic& operator--() {
+    --x;
+    return *this;
+  }
+
+  /** Atomic post-decrement operator */
+  inline nonatomic operator--(int) {
+    return atomic(x-1);
+  }
+
+  /** Atomic add operator */
+  inline nonatomic operator+(T count) const {
+    return nonatomic(x + count);
+  }
+
+  /** Atomic subtract operator */
+  inline nonatomic operator-(T count) const {
+    return nonatomic(x - count);
+  }
+
+  /** Atomic add assign operator */
+  inline nonatomic& operator+=(T count) {
+    x += count;
+    return *this;
+  }
+
+  /** Atomic subtract assign operator */
+  inline nonatomic& operator-=(T count) {
+    x -= count;
+    return *this;
+  }
+
+  /** Atomic assign operator */
+  inline nonatomic& operator=(T count) {
+    x = count;
+    return *this;
+  }
+
+  /** Equality check */
+  inline bool operator==(const nonatomic &other) const {
+    return (other.x == x);
+  }
+
+  /** Inequality check */
+  inline bool operator!=(const nonatomic &other) const {
+    return (other.x != x);
+  }
+};
+
+/** A wrapper around std::atomic */
+template<typename T>
+struct atomic {
+  std::atomic<T> x;
+
+  /** Constructor */
+  inline atomic() = default;
+
+  /** Full constructor */
+  inline atomic(T def) : x(def) {}
+
+  /** Atomic fetch_add wrapper*/
+  inline T fetch_add(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    return x.fetch_add(count, order);
+  }
+
+  /** Atomic fetch_sub wrapper*/
+  inline T fetch_sub(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    return x.fetch_sub(count, order);
+  }
+
+  /** Atomic load wrapper */
+  inline T load(
+    std::memory_order order = std::memory_order_seq_cst) const {
+    return x.load(order);
+  }
+
+  /** Atomic exchange wrapper */
+  inline void exchange(
+    T count, std::memory_order order = std::memory_order_seq_cst) {
+    x.exchange(count, order);
+  }
+
+  /** Atomic compare exchange weak wrapper */
+  inline bool compare_exchange_weak(T& expected, T desired,
+                                    std::memory_order order =
+                                    std::memory_order_seq_cst) {
+    return x.compare_exchange_weak(expected, desired, order);
+  }
+
+  /** Atomic compare exchange strong wrapper */
+  inline bool compare_exchange_strong(T& expected, T desired,
+                                      std::memory_order order =
+                                      std::memory_order_seq_cst) {
+    return x.compare_exchange_strong(expected, desired, order);
+  }
+
+  /** Atomic pre-increment operator */
+  inline atomic& operator++() {
+    ++x;
+    return *this;
+  }
+
+  /** Atomic post-increment operator */
+  inline atomic operator++(int) {
+    return atomic(x+1);
+  }
+
+  /** Atomic pre-decrement operator */
+  inline atomic& operator--() {
+    --x;
+    return *this;
+  }
+
+  /** Atomic post-decrement operator */
+  inline atomic operator--(int) {
+    return atomic(x-1);
+  }
+
+  /** Atomic add operator */
+  inline atomic operator+(T count) const {
+    return x + count;
+  }
+
+  /** Atomic subtract operator */
+  inline atomic operator-(T count) const {
+    return x - count;
+  }
+
+  /** Atomic add assign operator */
+  inline atomic& operator+=(T count) {
+    x += count;
+    return *this;
+  }
+
+  /** Atomic subtract assign operator */
+  inline atomic& operator-=(T count) {
+    x -= count;
+    return *this;
+  }
+
+  /** Atomic assign operator */
+  inline atomic& operator=(T count) {
+    x.exchange(count);
+    return *this;
+  }
+
+  /** Equality check */
+  inline bool operator==(const atomic &other) const {
+    return (other.x == x);
+  }
+
+  /** Inequality check */
+  inline bool operator!=(const atomic &other) const {
+    return (other.x != x);
+  }
+};
+
+}
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_ATOMIC_H_

--- a/hermes_shm/include/hermes_shm/types/basic.h
+++ b/hermes_shm/include/hermes_shm/types/basic.h
@@ -1,0 +1,139 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_BASICS_H
+#define HERMES_SHM_BASICS_H
+
+#define MODULE_KEY_SIZE 32
+
+#include <cstdint>
+using std::size_t;
+
+#include <stdint.h>
+#include <string>
+#include <cstring>
+#include <unordered_map>
+#include <limits>
+
+namespace hermes_shm {
+
+/**
+ * decimal + (numerator/65536)
+ * */
+struct RealNumber {
+  uint64_t decimal_;
+  uint32_t numerator_;
+  static const uint32_t precision = 65536;
+
+  RealNumber() =  default;
+
+  /**
+   * Converts numerator / denomintor ->
+   * decimal + (numerator / 65536);
+   *
+   * For example,
+   * 4/5 = (4 * 65536 / 5) / 65536
+   * */
+  explicit RealNumber(uint64_t numerator, uint64_t denominator) {
+    decimal_ = numerator / denominator;
+    uint64_t rem = numerator % denominator;
+    numerator_ = rem * precision / denominator;
+  }
+
+  /**
+   * (d1 + n1/p) * d2 =
+   * d1 * d2 + d2 * n1 / p
+   * */
+  RealNumber operator*(size_t other) const {
+    RealNumber res;
+    res.decimal_ = other * decimal_;
+    uint64_t frac = other * numerator_;
+    res.decimal_ += frac / precision;
+    res.numerator_ = frac % precision;
+    return res;
+  }
+
+  /**
+   * (d1 + n1/p) * (d2 + n2/p) =
+   * (d1 * d2) + (d1 * n2)/p + (d2 * n1) / p + (n1 * n2 / p) / p =
+   * (d1 * d2) + [(d1 * n2) + (d2 * n1) + (n1 * n2)/p] / p
+   * */
+  RealNumber operator*(const RealNumber &other) const {
+    RealNumber res;
+    // d1 * d2
+    res.decimal_ = other.decimal_ * decimal_;
+    uint64_t frac =
+      (decimal_ * other.numerator_) + // d1 * n2
+      (other.decimal_ * numerator_) + // d2 * n1
+      (numerator_ * other.numerator_) / precision; // n1 * n2 / p
+    res.decimal_ += frac / precision;
+    res.numerator_ = frac % precision;
+    return res;
+  }
+
+  RealNumber operator*=(size_t other) {
+    (*this) = (*this) * other;
+    return *this;
+  }
+
+  RealNumber operator*=(const RealNumber &other) {
+    (*this) = (*this) * other;
+    return *this;
+  }
+
+  size_t as_int() const {
+    return decimal_ + numerator_ / precision;
+  }
+};
+
+struct id {
+  char key_[MODULE_KEY_SIZE];
+  id() = default;
+  ~id() = default;
+  explicit id(const std::string &key_str) {
+    snprintf(key_, MODULE_KEY_SIZE, "%s", key_str.c_str());
+  }
+  explicit id(const char* key_str) {
+    snprintf(key_, MODULE_KEY_SIZE, "%s", key_str);
+  }
+  bool operator==(const id &other) const {
+    return strncmp(key_, other.key_, MODULE_KEY_SIZE) == 0;
+  }
+  void copy(const std::string &str) {
+    memcpy(key_, str.c_str(), str.size());
+    key_[str.size()] = 0;
+  }
+  const char& operator[](int i) {
+    return key_[i];
+  }
+};
+
+typedef int32_t off_t;
+
+}  // namespace hermes_shm
+
+namespace std {
+template<>
+struct hash<hermes_shm::id> {
+  size_t operator()(const hermes_shm::id &id) const {
+    size_t sum = 0;
+    int len = strnlen(id.key_, MODULE_KEY_SIZE);
+    for (int i = 0; i < len; ++i) {
+      if (id.key_[i] == 0) { break; }
+      sum += id.key_[i] << (i % 8);
+    }
+    return sum;
+  }
+};
+}  // namespace std
+
+#endif  // HERMES_SHM_BASICS_H

--- a/hermes_shm/include/hermes_shm/types/bitfield.h
+++ b/hermes_shm/include/hermes_shm/types/bitfield.h
@@ -1,0 +1,75 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_BITFIELD_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_BITFIELD_H_
+
+#include <cstdint>
+
+namespace hermes_shm {
+
+#define BIT_OPT(T, n) (((T)1) << n)
+
+/**
+ * A generic bitfield template
+ * */
+template<typename T=uint32_t>
+struct bitfield {
+  T bits_;
+
+  bitfield() : bits_(0) {}
+
+  inline void SetBits(T mask) {
+    bits_ |= mask;
+  }
+
+  inline void UnsetBits(T mask) {
+    bits_ &= ~mask;
+  }
+
+  inline bool OrBits(T mask) const {
+    return bits_ & mask;
+  }
+
+  inline void CopyBits(bitfield field, T mask) {
+    bits_ &= (field.bits_ & mask);
+  }
+
+  inline void Clear() {
+    bits_ = 0;
+  }
+} __attribute__((packed));
+typedef bitfield<uint8_t> bitfield8_t;
+typedef bitfield<uint16_t> bitfield16_t;
+typedef bitfield<uint32_t> bitfield32_t;
+
+#define INHERIT_BITFIELD_OPS(BITFIELD_VAR, MASK_T)\
+  inline void SetBits(MASK_T mask) {\
+    BITFIELD_VAR.SetBits(mask);\
+  }\
+  inline void UnsetBits(MASK_T mask) {\
+    BITFIELD_VAR.UnsetBits(mask);\
+  }\
+  inline bool OrBits(MASK_T mask) const {\
+    return BITFIELD_VAR.OrBits(mask);\
+  }\
+  inline void Clear() {\
+    BITFIELD_VAR.Clear();\
+  }\
+  template<typename BITFIELD_T>\
+  inline void CopyBits(BITFIELD_T field, MASK_T mask) {\
+    BITFIELD_VAR.CopyBits(field, mask);\
+  }
+
+}  // namespace hermes_shm
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_BITFIELD_H_

--- a/hermes_shm/include/hermes_shm/types/charbuf.h
+++ b/hermes_shm/include/hermes_shm/types/charbuf.h
@@ -1,0 +1,204 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_CHARBUF_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_CHARBUF_H_
+
+#include "basic.h"
+#include "hermes_shm/memory/memory_manager.h"
+#include <string>
+
+namespace hermes_shm {
+
+/** An uninterpreted array of bytes */
+struct charbuf {
+  hipc::Allocator *alloc_; /**< The allocator used to allocate data */
+  char *data_; /**< The pointer to data */
+  size_t size_; /**< The size of data */
+  bool destructable_;  /**< Whether or not this container owns data */
+
+  /** Default constructor */
+  charbuf() : alloc_(nullptr), data_(nullptr), size_(0), destructable_(false) {}
+
+  /** Destructor */
+  ~charbuf() { Free(); }
+
+  /** Size-based constructor */
+  explicit charbuf(size_t size) {
+    Allocate(HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator(), size);
+  }
+
+  /** String-based constructor */
+  explicit charbuf(const std::string &data) {
+    Allocate(HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator(), data.size());
+    memcpy(data_, data.data(), data.size());
+  }
+
+  /** Pointer-based constructor */
+  explicit charbuf(char *data, size_t size)
+  : alloc_(nullptr), data_(data), size_(size), destructable_(false) {}
+
+  /**
+   * Pointer-based constructor
+   * This should only be used when Blob itself is const.
+   * */
+  explicit charbuf(const char *data, size_t size)
+  : alloc_(nullptr), data_(const_cast<char*>(data)),
+    size_(size), destructable_(false) {}
+
+
+  /** Copy constructor */
+  charbuf(const charbuf &other) {
+    if (!Allocate(HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator(),
+                  other.size())) {
+      return;
+    }
+    memcpy(data_, other.data(), size());
+  }
+
+  /** Copy assignment operator */
+  charbuf& operator=(const charbuf &other) {
+    if (this != &other) {
+      Free();
+      if (!Allocate(HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator(),
+                    other.size())) {
+        return *this;
+      }
+      memcpy(data_, other.data(), size());
+    }
+    return *this;
+  }
+
+  /** Move constructor */
+  charbuf(charbuf &&other) {
+    alloc_ = other.alloc_;
+    data_ = other.data_;
+    size_ = other.size_;
+    destructable_ = other.destructable_;
+    other.size_ = 0;
+    other.destructable_ = false;
+  }
+
+  /** Move assignment operator */
+  charbuf& operator=(charbuf &other) {
+    if (this != &other) {
+      Free();
+      alloc_ = other.alloc_;
+      data_ = other.data_;
+      size_ = other.size_;
+      destructable_ = other.destructable_;
+      other.size_ = 0;
+      other.destructable_ = false;
+    }
+    return *this;
+  }
+
+  /** Destroy and resize */
+  void resize(size_t new_size) {
+    if (new_size <= size()) {
+      size_ = new_size;
+      return;
+    }
+    if (alloc_ == nullptr) {
+      alloc_ = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();
+    }
+    if (destructable_) {
+      data_ = alloc_->ReallocatePtr<char>(data_, new_size);
+    } else {
+      data_ = alloc_->AllocatePtr<char>(new_size);
+    }
+    destructable_ = true;
+    size_ = new_size;
+  }
+
+  /** Reference data */
+  char* data() {
+    return data_;
+  }
+
+  /** Reference data */
+  char* data() const {
+    return data_;
+  }
+
+  /** Reference size */
+  size_t size() const {
+    return size_;
+  }
+
+  /**
+    * Comparison operators
+    * */
+
+  int _strncmp(const char *a, size_t len_a,
+               const char *b, size_t len_b) const {
+    if (len_a != len_b) {
+      return int((int64_t)len_a - (int64_t)len_b);
+    }
+    int sum = 0;
+    for (size_t i = 0; i < len_a; ++i) {
+      sum += a[i] - b[i];
+    }
+    return sum;
+  }
+
+#define HERMES_SHM_STR_CMP_OPERATOR(op) \
+  bool operator op(const char *other) const { \
+    return _strncmp(data(), size(), other, strlen(other)) op 0; \
+  } \
+  bool operator op(const std::string &other) const { \
+    return _strncmp(data(), size(), other.data(), other.size()) op 0; \
+  } \
+  bool operator op(const charbuf &other) const { \
+    return _strncmp(data(), size(), other.data(), other.size()) op 0; \
+  }
+
+  HERMES_SHM_STR_CMP_OPERATOR(==)
+  HERMES_SHM_STR_CMP_OPERATOR(!=)
+  HERMES_SHM_STR_CMP_OPERATOR(<)
+  HERMES_SHM_STR_CMP_OPERATOR(>)
+  HERMES_SHM_STR_CMP_OPERATOR(<=)
+  HERMES_SHM_STR_CMP_OPERATOR(>=)
+
+#undef HERMES_SHM_STR_CMP_OPERATOR
+
+ private:
+  /** Allocate charbuf */
+  bool Allocate(hipc::Allocator *alloc, size_t size) {
+    hipc::OffsetPointer p;
+    if (size == 0) {
+      alloc_ = nullptr;
+      data_ = nullptr;
+      size_ = 0;
+      destructable_ = false;
+      return false;
+    }
+    alloc_ = alloc;
+    data_ = alloc->AllocatePtr<char>(size, p);
+    size_ = size;
+    destructable_ = true;
+    return true;
+  }
+
+  /** Explicitly free the charbuf */
+  void Free() {
+    if (destructable_ && data_ && size_) {
+      alloc_->FreePtr<char>(data_);
+    }
+  }
+};
+
+typedef charbuf string;
+
+}  // namespace hermes_shm
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_TYPES_CHARBUF_H_

--- a/hermes_shm/include/hermes_shm/types/messages.h
+++ b/hermes_shm/include/hermes_shm/types/messages.h
@@ -1,0 +1,49 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_MESSAGES_H
+#define HERMES_SHM_MESSAGES_H
+
+namespace hermes_shm {
+
+enum {
+  HERMES_SHM_ADMIN_REGISTER_QP
+};
+
+struct admin_request {
+  int op_;
+  admin_request() {}
+  explicit admin_request(int op) : op_(op) {}
+};
+
+struct admin_reply {
+  int code_;
+  admin_reply() {}
+  explicit admin_reply(int code) : code_(code) {}
+};
+
+struct setup_reply : public admin_reply {
+  uint32_t region_id_;
+  uint32_t region_size_;
+  uint32_t request_region_size_;
+  uint32_t request_unit_;
+  uint32_t queue_region_size_;
+  uint32_t queue_depth_;
+  uint32_t num_queues_;
+  uint32_t namespace_region_id_;
+  uint32_t namespace_region_size_;
+  uint32_t namespace_max_entries_;
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_MESSAGES_H

--- a/hermes_shm/include/hermes_shm/types/tuple_base.h
+++ b/hermes_shm/include/hermes_shm/types/tuple_base.h
@@ -1,0 +1,247 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_TupleBase_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_TupleBase_H_
+
+#include <utility>
+#include "basic.h"
+#include "argpack.h"
+
+namespace hermes_shm {
+
+/** The null container wrapper */
+template<typename T>
+using NullWrap = T;
+
+/** Recurrence used to create argument pack */
+template<
+  template<typename> typename Wrap,
+  size_t idx,
+  typename T=EndTemplateRecurrence,
+  typename ...Args>
+struct TupleBaseRecur {
+  Wrap<T> arg_; /**< The element stored */
+  TupleBaseRecur<Wrap, idx + 1, Args...>
+    recur_; /**< Remaining args */
+
+  /** Default constructor */
+  TupleBaseRecur() = default;
+
+  /** Constructor. Const reference. */
+  explicit TupleBaseRecur(const T &arg, Args&& ...args)
+    : arg_(std::forward<T>(arg)), recur_(std::forward<Args>(args)...) {}
+
+  /** Constructor. Lvalue reference. */
+  explicit TupleBaseRecur(T& arg, Args&& ...args)
+  : arg_(std::forward<T>(arg)), recur_(std::forward<Args>(args)...) {}
+
+  /** Constructor. Rvalue reference. */
+  explicit TupleBaseRecur(T&& arg, Args&& ...args)
+  : arg_(std::forward<T>(arg)), recur_(std::forward<Args>(args)...) {}
+
+  /** Move constructor */
+  TupleBaseRecur(TupleBaseRecur &&other) noexcept
+  : arg_(std::move(other.arg_)), recur_(std::move(other.recur_)) {}
+
+  /** Move assignment operator */
+  TupleBaseRecur& operator=(TupleBaseRecur &&other) {
+    if (this != &other) {
+      arg_ = std::move(other.arg_);
+      recur_ = std::move(other.recur_);
+    }
+    return *this;
+  }
+
+  /** Copy constructor */
+  TupleBaseRecur(const TupleBaseRecur &other)
+  : arg_(other.arg_), recur_(other.recur_) {}
+
+  /** Copy assignment operator */
+  TupleBaseRecur& operator=(const TupleBaseRecur &other) {
+    if (this != &other) {
+      arg_ = other.arg_;
+      recur_ = other.recur_;
+    }
+    return *this;
+  }
+
+  /** Solidification constructor */
+  template<typename ...CArgs>
+  explicit TupleBaseRecur(ArgPack<CArgs...> &&other)
+    : arg_(other.template Forward<idx>()),
+      recur_(std::forward<ArgPack<CArgs...>>(other)) {}
+
+  /** Get reference to internal variable (only if tuple) */
+  template<size_t i>
+  constexpr auto& Get() {
+    if constexpr(i == idx) {
+      return arg_;
+    } else {
+      return recur_.template
+        Get<i>();
+    }
+  }
+
+  /** Get reference to internal variable (only if tuple, const) */
+  template<size_t i>
+  constexpr auto& Get() const {
+    if constexpr(i == idx) {
+      return arg_;
+    } else {
+      return recur_.template
+        Get<i>();
+    }
+  }
+};
+
+/** Terminator of the TupleBase recurrence */
+template<
+  template<typename> typename Wrap,
+  size_t idx>
+struct TupleBaseRecur<Wrap, idx, EndTemplateRecurrence> {
+  /** Default constructor */
+  TupleBaseRecur() = default;
+
+  /** Solidification constructor */
+  template<typename ...CArgs>
+  explicit TupleBaseRecur(ArgPack<CArgs...> &&other) {}
+
+  /** Getter */
+  template<size_t i>
+  void Get() {
+    throw std::logic_error("(Get) TupleBase index outside of range");
+  }
+
+  /** Getter */
+  template<size_t i>
+  void Get() const {
+    throw std::logic_error("(Get) TupleBase index outside of range");
+  }
+};
+
+/** Used to semantically pack arguments */
+template<
+  bool is_argpack,
+  template<typename> typename Wrap,
+  typename ...Args>
+struct TupleBase {
+  /** Variable argument pack */
+  TupleBaseRecur<Wrap, 0, Args...> recur_;
+
+  /** Default constructor */
+  TupleBase() = default;
+
+  /** General Constructor. */
+  template<typename ...CArgs>
+  explicit TupleBase(Args&& ...args)
+  : recur_(std::forward<Args>(args)...) {}
+
+  /** Move constructor */
+  TupleBase(TupleBase &&other) noexcept
+  : recur_(std::move(other.recur_)) {}
+
+  /** Move assignment operator */
+  TupleBase& operator=(TupleBase &&other) noexcept {
+    if (this != &other) {
+      recur_ = std::move(other.recur_);
+    }
+    return *this;
+  }
+
+  /** Copy constructor */
+  TupleBase(const TupleBase &other)
+  : recur_(other.recur_) {}
+
+  /** Copy assignment operator */
+  TupleBase& operator=(const TupleBase &other) {
+    if (this != &other) {
+      recur_ = other.recur_;
+    }
+    return *this;
+  }
+
+  /** Solidification constructor */
+  template<typename ...CArgs>
+  explicit TupleBase(ArgPack<CArgs...> &&other)
+  : recur_(std::forward<ArgPack<CArgs...>>(other)) {}
+
+  /** Getter */
+  template<size_t idx>
+  constexpr auto& Get() {
+    return recur_.template Get<idx>();
+  }
+
+  /** Getter (const) */
+  template<size_t idx>
+  constexpr auto& Get() const {
+    return recur_.template Get<idx>();
+  }
+
+  /** Size */
+  constexpr static size_t Size() {
+    return sizeof...(Args);
+  }
+};
+
+/** Tuple definition */
+template<typename ...Containers>
+using tuple = TupleBase<false, NullWrap, Containers...>;
+
+/** Tuple Wrapper Definition */
+template<template<typename> typename Wrap, typename ...Containers>
+using tuple_wrap = TupleBase<false, Wrap, Containers...>;
+
+/** Used to emulate constexpr to lambda */
+template<typename T, T Val>
+struct MakeConstexpr {
+  constexpr static T val_ = Val;
+  constexpr static T Get() {
+    return val_;
+  }
+};
+
+/** Apply a function over an entire TupleBase / tuple */
+template<bool reverse>
+class IterateTuple {
+ public:
+  /** Apply a function to every element of a tuple */
+  template<typename TupleT, typename F>
+  constexpr static void Apply(TupleT &pack, F &&f) {
+    _Apply<0, TupleT, F>(pack, std::forward<F>(f));
+  }
+
+ private:
+  /** Apply the function recursively */
+  template<size_t i, typename TupleT, typename F>
+  constexpr static void _Apply(TupleT &pack, F &&f) {
+    if constexpr(i < TupleT::Size()) {
+      if constexpr(reverse) {
+        _Apply<i + 1, TupleT, F>(pack, std::forward<F>(f));
+        f(MakeConstexpr<size_t, i>(), pack.template Get<i>());
+      } else {
+        f(MakeConstexpr<size_t, i>(), pack.template Get<i>());
+        _Apply<i + 1, TupleT, F>(pack, std::forward<F>(f));
+      }
+    }
+  }
+};
+
+/** Forward iterate over tuple and apply function  */
+using ForwardIterateTuple = IterateTuple<false>;
+
+/** Reverse iterate over tuple and apply function */
+using ReverseIterateTuple = IterateTuple<true>;
+
+}  // namespace hermes_shm
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_DATA_STRUCTURES_TupleBase_H_

--- a/hermes_shm/include/hermes_shm/util/auto_trace.h
+++ b/hermes_shm/include/hermes_shm/util/auto_trace.h
@@ -1,0 +1,52 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_INCLUDE_HERMES_SHM_UTIL_AUTO_TRACE_H_
+#define HERMES_SHM_INCLUDE_HERMES_SHM_UTIL_AUTO_TRACE_H_
+
+#include "formatter.h"
+#include "timer.h"
+
+namespace hermes_shm {
+
+#define AUTO_TRACE() AutoTrace(__PRETTY_FUNCTION__);
+
+/** An in-memory log of trace times */
+class AutoTraceLog {
+ public:
+  std::stringstream ss_;
+  void emplace_back(const std::string &fname, Timer timer) {
+    ss_ << fname << "," << timer.GetUsec() << "," << std::endl;
+  }
+};
+
+/** Trace function execution times */
+class AutoTrace {
+ private:
+  HighResMonotonicTimer timer_;
+  std::string fname_;
+  static AutoTraceLog log_;
+
+ public:
+  AutoTrace(const std::string &fname) : fname_(fname) {
+    timer_.Resume();
+  }
+
+  ~AutoTrace() {
+    timer_.Pause();
+    log_.emplace_back(fname_, timer_);
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif //HERMES_SHM_INCLUDE_HERMES_SHM_UTIL_AUTO_TRACE_H_

--- a/hermes_shm/include/hermes_shm/util/debug.h
+++ b/hermes_shm/include/hermes_shm/util/debug.h
@@ -1,0 +1,77 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_DEBUG_H
+#define HERMES_SHM_DEBUG_H
+
+#if defined(HERMES_SHM_DEBUG) && defined(__cplusplus)
+#define AUTO_TRACE(...) \
+  hermes_shm::AutoTrace auto_tracer(false, __PRETTY_FUNCTION__, __VA_ARGS__);
+#define TRACEPOINT(...) \
+  hermes_shm::AutoTrace(true, __PRETTY_FUNCTION__, __VA_ARGS__);
+#elif defined(KERNEL_BUILD) && defined(DEBUG)
+#define AUTO_TRACE(...) pr_info(__VA_ARGS__);
+#define TRACEPOINT(...) pr_info(__VA_ARGS__);
+#else
+#define AUTO_TRACE(...)
+#define TRACEPOINT(...)
+#endif
+
+#ifdef __cplusplus
+
+#include "stdio.h"
+#include "hermes_shm/util/timer.h"
+#include "hermes_shm/util/formatter.h"
+#include <sched.h>
+#include <unistd.h>
+
+namespace hermes_shm {
+
+class AutoTrace {
+ private:
+  std::string base_text_;
+  bool tracepoint_;
+  hermes_shm::HighResCpuTimer t_cpu_;
+  hermes_shm::HighResMonotonicTimer t_total_;
+
+ public:
+  template<typename ...Args>
+  AutoTrace(bool tracepoint, Args&& ...args) : tracepoint_(tracepoint) {
+    // TODO(llogan): Redo with good argpack
+    std::stringstream ss;
+    base_text_ = ss.str();
+    t_cpu_.Resume();
+    t_total_.Resume();
+    if (!tracepoint) {
+      printf("%s\n", (base_text_ + "start").c_str());
+    } else {
+      printf("%d;%s\n", gettid(), (base_text_).c_str());
+    }
+  }
+
+  ~AutoTrace() {
+    if (!tracepoint_) {
+      t_cpu_.Pause();
+      t_total_.Pause();
+      base_text_ += "cpu-time-us;" +
+          std::to_string(t_cpu_.GetUsec()) + ";total-time-us;" +
+          std::to_string(t_total_.GetUsec()) + ";";
+      printf("%s\n", (base_text_ + "end").c_str());
+    }
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif
+
+#endif  // HERMES_SHM_DEBUG_H

--- a/hermes_shm/include/hermes_shm/util/error.h
+++ b/hermes_shm/include/hermes_shm/util/error.h
@@ -1,0 +1,60 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_ERROR_H
+#define HERMES_SHM_ERROR_H
+
+// #ifdef __cplusplus
+
+#include <iostream>
+#include <string>
+#include <cstdlib>
+#include <memory>
+#include <hermes_shm/util/formatter.h>
+
+#define HERMES_SHM_ERROR_TYPE std::shared_ptr<hermes_shm::Error>
+#define HERMES_SHM_ERROR_HANDLE_START() try {
+#define HERMES_SHM_ERROR_HANDLE_END() \
+  } catch(HERMES_SHM_ERROR_TYPE &err) { err->print(); exit(-1024); }
+#define HERMES_SHM_ERROR_HANDLE_TRY try
+#define HERMES_SHM_ERROR_PTR err
+#define HERMES_SHM_ERROR_HANDLE_CATCH catch(HERMES_SHM_ERROR_TYPE &HERMES_SHM_ERROR_PTR)
+#define HERMES_SHM_ERROR_IS(err, check) (err->get_code() == check.get_code())
+
+namespace hermes_shm {
+
+class Error {
+ private:
+  std::string fmt_;
+  std::string msg_;
+ public:
+  Error() : fmt_() {}
+  explicit Error(std::string fmt) : fmt_(std::move(fmt)) {}
+  ~Error() = default;
+
+  template<typename ...Args>
+  std::shared_ptr<Error> format(Args&& ...args) const {
+    std::shared_ptr<Error> err = std::make_shared<Error>(fmt_);
+    err->msg_ = Formatter::format(fmt_, std::forward<Args>(args)...);
+    return err;
+  }
+
+  void print() {
+    std::cout << msg_ << std::endl;
+  }
+};
+
+}  // namespace hermes_shm
+
+// #endif
+
+#endif  // HERMES_SHM_ERROR_H

--- a/hermes_shm/include/hermes_shm/util/errors.h
+++ b/hermes_shm/include/hermes_shm/util/errors.h
@@ -1,0 +1,62 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_ERRORS_H
+#define HERMES_SHM_ERRORS_H
+
+#ifdef __cplusplus
+
+#include <hermes_shm/util/error.h>
+
+namespace hermes_shm {
+  const Error FILE_NOT_FOUND("File not found at {}");
+  const Error INVALID_STORAGE_TYPE("{} is not a valid storage method");
+  const Error INVALID_SERIALIZER_TYPE("{} is not a valid serializer type");
+  const Error INVALID_TRANSPORT_TYPE("{} is not a valid transport type");
+  const Error INVALID_AFFINITY("Could not set CPU affinity of thread: {}");
+  const Error MMAP_FAILED("Could not mmap file: {}");
+  const Error LAZY_ERROR("Error in function {}");
+  const Error PTHREAD_CREATE_FAILED("Failed to create a pthread");
+  const Error NOT_IMPLEMENTED("{} not implemented");
+
+  const Error DLSYM_MODULE_NOT_FOUND("Module {} was not loaded; error {}");
+  const Error DLSYM_MODULE_NO_CONSTRUCTOR("Module {} has no constructor");
+
+  const Error UNIX_SOCKET_FAILED("Failed to create socket: {}");
+  const Error UNIX_BIND_FAILED("Failed to bind socket: {}");
+  const Error UNIX_CONNECT_FAILED("Failed to connect over socket: {}");
+  const Error UNIX_SENDMSG_FAILED("Failed to send message over socket: {}");
+  const Error UNIX_RECVMSG_FAILED("Failed to receive message over socket: {}");
+  const Error UNIX_SETSOCKOPT_FAILED("Failed to set socket options: {}");
+  const Error UNIX_GETSOCKOPT_FAILED("Failed to acquire user credentials: {}");
+  const Error UNIX_LISTEN_FAILED("Failed to listen for connections: {}");
+  const Error UNIX_ACCEPT_FAILED("Failed accept connections: {}");
+
+  const Error ARRAY_OUT_OF_BOUNDS("Exceeded the bounds of array in {}");
+
+  const Error SHMEM_CREATE_FAILED("Failed to allocate SHMEM");
+  const Error SHMEM_RESERVE_FAILED("Failed to reserve SHMEM");
+  const Error SHMEM_NOT_SUPPORTED("Attempting to deserialize a non-shm backend");
+  const Error MEMORY_BACKEND_NOT_FOUND("Failed to find the memory backend");
+  const Error NOT_ENOUGH_CONCURRENT_SPACE("{}: Failed to divide memory slot {} among {} devices");
+  const Error ALIGNED_ALLOC_NOT_SUPPORTED("Allocator does not support aligned allocations");
+  const Error PAGE_SIZE_UNSUPPORTED("Allocator does not support size: {}");
+  const Error OUT_OF_MEMORY("{}: could not allocate memory of size {}");
+  const Error INVALID_FREE("{}: could not free memory of size {}");
+  const Error DOUBLE_FREE("Freeing the same memory twice!");
+
+  const Error UNORDERED_MAP_CANT_FIND("Could not find key in unordered_map");
+}  // namespace hermes_shm
+
+#endif
+
+#endif  // HERMES_SHM_ERRORS_H

--- a/hermes_shm/include/hermes_shm/util/formatter.h
+++ b/hermes_shm/include/hermes_shm/util/formatter.h
@@ -1,0 +1,100 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_ERROR_SERIALIZER_H
+#define HERMES_SHM_ERROR_SERIALIZER_H
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <type_traits>
+#include <cstring>
+#include <sstream>
+#include <hermes_shm/types/argpack.h>
+
+#define NUMBER_SERIAL(type) \
+    return std::to_string(num_.type);
+
+namespace hermes_shm {
+
+class Formattable {
+ public:
+  virtual std::string ToString() = 0;
+};
+
+class SizeType : public Formattable {
+ public:
+  double num_;
+  size_t unit_;
+
+  static const size_t
+      BYTES = 1,
+      KB = (1ul << 10),
+      MB = (1ul << 20),
+      GB = (1ul << 30),
+      TB = (1ul << 40);
+
+  std::string unit_to_str(size_t unit) {
+    switch (unit) {
+      case BYTES: return "BYTES";
+      case KB: return "KB";
+      case MB: return "MB";
+      case GB: return "GB";
+      case TB: return "TB";
+    }
+    return "";
+  }
+
+  SizeType() : num_(0), unit_(0) {}
+  SizeType(const SizeType &old_obj) {
+    num_ = old_obj.num_;
+    unit_ = old_obj.unit_;
+  }
+
+  SizeType(int8_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(int16_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(int32_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(int64_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(uint8_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(uint16_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(uint32_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(uint64_t bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(float bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+  SizeType(double bytes, size_t unit) :
+  num_(((double)bytes)/unit), unit_(unit) {}
+
+  std::string ToString() {
+    return std::to_string(num_) + unit_to_str(unit_);
+  }
+};
+
+class Formatter {
+ public:
+  template<typename ...Args>
+  static std::string format(std::string fmt, Args&& ...args) {
+    // make_argpack(std::forward<Args>(args)...);
+    return fmt;
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  //HERMES_SHM_ERROR_SERIALIZER_H

--- a/hermes_shm/include/hermes_shm/util/partitioner.h
+++ b/hermes_shm/include/hermes_shm/util/partitioner.h
@@ -1,0 +1,156 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_PARTITIONER_H
+#define HERMES_SHM_PARTITIONER_H
+
+// Reference: https://stackoverflow.com/questions/63372288/getting-list-of-pids-from-proc-in-linux
+
+#include <vector>
+#include <dirent.h>
+#include <sys/sysinfo.h>
+#include <sched.h>
+#include <string>
+
+namespace hermes_shm {
+
+class ProcessAffiner {
+ private:
+  int n_cpu_;
+  cpu_set_t *cpus_;
+
+ public:
+  ProcessAffiner() {
+    n_cpu_ = get_nprocs_conf();
+    cpus_ = new cpu_set_t[n_cpu_];
+    CPU_ZERO(cpus_);
+  }
+
+  ~ProcessAffiner() {
+    delete cpus_;
+  }
+
+  inline bool isdigit(char digit) {
+    return ('0' <= digit && digit <= '9');
+  }
+
+  inline int GetNumCPU() {
+    return n_cpu_;
+  }
+
+  inline void SetCpu(int cpu) {
+    CPU_SET(cpu, cpus_);
+  }
+
+  inline void SetCpus(int off, int len) {
+    for (int i = 0; i < len; ++i) {
+      SetCpu(off + i);
+    }
+  }
+
+  inline void ClearCpu(int cpu) {
+    CPU_CLR(cpu, cpus_);
+  }
+
+  inline void ClearCpus(int off, int len) {
+    for (int i = 0; i < len; ++i) {
+      ClearCpu(off + i);
+    }
+  }
+
+  inline void Clear() {
+    CPU_ZERO(cpus_);
+  }
+
+  int AffineAll(void) {
+    DIR *procdir;
+    struct dirent *entry;
+    int count = 0;
+
+    // Open /proc directory.
+    procdir = opendir("/proc");
+    if (!procdir) {
+      perror("opendir failed");
+      return 0;
+    }
+
+    // Iterate through all files and folders of /proc.
+    while ((entry = readdir(procdir))) {
+      // Skip anything that is not a PID folder.
+      if (!is_pid_folder(entry))
+        continue;
+      // Get the PID of the running process
+      int proc_pid = atoi(entry->d_name);
+      // Set the affinity of all running process to this mask
+      count += Affine(proc_pid);
+    }
+    closedir(procdir);
+    return count;
+  }
+  int Affine(std::vector<pid_t> &&pids) {
+    return Affine(pids);
+  }
+  int Affine(std::vector<pid_t> &pids) {
+    // Set the affinity of all running process to this mask
+    int count = 0;
+    for (pid_t &pid : pids) {
+      count += Affine(pid);
+    }
+    return count;
+  }
+  int Affine(int pid) {
+    return SetAffinitySafe(pid, n_cpu_, cpus_);
+  }
+
+  void PrintAffinity(int pid) {
+    PrintAffinity("", pid);
+  }
+  void PrintAffinity(std::string prefix, int pid) {
+    std::vector<cpu_set_t> cpus(n_cpu_);
+    sched_getaffinity(pid, n_cpu_, cpus.data());
+    PrintAffinity(prefix, pid, cpus.data());
+  }
+
+  void PrintAffinity(std::string prefix, int pid, cpu_set_t *cpus) {
+    std::string affinity = "";
+    for (int i = 0; i < n_cpu_; ++i) {
+      if (CPU_ISSET(i, cpus)) {
+        affinity += std::to_string(i) + ", ";
+      }
+    }
+    printf("%s: CPU affinity[pid=%d]: %s\n", prefix.c_str(),
+           pid, affinity.c_str());
+  }
+
+ private:
+  int SetAffinitySafe(int pid, int n_cpu, cpu_set_t *cpus) {
+    int ret = sched_setaffinity(pid, n_cpu, cpus);
+    if (ret == -1) {
+      return 0;
+    }
+    return 1;
+  }
+
+  // Helper function to check if a struct dirent from /proc is a PID folder.
+  int is_pid_folder(const struct dirent *entry) {
+    const char *p;
+    for (p = entry->d_name; *p; p++) {
+      if (!isdigit(*p))
+        return false;
+    }
+    return true;
+  }
+};
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_PARTITIONER_H

--- a/hermes_shm/include/hermes_shm/util/path_parser.h
+++ b/hermes_shm/include/hermes_shm/util/path_parser.h
@@ -1,0 +1,50 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_PATH_PARSER_H
+#define HERMES_SHM_PATH_PARSER_H
+
+#include <cstdlib>
+#include <string>
+#include <regex>
+#include <list>
+
+namespace scs {
+
+std::string path_parser(std::string path) {
+  std::smatch env_names;
+  std::regex expr("\\$\\{[^\\}]+\\}");
+  if (!std::regex_search(path, env_names, expr)) {
+    return path;
+  }
+  for (auto &env_name_re : env_names) {
+    std::string to_replace = std::string(env_name_re);
+    std::string env_name = to_replace.substr(2, to_replace.size()-3);
+    std::string env_val = env_name;
+    try {
+      char *ret = getenv(env_name.c_str());
+      if (ret) {
+        env_val = ret;
+      } else {
+        continue;
+      }
+    } catch(...) {
+    }
+    std::regex replace_expr("\\$\\{" + env_name + "\\}");
+    path = std::regex_replace(path, replace_expr, env_val);
+  }
+  return path;
+}
+
+}  // namespace scs
+
+#endif  // HERMES_SHM_PATH_PARSER_H

--- a/hermes_shm/include/hermes_shm/util/singleton.h
+++ b/hermes_shm/include/hermes_shm/util/singleton.h
@@ -1,0 +1,34 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef SCS_SINGLETON_H
+#define SCS_SINGLETON_H
+
+#include <memory>
+#include "hermes_shm/thread/lock/mutex.h"
+
+namespace scs {
+
+template<typename T>
+class Singleton {
+ private:
+  static T obj_;
+ public:
+  Singleton() = default;
+  static T* GetInstance() {
+    return &obj_;
+  }
+};
+
+}  // namespace scs
+
+#endif  // SCS_SINGLETON_H

--- a/hermes_shm/include/hermes_shm/util/timer.h
+++ b/hermes_shm/include/hermes_shm/util/timer.h
@@ -1,0 +1,96 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TIMER_H
+#define HERMES_SHM_TIMER_H
+
+#include <chrono>
+#include <vector>
+#include <functional>
+
+namespace hermes_shm {
+
+template<typename T>
+class TimerBase {
+ private:
+  std::chrono::time_point<T> start_, end_;
+  double time_ns_;
+
+ public:
+  TimerBase() : time_ns_(0) {}
+
+  void Resume() {
+    start_ = T::now();
+  }
+  double Pause() {
+    time_ns_ += GetNsecFromStart();
+    return time_ns_;
+  }
+  double Pause(double &dt) {
+    dt = GetNsecFromStart();
+    time_ns_ += dt;
+    return time_ns_;
+  }
+  void Reset() {
+    time_ns_ = 0;
+  }
+
+  double GetNsecFromStart() {
+    end_ = T::now();
+    double elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        end_ - start_).count();
+    return elapsed;
+  }
+  double GetUsecFromStart() {
+    end_ = T::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+        end_ - start_).count();
+  }
+  double GetMsecFromStart() {
+    end_ = T::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_ - start_).count();
+  }
+  double GetSecFromStart() {
+    end_ = T::now();
+    return std::chrono::duration_cast<std::chrono::seconds>(
+        end_ - start_).count();
+  }
+
+  double GetNsec() const {
+    return time_ns_;
+  }
+  double GetUsec() const {
+    return time_ns_/1000;
+  }
+  double GetMsec() const {
+    return time_ns_/1000000;
+  }
+  double GetSec() const {
+    return time_ns_/1000000000;
+  }
+
+  double GetUsFromEpoch() const {
+    std::chrono::time_point<std::chrono::system_clock> point =
+        std::chrono::system_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+        point.time_since_epoch()).count();
+  }
+};
+
+typedef TimerBase<std::chrono::high_resolution_clock> HighResCpuTimer;
+typedef TimerBase<std::chrono::steady_clock> HighResMonotonicTimer;
+typedef HighResMonotonicTimer Timer;
+
+}  // namespace hermes_shm
+
+#endif  // HERMES_SHM_TIMER_H

--- a/hermes_shm/src/CMakeLists.txt
+++ b/hermes_shm/src/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+##################Build HermesShm main packages
+add_library(hermes_shm_data_structures
+        ${CMAKE_CURRENT_SOURCE_DIR}/thread/mutex.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/thread/rwlock.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/memory/malloc_allocator.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/memory/stack_allocator.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/memory/memory_manager.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/data_structure_singleton.cc)
+target_link_libraries(hermes_shm_data_structures
+        yaml-cpp pthread -lrt -ldl)
+
+##################Install HermesShm
+install(TARGETS
+        hermes_shm_data_structures
+        EXPORT
+        ${HERMES_EXPORTED_TARGETS}
+        LIBRARY DESTINATION ${HERMES_INSTALL_LIB_DIR}
+        ARCHIVE DESTINATION ${HERMES_INSTALL_LIB_DIR}
+        RUNTIME DESTINATION ${HERMES_INSTALL_BIN_DIR})
+
+##################COVERAGE
+if(HERMES_ENABLE_COVERAGE)
+    set_coverage_flags(hermes_shm_data_structures)
+endif()
+
+#-----------------------------------------------------------------------------
+# Export all exported targets to the build tree for use by parent project
+#-----------------------------------------------------------------------------
+set(HERMES_EXPORTED_LIBS
+        hermes_shm_data_structures
+        ${HERMES_EXPORTED_LIBS})
+if(NOT HERMES_EXTERNALLY_CONFIGURED)
+    EXPORT (
+        TARGETS
+        ${HERMES_EXPORTED_LIBS}
+        FILE
+        ${HERMES_EXPORTED_TARGETS}.cmake
+    )
+endif()

--- a/hermes_shm/src/data_structure_singleton.cc
+++ b/hermes_shm/src/data_structure_singleton.cc
@@ -1,0 +1,23 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <hermes_shm/constants/macros.h>
+#include <hermes_shm/util/singleton.h>
+#include <hermes_shm/thread/lock/mutex.h>
+#include <hermes_shm/constants/data_structure_singleton_macros.h>
+
+#include <hermes_shm/introspect/system_info.h>
+template<> hermes_shm::SystemInfo scs::Singleton<hermes_shm::SystemInfo>::obj_ = hermes_shm::SystemInfo();
+#include <hermes_shm/memory/memory_manager.h>
+template<> hermes_shm::ipc::MemoryManager scs::Singleton<hermes_shm::ipc::MemoryManager>::obj_ = hermes_shm::ipc::MemoryManager();
+#include <hermes_shm/thread/thread_manager.h>
+template<> hermes_shm::ThreadManager scs::Singleton<hermes_shm::ThreadManager>::obj_ = hermes_shm::ThreadManager();

--- a/hermes_shm/src/memory/malloc_allocator.cc
+++ b/hermes_shm/src/memory/malloc_allocator.cc
@@ -1,0 +1,79 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <hermes_shm/memory/allocator/malloc_allocator.h>
+
+namespace hermes_shm::ipc {
+
+struct MallocPage {
+  size_t page_size_;
+};
+
+void MallocAllocator::shm_init(MemoryBackend *backend,
+                               allocator_id_t id,
+                               size_t custom_header_size) {
+  backend_ = backend;
+  header_ = reinterpret_cast<MallocAllocatorHeader*>(
+    malloc(sizeof(MallocAllocatorHeader) + custom_header_size));
+  custom_header_ = reinterpret_cast<char*>(header_ + 1);
+  header_->Configure(id, custom_header_size);
+}
+
+void MallocAllocator::shm_deserialize(MemoryBackend *backend) {
+  throw NOT_IMPLEMENTED.format("MallocAllocator::shm_deserialize");
+}
+
+size_t MallocAllocator::GetCurrentlyAllocatedSize() {
+  return header_->total_alloc_size_;
+}
+
+OffsetPointer MallocAllocator::AllocateOffset(size_t size) {
+  auto page = reinterpret_cast<MallocPage*>(
+    malloc(sizeof(MallocPage) + size));
+  page->page_size_ = size;
+  header_->total_alloc_size_ += size;
+  return OffsetPointer(size_t(page + 1));
+}
+
+OffsetPointer MallocAllocator::AlignedAllocateOffset(size_t size,
+                                                     size_t alignment) {
+  auto page = reinterpret_cast<MallocPage*>(
+    aligned_alloc(alignment, sizeof(MallocPage) + size));
+  page->page_size_ = size;
+  header_->total_alloc_size_ += size;
+  return OffsetPointer(size_t(page + 1));
+}
+
+OffsetPointer MallocAllocator::ReallocateOffsetNoNullCheck(OffsetPointer p,
+                                                           size_t new_size) {
+  // Get the input page
+  auto page = reinterpret_cast<MallocPage*>(
+    p.off_.load() - sizeof(MallocPage));
+  header_->total_alloc_size_ += new_size - page->page_size_;
+
+  // Reallocate the input page
+  auto new_page = reinterpret_cast<MallocPage*>(
+    realloc(page, sizeof(MallocPage) + new_size));
+  new_page->page_size_ = new_size;
+
+  // Create the pointer
+  return OffsetPointer(size_t(new_page + 1));
+}
+
+void MallocAllocator::FreeOffsetNoNullCheck(OffsetPointer p) {
+  auto page = reinterpret_cast<MallocPage*>(
+    p.off_.load() - sizeof(MallocPage));
+  header_->total_alloc_size_ -= page->page_size_;
+  free(page);
+}
+
+}  // namespace hermes_shm::ipc

--- a/hermes_shm/src/memory/memory_intercept.cc
+++ b/hermes_shm/src/memory/memory_intercept.cc
@@ -1,0 +1,93 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <malloc.h>
+#include <stdlib.h>
+#include "hermes_shm/memory/memory_manager.h"
+
+using hermes_shm::ipc::Pointer;
+using hermes_shm::ipc::Allocator;
+
+/** Allocate SIZE bytes of memory. */
+void* malloc(size_t size) {
+  auto alloc = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();
+  return alloc->AllocatePtr<void>(size);
+}
+
+/** Allocate NMEMB elements of SIZE bytes each, all initialized to 0. */
+void* calloc(size_t nmemb, size_t size) {
+  auto alloc = HERMES_SHM_MEMORY_MANAGER->GetDefaultAllocator();
+  return alloc->ClearAllocatePtr<void>(nmemb * size);
+}
+
+/**
+ * Re-allocate the previously allocated block in ptr, making the new
+ * block SIZE bytes long.
+ * */
+void* realloc(void *ptr, size_t size) {
+  Pointer p = HERMES_SHM_MEMORY_MANAGER->Convert(ptr);
+  auto alloc = HERMES_SHM_MEMORY_MANAGER->GetAllocator(p.allocator_id_);
+  return alloc->AllocatePtr<void>(size);
+}
+
+/**
+ * Re-allocate the previously allocated block in PTR, making the new
+ * block large enough for NMEMB elements of SIZE bytes each.
+ * */
+void* reallocarray(void *ptr, size_t nmemb, size_t size) {
+  return realloc(ptr, nmemb * size);
+}
+
+/** Free a block allocated by `malloc', `realloc' or `calloc'. */
+void free(void *ptr) {
+  Pointer p = HERMES_SHM_MEMORY_MANAGER->Convert(ptr);
+  auto alloc = HERMES_SHM_MEMORY_MANAGER->GetAllocator(p.allocator_id_);
+  alloc->Free(p);
+}
+
+/** Allocate SIZE bytes allocated to ALIGNMENT bytes. */
+void* memalign(size_t alignment, size_t size) {
+  // TODO(llogan): need to add an aligned allocator
+  return malloc(size);
+}
+
+/** Allocate SIZE bytes on a page boundary. */
+void* valloc(size_t size) {
+  return memalign(HERMES_SHM_SYSTEM_INFO->page_size_, size);
+}
+
+/**
+ * Equivalent to valloc(minimum-page-that-holds(n)),
+ * that is, round up size to nearest pagesize.
+ * */
+void* pvalloc(size_t size) {
+  size_t new_size = hermes_shm::ipc::NextPageSizeMultiple(size);
+  return valloc(new_size);
+}
+
+/**
+ * Allocates size bytes and places the address of the
+ * allocated memory in *memptr. The address of the allocated memory
+ * will be a multiple of alignment, which must be a power of two and a multiple
+ * of sizeof(void *). Returns NULL if size is 0. */
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+  (*memptr) = memalign(alignment, size);
+  return 0;
+}
+
+/**
+ * Aligned to an alignment with a size that is a multiple of the
+ * alignment
+ * */
+void *aligned_alloc(size_t alignment, size_t size) {
+  return memalign(alignment, hermes_shm::ipc::NextAlignmentMultiple(alignment, size));
+}

--- a/hermes_shm/src/memory/memory_intercept.h
+++ b/hermes_shm/src/memory/memory_intercept.h
@@ -1,0 +1,18 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_SRC_MEMORY_MEMORY_INTERCEPT_H_
+#define HERMES_SHM_SRC_MEMORY_MEMORY_INTERCEPT_H_
+
+
+
+#endif //HERMES_SHM_SRC_MEMORY_MEMORY_INTERCEPT_H_

--- a/hermes_shm/src/memory/memory_manager.cc
+++ b/hermes_shm/src/memory/memory_manager.cc
@@ -1,0 +1,45 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <hermes_shm/memory/memory_manager.h>
+#include "hermes_shm/memory/backend/memory_backend_factory.h"
+#include "hermes_shm/memory/allocator/allocator_factory.h"
+#include <hermes_shm/introspect/system_info.h>
+
+namespace hermes_shm::ipc {
+
+MemoryBackend* MemoryManager::GetBackend(const std::string &url) {
+  return backends_[url].get();
+}
+
+void MemoryManager::DestroyBackend(const std::string &url) {
+  auto backend = GetBackend(url);
+  backend->shm_destroy();
+  backends_.erase(url);
+}
+
+void MemoryManager::ScanBackends() {
+  for (auto &[url, backend] : backends_) {
+    auto alloc = AllocatorFactory::shm_deserialize(backend.get());
+    RegisterAllocator(alloc);
+  }
+}
+
+void MemoryManager::RegisterAllocator(std::unique_ptr<Allocator> &alloc) {
+  if (default_allocator_ == nullptr ||
+      default_allocator_ == &root_allocator_) {
+    default_allocator_ = alloc.get();
+  }
+  allocators_.emplace(alloc->GetId(), std::move(alloc));
+}
+
+}  // namespace hermes_shm::ipc

--- a/hermes_shm/src/memory/stack_allocator.cc
+++ b/hermes_shm/src/memory/stack_allocator.cc
@@ -1,0 +1,76 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <hermes_shm/memory/allocator/stack_allocator.h>
+#include <hermes_shm/memory/allocator/mp_page.h>
+
+namespace hermes_shm::ipc {
+
+void StackAllocator::shm_init(MemoryBackend *backend,
+                             allocator_id_t id,
+                             size_t custom_header_size) {
+  backend_ = backend;
+  header_ = reinterpret_cast<StackAllocatorHeader*>(backend_->data_);
+  custom_header_ = reinterpret_cast<char*>(header_ + 1);
+  size_t region_off = (custom_header_ - backend_->data_) + custom_header_size;
+  size_t region_size = backend_->data_size_ - region_off;
+  header_->Configure(id, custom_header_size, region_off, region_size);
+}
+
+void StackAllocator::shm_deserialize(MemoryBackend *backend) {
+  backend_ = backend;
+  header_ = reinterpret_cast<StackAllocatorHeader*>(backend_->data_);
+  custom_header_ = reinterpret_cast<char*>(header_ + 1);
+}
+
+size_t StackAllocator::GetCurrentlyAllocatedSize() {
+  return header_->total_alloc_;
+}
+
+OffsetPointer StackAllocator::AllocateOffset(size_t size) {
+  size += sizeof(MpPage);
+  OffsetPointer p(header_->region_off_.fetch_add(size));
+  auto hdr = Convert<MpPage>(p);
+  hdr->SetAllocated();
+  hdr->page_size_ = size;
+  header_->region_size_.fetch_sub(hdr->page_size_);
+  header_->total_alloc_.fetch_add(hdr->page_size_);
+  return p + sizeof(MpPage);
+}
+
+OffsetPointer StackAllocator::AlignedAllocateOffset(size_t size,
+                                                    size_t alignment) {
+  throw ALIGNED_ALLOC_NOT_SUPPORTED.format();
+}
+
+OffsetPointer StackAllocator::ReallocateOffsetNoNullCheck(OffsetPointer p,
+                                                          size_t new_size) {
+  OffsetPointer new_p;
+  void *src = Convert<void>(p);
+  auto hdr = Convert<MpPage>(p - sizeof(MpPage));
+  size_t old_size = hdr->page_size_ - sizeof(MpPage);
+  void *dst = AllocatePtr<void, OffsetPointer>(new_size, new_p);
+  memcpy(dst, src, old_size);
+  Free(p);
+  return new_p;
+}
+
+void StackAllocator::FreeOffsetNoNullCheck(OffsetPointer p) {
+  auto hdr = Convert<MpPage>(p - sizeof(MpPage));
+  if (!hdr->IsAllocated()) {
+    throw DOUBLE_FREE.format();
+  }
+  hdr->UnsetAllocated();
+  header_->total_alloc_.fetch_sub(hdr->page_size_);
+}
+
+}  // namespace hermes_shm::ipc

--- a/hermes_shm/src/thread/mutex.cc
+++ b/hermes_shm/src/thread/mutex.cc
@@ -1,0 +1,96 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "hermes_shm/thread/lock.h"
+#include "hermes_shm/thread/thread_manager.h"
+
+namespace hermes_shm {
+
+/**
+ * Acquire the mutex
+ * */
+void Mutex::Lock() {
+  auto thread_info = HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+  while (!TryLock()) {
+    thread_info->Yield();
+  }
+}
+
+/**
+ * Attempt to acquire the mutex
+ * */
+bool Mutex::TryLock() {
+  if (lock_.load() != 0) return false;
+  uint32_t tkt = lock_.fetch_add(1);
+  if (tkt != 0) {
+    lock_.fetch_sub(1);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Release the mutex
+ * */
+void Mutex::Unlock() {
+  lock_.fetch_sub(1);
+}
+
+/**
+ * SCOPED MUTEX
+ * */
+
+/**
+ * Constructor
+ * */
+ScopedMutex::ScopedMutex(Mutex &lock)
+: lock_(lock), is_locked_(false) {
+}
+
+/**
+ * Release the mutex
+ * */
+ScopedMutex::~ScopedMutex() {
+  Unlock();
+}
+
+/**
+ * Acquire the mutex
+ * */
+void ScopedMutex::Lock() {
+  if (!is_locked_) {
+    lock_.Lock();
+    is_locked_ = true;
+  }
+}
+
+/**
+ * Attempt to acquire the mutex
+ * */
+bool ScopedMutex::TryLock() {
+  if (!is_locked_) {
+    is_locked_ = lock_.TryLock();
+  }
+  return is_locked_;
+}
+
+/**
+ * Acquire the mutex
+ * */
+void ScopedMutex::Unlock() {
+  if (is_locked_) {
+    lock_.Unlock();
+    is_locked_ = false;
+  }
+}
+
+}  // namespace hermes_shm

--- a/hermes_shm/src/thread/rwlock.cc
+++ b/hermes_shm/src/thread/rwlock.cc
@@ -1,0 +1,192 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "hermes_shm/thread/lock/rwlock.h"
+#include "hermes_shm/thread/thread_manager.h"
+
+namespace hermes_shm {
+
+/**
+ * Acquire the read lock
+ * */
+void RwLock::ReadLock() {
+  bool ret = false;
+  RwLockPayload expected, desired;
+  auto thread_info = HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+  do {
+    expected.as_int_ = payload_.load();
+    if (expected.IsWriteLocked()) {
+      thread_info->Yield();
+      continue;
+    }
+    desired = expected;
+    desired.bits_.r_ += 1;
+    ret = payload_.compare_exchange_weak(
+      expected.as_int_,
+      desired.as_int_);
+  } while (!ret);
+}
+
+/**
+ * Release the read lock
+ * */
+void RwLock::ReadUnlock() {
+  bool ret;
+  RwLockPayload expected, desired;
+  do {
+    expected.as_int_ = payload_.load();
+    desired = expected;
+    desired.bits_.r_ -= 1;
+    ret = payload_.compare_exchange_weak(
+      expected.as_int_,
+      desired.as_int_);
+  } while (!ret);
+}
+
+/**
+ * Acquire the write lock
+ * */
+void RwLock::WriteLock() {
+  bool ret = false;
+  RwLockPayload expected, desired;
+  auto thread_info = HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+  do {
+    expected.as_int_ = payload_.load();
+    if (expected.IsReadLocked()) {
+      thread_info->Yield();
+      continue;
+    }
+    if (expected.IsWriteLocked()) {
+      thread_info->Yield();
+      continue;
+    }
+    desired = expected;
+    desired.bits_.w_ += 1;
+    ret = payload_.compare_exchange_weak(
+      expected.as_int_,
+      desired.as_int_);
+  } while (!ret);
+}
+
+/**
+ * Release the write lock
+ * */
+void RwLock::WriteUnlock() {
+  bool ret;
+  RwLockPayload expected, desired;
+  do {
+    expected.as_int_ = payload_.load();
+    desired = expected;
+    desired.bits_.w_ -= 1;
+    ret = payload_.compare_exchange_weak(
+      expected.as_int_,
+      desired.as_int_);
+  } while (!ret);
+}
+
+/**
+ * Verify the reference count for reads (for debugging)
+ * */
+void RwLock::assert_r_refcnt(int ref) {
+  if (RwLockPayload(payload_).bits_.r_ != ref) {
+    throw 1;
+  }
+}
+
+/**
+ * Verify the reference count for writes (for debugging)
+ * */
+void RwLock::assert_w_refcnt(int ref) {
+  if (RwLockPayload(payload_).bits_.w_ > 1) {
+    throw 1;
+  }
+}
+
+/**
+ * SCOPED R/W READ LOCK
+ * */
+
+/**
+ * Constructor
+ * */
+ScopedRwReadLock::ScopedRwReadLock(RwLock &lock)
+: lock_(lock), is_locked_(false) {
+  Lock();
+}
+
+/**
+ * Release the read lock
+ * */
+ScopedRwReadLock::~ScopedRwReadLock() {
+  Unlock();
+}
+
+/**
+ * Acquire the read lock
+ * */
+void ScopedRwReadLock::Lock() {
+  if (!is_locked_) {
+    lock_.ReadLock();
+    is_locked_ = true;
+  }
+}
+
+/**
+ * Release the read lock
+ * */
+void ScopedRwReadLock::Unlock() {
+  if (is_locked_) {
+    lock_.ReadUnlock();
+    is_locked_ = false;
+  }
+}
+
+/**
+ * SCOPED R/W WRITE LOCK
+ * */
+
+/**
+ * Constructor
+ * */
+ScopedRwWriteLock::ScopedRwWriteLock(RwLock &lock)
+: lock_(lock), is_locked_(false) {
+  Lock();
+}
+
+/**
+ * Release the write lock
+ * */
+ScopedRwWriteLock::~ScopedRwWriteLock() {
+  Unlock();
+}
+
+/**
+ * Acquire the write lock
+ * */
+void ScopedRwWriteLock::Lock() {
+  if (!is_locked_) {
+    lock_.WriteLock();
+    is_locked_ = true;
+  }
+}
+
+/**
+ * Release the write lock
+ * */
+void ScopedRwWriteLock::Unlock() {
+  if (is_locked_) {
+    lock_.WriteUnlock();
+    is_locked_ = false;
+  }
+}
+
+}  // namespace hermes_shm

--- a/hermes_shm/test/CMakeLists.txt
+++ b/hermes_shm/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_subdirectory(unit)

--- a/hermes_shm/test/unit/CMakeLists.txt
+++ b/hermes_shm/test/unit/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(TEST_MAIN ${CMAKE_CURRENT_SOURCE_DIR})
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(data_structures)
+add_subdirectory(allocators)
+add_subdirectory(types)

--- a/hermes_shm/test/unit/allocators/CMakeLists.txt
+++ b/hermes_shm/test/unit/allocators/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_allocator_exec
+        ${TEST_MAIN}/main.cc
+        test_init.cc
+        allocator.cc
+        allocator_thread.cc)
+add_dependencies(test_allocator_exec hermes_shm_data_structures)
+target_link_libraries(test_allocator_exec
+        hermes_shm_data_structures Catch2::Catch2 MPI::MPI_CXX OpenMP::OpenMP_CXX)
+
+# PAGE ALLOCATOR TESTS
+add_test(NAME test_page_allocator COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_allocator_exec "StackAllocator")
+add_test(NAME test_page_allocator_4t COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_allocator_exec "StackAllocatorMultithreaded")

--- a/hermes_shm/test/unit/allocators/allocator.cc
+++ b/hermes_shm/test/unit/allocators/allocator.cc
@@ -1,0 +1,135 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "test_init.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+void PageAllocationTest(Allocator *alloc) {
+  int count = 1024;
+  size_t page_size = KILOBYTES(4);
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+
+  // Allocate pages
+  std::vector<Pointer> ps(count);
+  void *ptrs[count];
+  for (int i = 0; i < count; ++i) {
+    ptrs[i] = alloc->AllocatePtr<void>(page_size, ps[i]);
+    memset(ptrs[i], i, page_size);
+    REQUIRE(ps[i].off_.load() != 0);
+    REQUIRE(!ps[i].IsNull());
+    REQUIRE(ptrs[i] != nullptr);
+  }
+
+  // Convert process pointers into independent pointers
+  for (int i = 0; i < count; ++i) {
+    Pointer p = mem_mngr->Convert(ptrs[i]);
+    REQUIRE(p == ps[i]);
+    REQUIRE(VerifyBuffer((char*)ptrs[i], page_size, i));
+  }
+
+  // Check the custom header
+  auto hdr = alloc->GetCustomHeader<SimpleAllocatorHeader>();
+  REQUIRE(hdr->checksum_ == HEADER_CHECKSUM);
+
+  // Free pages
+  for (int i = 0; i < count; ++i) {
+    alloc->Free(ps[i]);
+  }
+
+  // Reallocate pages
+  for (int i = 0; i < count; ++i) {
+    ptrs[i] = alloc->AllocatePtr<void>(page_size, ps[i]);
+    REQUIRE(ps[i].off_.load() != 0);
+    REQUIRE(!ps[i].IsNull());
+  }
+
+  // Free again
+  for (int i = 0; i < count; ++i) {
+    alloc->Free(ps[i]);
+  }
+}
+
+void MultiPageAllocationTest(Allocator *alloc) {
+  size_t alloc_sizes[] = {
+    64, 128, 256,
+    KILOBYTES(1), KILOBYTES(4), KILOBYTES(64),
+    MEGABYTES(1), MEGABYTES(16), MEGABYTES(32)
+  };
+
+  // Allocate and free pages between 64 bytes and 1MB
+  {
+    REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+    for (size_t r = 0; r < 10; ++r) {
+      for (size_t i = 0; i < 1000; ++i) {
+        Pointer ps[4];
+        for (size_t j = 0; j < 4; ++j) {
+          ps[j] = alloc->Allocate(alloc_sizes[i % 9]);
+        }
+        for (size_t j = 0; j < 4; ++j) {
+          alloc->Free(ps[j]);
+        }
+      }
+    }
+    REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  }
+
+  // Aligned allocate 4KB pages
+  {
+    for (size_t i = 0; i < 1024; ++i) {
+      Pointer p = alloc->AlignedAllocate(KILOBYTES(4), KILOBYTES(4));
+      memset(alloc->Convert<void>(p), 0, KILOBYTES(4));
+      alloc->Free(p);
+    }
+  }
+
+  // Reallocate a 4KB page to 16KB
+  {
+    Pointer p = alloc->Allocate(KILOBYTES(4));
+    alloc->Reallocate(p, KILOBYTES(16));
+    memset(alloc->Convert<void>(p), 0, KILOBYTES(16));
+    alloc->Free(p);
+  }
+}
+
+TEST_CASE("StackAllocator") {
+  auto alloc = Pretest<hipc::PosixShmMmap, hipc::StackAllocator>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  PageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  Posttest();
+}
+
+TEST_CASE("MultiPageAllocator") {
+  auto alloc = Pretest<hipc::PosixShmMmap, hipc::MultiPageAllocator>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  PageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  MultiPageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+
+  Posttest();
+}
+
+TEST_CASE("MallocAllocator") {
+  auto alloc = Pretest<hipc::NullBackend, hipc::MultiPageAllocator>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  PageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  MultiPageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+
+  Posttest();
+}

--- a/hermes_shm/test/unit/allocators/allocator_thread.cc
+++ b/hermes_shm/test/unit/allocators/allocator_thread.cc
@@ -1,0 +1,42 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "test_init.h"
+
+void MultiThreadedPageAllocationTest(Allocator *alloc) {
+  int nthreads = 8;
+  HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+
+  omp_set_dynamic(0);
+#pragma omp parallel shared(alloc) num_threads(nthreads)
+  {
+#pragma omp barrier
+    PageAllocationTest(alloc);
+#pragma omp barrier
+  }
+}
+
+TEST_CASE("StackAllocatorMultithreaded") {
+  auto alloc = Pretest<hipc::PosixShmMmap, hipc::StackAllocator>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  MultiThreadedPageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  Posttest();
+}
+
+TEST_CASE("MultiPageAllocatorMultithreaded") {
+  auto alloc = Pretest<hipc::PosixShmMmap, hipc::MultiPageAllocator>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  MultiThreadedPageAllocationTest(alloc);
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  Posttest();
+}

--- a/hermes_shm/test/unit/allocators/test_init.cc
+++ b/hermes_shm/test/unit/allocators/test_init.cc
@@ -1,0 +1,23 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "test_init.h"
+
+void Posttest() {
+  std::string shm_url = "test_allocators";
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->DestroyBackend(shm_url);
+}
+
+void MainPretest() {}
+
+void MainPosttest() {}

--- a/hermes_shm/test/unit/allocators/test_init.h
+++ b/hermes_shm/test/unit/allocators/test_init.h
@@ -1,0 +1,52 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_ALLOCATORS_TEST_INIT_H_
+#define HERMES_SHM_TEST_UNIT_ALLOCATORS_TEST_INIT_H_
+
+#include "basic_test.h"
+#include "omp.h"
+#include "hermes_shm/memory/memory_manager.h"
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::MemoryManager;
+using hermes_shm::ipc::Pointer;
+
+#define HEADER_CHECKSUM 8482942
+
+struct SimpleAllocatorHeader {
+  int checksum_;
+};
+
+template<typename BackendT, typename AllocT>
+Allocator* Pretest() {
+  std::string shm_url = "test_allocators";
+  allocator_id_t alloc_id(0, 1);
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->CreateBackend<BackendT>(
+    MemoryManager::kDefaultBackendSize, shm_url);
+  mem_mngr->CreateAllocator<AllocT>(
+    shm_url, alloc_id, sizeof(SimpleAllocatorHeader));
+  auto alloc = mem_mngr->GetAllocator(alloc_id);
+  auto hdr = alloc->GetCustomHeader<SimpleAllocatorHeader>();
+  hdr->checksum_ = HEADER_CHECKSUM;
+  return alloc;
+}
+
+void Posttest();
+void PageAllocationTest(Allocator *alloc);
+
+#endif  // HERMES_SHM_TEST_UNIT_ALLOCATORS_TEST_INIT_H_

--- a/hermes_shm/test/unit/basic_test.h
+++ b/hermes_shm/test/unit/basic_test.h
@@ -1,0 +1,68 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_BASIC_TEST_H_
+#define HERMES_SHM_TEST_UNIT_BASIC_TEST_H_
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_all.hpp>
+
+namespace cl = Catch::Clara;
+cl::Parser define_options();
+
+#include <iostream>
+#include <cstdlib>
+
+static bool VerifyBuffer(char *ptr, size_t size, char nonce) {
+  for (size_t i = 0; i < size; ++i) {
+    if (ptr[i] != nonce) {
+      std::cout << (int)ptr[i] << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+/** var = TYPE(val) */
+#define SET_VAR_TO_INT_OR_STRING(TYPE, VAR, VAL)\
+  if constexpr(std::is_same_v<TYPE, hipc::string>) {\
+    VAR = hipc::string(std::to_string(VAL));\
+  } else if constexpr(std::is_same_v<TYPE, std::string>) {\
+    VAR = std::string(std::to_string(VAL));\
+  } else {\
+    VAR = VAL;\
+  }
+
+/** TYPE VAR = TYPE(VAL) */
+#define CREATE_SET_VAR_TO_INT_OR_STRING(TYPE, VAR, VAL)\
+  TYPE VAR;\
+  SET_VAR_TO_INT_OR_STRING(TYPE, VAR, VAL);
+
+/** RET = int(TYPE(VAR)); */
+#define GET_INT_FROM_VAR(TYPE, RET, VAR)\
+  if constexpr(std::is_same_v<TYPE, hipc::string>) {\
+    RET = atoi((VAR).str().c_str());\
+  } else if constexpr(std::is_same_v<TYPE, std::string>) {\
+    RET = atoi((VAR).c_str());\
+  } else {\
+    RET = VAR;\
+  }
+
+/** int RET = int(TYPE(VAR)); */
+#define CREATE_GET_INT_FROM_VAR(TYPE, RET, VAR)\
+  int RET;\
+  GET_INT_FROM_VAR(TYPE, RET, VAR)
+
+void MainPretest();
+void MainPosttest();
+
+#endif  // HERMES_SHM_TEST_UNIT_BASIC_TEST_H_

--- a/hermes_shm/test/unit/data_structures/CMakeLists.txt
+++ b/hermes_shm/test/unit/data_structures/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include_directories(${CMAKE_SOURCE_DIR}/test/unit)
+add_subdirectory(backend)
+add_subdirectory(containers)
+add_subdirectory(containers_mpi)
+add_subdirectory(lock)

--- a/hermes_shm/test/unit/data_structures/backend/CMakeLists.txt
+++ b/hermes_shm/test/unit/data_structures/backend/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_memory_exec
+        ${TEST_MAIN}/main_mpi.cc
+        test_init.cc
+        backend.cc
+        memory_slots.cc
+        memory_manager.cc)
+add_dependencies(test_memory_exec hermes_shm_data_structures)
+target_link_libraries(test_memory_exec
+        hermes_shm_data_structures Catch2::Catch2 MPI::MPI_CXX)
+
+# TESTS
+add_test(NAME test_memory_slots COMMAND
+        mpirun -n 2 ${CMAKE_CURRENT_BINARY_DIR}/test_memory_exec "MemorySlot")
+add_test(NAME test_reserve COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_memory_exec "BackendReserve")
+add_test(NAME test_memory_manager COMMAND
+        mpirun -n 2 ${CMAKE_CURRENT_BINARY_DIR}/test_memory_exec "MemoryManager")

--- a/hermes_shm/test/unit/data_structures/backend/backend.cc
+++ b/hermes_shm/test/unit/data_structures/backend/backend.cc
@@ -1,0 +1,30 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+#include "hermes_shm/memory/backend/posix_shm_mmap.h"
+
+using hermes_shm::ipc::PosixShmMmap;
+
+TEST_CASE("BackendReserve") {
+  PosixShmMmap b1;
+
+  // Reserve + Map 8GB of memory
+  b1.shm_init(GIGABYTES(8), "shmem_test");
+
+  // Set 2GB of SHMEM
+  memset(b1.data_, 0, GIGABYTES(2));
+
+  // Destroy SHMEM
+  b1.shm_destroy();
+}

--- a/hermes_shm/test/unit/data_structures/backend/memory_manager.cc
+++ b/hermes_shm/test/unit/data_structures/backend/memory_manager.cc
@@ -1,0 +1,78 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+#include <mpi.h>
+#include "hermes_shm/memory/memory_manager.h"
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::MemoryManager;
+
+struct SimpleHeader {
+  hermes_shm::ipc::Pointer p_;
+};
+
+TEST_CASE("MemoryManager") {
+  int rank;
+  char nonce = 8;
+  size_t page_size = KILOBYTES(4);
+  std::string shm_url = "test_mem_backend";
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  allocator_id_t alloc_id(0, 1);
+
+  HERMES_SHM_ERROR_HANDLE_START()
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+
+  if (rank == 0) {
+    std::cout << "Creating SHMEM (rank 0): " << shm_url << std::endl;
+    mem_mngr->CreateBackend<hipc::PosixShmMmap>(
+      MemoryManager::kDefaultBackendSize, shm_url);
+    mem_mngr->CreateAllocator<hipc::StackAllocator>(
+      shm_url, alloc_id, 0);
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank != 0) {
+    std::cout << "Attaching SHMEM (rank 1): " << shm_url << std::endl;
+    mem_mngr->AttachBackend(MemoryBackendType::kPosixShmMmap, shm_url);
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank == 0) {
+    std::cout << "Allocating pages (rank 0)" << std::endl;
+    hipc::Allocator *alloc = mem_mngr->GetAllocator(alloc_id);
+    char *page = alloc->AllocatePtr<char>(page_size);
+    memset(page, nonce, page_size);
+    auto header = alloc->GetCustomHeader<SimpleHeader>();
+    hipc::Pointer p1 = mem_mngr->Convert<void>(alloc_id, page);
+    hipc::Pointer p2 = mem_mngr->Convert<char>(page);
+    header->p_ = p1;
+    REQUIRE(p1 == p2);
+    REQUIRE(VerifyBuffer(page, page_size, nonce));
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank != 0) {
+    std::cout << "Finding and checking pages (rank 1)" << std::endl;
+    hipc::Allocator *alloc = mem_mngr->GetAllocator(alloc_id);
+    SimpleHeader *header = alloc->GetCustomHeader<SimpleHeader>();
+    char *page = alloc->Convert<char>(header->p_);
+    REQUIRE(VerifyBuffer(page, page_size, nonce));
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank == 0) {
+    mem_mngr->DestroyBackend(shm_url);
+  }
+
+  HERMES_SHM_ERROR_HANDLE_END()
+}

--- a/hermes_shm/test/unit/data_structures/backend/memory_slots.cc
+++ b/hermes_shm/test/unit/data_structures/backend/memory_slots.cc
@@ -1,0 +1,53 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+#include <mpi.h>
+#include <iostream>
+#include "hermes_shm/memory/backend/posix_shm_mmap.h"
+
+using hermes_shm::ipc::PosixShmMmap;
+
+TEST_CASE("MemorySlot") {
+  int rank;
+  char nonce = 8;
+  std::string shm_url = "test_mem_backend";
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  HERMES_SHM_ERROR_HANDLE_START()
+
+  PosixShmMmap backend;
+  if (rank == 0) {
+    std::cout << "HERE?" << std::endl;
+    SECTION("Creating SHMEM (rank 0)") {
+      backend.shm_init(MEGABYTES(1), shm_url);
+      memset(backend.data_, nonce, backend.data_size_);
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank != 0) {
+    SECTION("Attaching SHMEM (rank 1)") {
+      backend.shm_deserialize(shm_url);
+      char *ptr = backend.data_;
+      REQUIRE(VerifyBuffer(ptr, backend.data_size_, nonce));
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank == 0) {
+    SECTION("Destroying shmem (rank 1)") {
+      backend.shm_destroy();
+    }
+  }
+
+  HERMES_SHM_ERROR_HANDLE_END()
+}

--- a/hermes_shm/test/unit/data_structures/backend/test_init.cc
+++ b/hermes_shm/test/unit/data_structures/backend/test_init.cc
@@ -1,0 +1,17 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+void MainPretest() {}
+
+void MainPosttest() {}

--- a/hermes_shm/test/unit/data_structures/containers/CMakeLists.txt
+++ b/hermes_shm/test/unit/data_structures/containers/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_data_structure_exec
+        ${TEST_MAIN}/main.cc
+        test_init.cc
+        string.cc
+        pair.cc
+        list.cc
+        vector.cc
+        manual_ptr.cc
+        unordered_map.cc
+)
+
+add_dependencies(test_data_structure_exec hermes_shm_data_structures)
+target_link_libraries(test_data_structure_exec
+        hermes_shm_data_structures Catch2::Catch2 MPI::MPI_CXX OpenMP::OpenMP_CXX)
+
+# STRING TESTS
+add_test(NAME test_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "String")
+
+# VECTOR TESTS
+add_test(NAME test_vector_of_int COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "VectorOfInt")
+add_test(NAME test_vector_of_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "VectorOfString")
+add_test(NAME test_vector_of_list_of_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "VectorOfListOfString")
+
+# LIST TESTS
+add_test(NAME test_list_of_int COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "ListOfInt")
+add_test(NAME test_list_of_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "ListOfString")
+
+# MANUAL PTR TESTS
+add_test(NAME test_manual_ptr_of_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "ManualPtrOfString")
+
+# UNIQUE PTR TESTS
+add_test(NAME test_unique_ptr_of_string COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "UniquePtrOfString")
+
+# UNORDERED_MAP TESTS
+add_test(NAME test_unordered_map_of_int_int COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "UnorderedMapOfIntInt")
+add_test(NAME test_unordered_map_of_int_str COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "UnorderedMapOfIntString")
+add_test(NAME test_unordered_map_of_str_int COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "UnorderedMapOfStringInt")
+add_test(NAME test_unordered_map_of_str_str COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_exec "UnorderedMapOfStringString")

--- a/hermes_shm/test/unit/data_structures/containers/list.cc
+++ b/hermes_shm/test/unit/data_structures/containers/list.cc
@@ -1,0 +1,60 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "list.h"
+#include "hermes_shm/data_structures/thread_unsafe/list.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+using hermes_shm::ipc::list;
+
+template<typename T>
+void ListTest() {
+  Allocator *alloc = alloc_g;
+  list<T> lp(alloc);
+  ListTestSuite<T, list<T>> test(lp, alloc);
+
+  test.EmplaceTest(30);
+  test.ForwardIteratorTest();
+  test.ConstForwardIteratorTest();
+  test.CopyConstructorTest();
+  test.CopyAssignmentTest();
+  test.MoveConstructorTest();
+  test.MoveAssignmentTest();
+  test.EmplaceFrontTest();
+  test.ModifyEntryCopyIntoTest();
+  test.ModifyEntryMoveIntoTest();
+  test.EraseTest();
+}
+
+TEST_CASE("ListOfInt") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  ListTest<int>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("ListOfString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  ListTest<hipc::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("ListOfStdString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  ListTest<std::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/list.h
+++ b/hermes_shm/test/unit/data_structures/containers/list.h
@@ -1,0 +1,192 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_LIST_H_
+#define HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_LIST_H_
+
+#include "basic_test.h"
+#include "test_init.h"
+#include <hermes_shm/data_structures/string.h>
+
+template<typename T, typename Container>
+class ListTestSuite {
+ public:
+  Container &obj_;
+  Allocator *alloc_;
+
+  /// Constructor
+  ListTestSuite(Container &obj, Allocator *alloc)
+  : obj_(obj), alloc_(alloc) {}
+
+  /// Emplace elements
+  void EmplaceTest(int count = 30) {
+    for (int i = 0; i < count; ++i) {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, var, i);
+      obj_.emplace_back(var);
+    }
+    REQUIRE(obj_.size() == count);
+  }
+
+  /// Forward iterator
+  void ForwardIteratorTest(int count = 30) {
+    int fcur = 0;
+    for (auto num : obj_) {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, fcur_conv, fcur);
+      REQUIRE(*num == fcur_conv);
+      ++fcur;
+    }
+  }
+
+  /// Constant Forward iterator
+  void ConstForwardIteratorTest(int count = 30) {
+    const Container &obj = obj_;
+    int fcur = 0;
+    for (auto iter = obj.cbegin(); iter != obj.cend(); ++iter) {
+      hipc::ShmRef<T> num = *iter;
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, fcur_conv, fcur);
+      REQUIRE(*num == fcur_conv);
+      ++fcur;
+    }
+  }
+
+  /// Copy constructor
+  void CopyConstructorTest() {
+    int count = obj_.size();
+    Container cpy(obj_);
+    VerifyCopy(obj_, cpy, count);
+  }
+
+  /// Copy assignment
+  void CopyAssignmentTest() {
+    int count = obj_.size();
+    Container cpy;
+    cpy = obj_;
+    VerifyCopy(obj_, cpy, count);
+  }
+
+  /// Move constructor
+  void MoveConstructorTest() {
+    int count = obj_.size();
+    Container cpy(std::move(obj_));
+    VerifyMove(obj_, cpy, count);
+    obj_ = std::move(cpy);
+    VerifyMove(cpy, obj_, count);
+  }
+
+  /// Move assignment
+  void MoveAssignmentTest() {
+    int count = obj_.size();
+    Container cpy;
+    cpy = std::move(obj_);
+    VerifyMove(obj_, cpy, count);
+    obj_ = std::move(cpy);
+    VerifyMove(cpy, obj_, count);
+  }
+
+  /// Emplace and erase front
+  void EmplaceFrontTest() {
+    CREATE_SET_VAR_TO_INT_OR_STRING(T, i0, 100);
+    int old_size = obj_.size();
+    obj_.emplace_front(i0);
+    REQUIRE(*obj_.front() == i0);
+    REQUIRE(obj_.size() == old_size + 1);
+    obj_.erase(obj_.begin(), obj_.begin() + 1);
+  }
+
+  /// Copy an object into the container
+  void ModifyEntryCopyIntoTest() {
+    // Modify the fourth list entry
+    {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, i4, 25);
+      auto iter = obj_.begin() + 4;
+      (**iter) = i4;
+    }
+
+    // Verify the modification took place
+    {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, i4, 25);
+      auto iter = obj_.begin() + 4;
+      REQUIRE((**iter) == i4);
+    }
+  }
+
+  /// Move an object into the container
+  void ModifyEntryMoveIntoTest() {
+    // Modify the fourth list entry
+    {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, i4, 25);
+      auto iter = obj_.begin() + 4;
+      (**iter) = std::move(i4);
+    }
+
+    // Verify the modification took place
+    {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, i4, 25);
+      auto iter = obj_.begin() + 4;
+      REQUIRE((**iter) == i4);
+    }
+  }
+
+  /// Verify erase
+  void EraseTest() {
+    obj_.clear();
+    REQUIRE(obj_.size() == 0);
+  }
+
+ private:
+  /// Verify copy construct/assign worked
+  void VerifyCopy(Container &obj,
+                  Container &cpy,
+                  int count) {
+    REQUIRE(obj_.size() == count);
+    REQUIRE(cpy.size() == count);
+
+    // Verify obj
+    {
+      int fcur = 0;
+      for (auto num : obj_) {
+        CREATE_SET_VAR_TO_INT_OR_STRING(T, fcur_conv, fcur);
+        REQUIRE(*num == fcur_conv);
+        ++fcur;
+      }
+    }
+
+    // Verify copy
+    {
+      int fcur = 0;
+      for (auto num : cpy) {
+        CREATE_SET_VAR_TO_INT_OR_STRING(T, fcur_conv, fcur);
+        REQUIRE(*num == fcur_conv);
+        ++fcur;
+      }
+    }
+  }
+
+  /// Verify move worked
+  void VerifyMove(Container &orig_obj,
+                  Container &new_obj,
+                  int count) {
+    // Verify move into cpy worked
+    {
+      int fcur = 0;
+      REQUIRE(orig_obj.size() == 0);
+      REQUIRE(new_obj.size() == count);
+      for (auto num : new_obj) {
+        CREATE_SET_VAR_TO_INT_OR_STRING(T, fcur_conv, fcur);
+        REQUIRE(*num == fcur_conv);
+        ++fcur;
+      }
+    }
+  }
+};
+
+#endif //HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_LIST_H_

--- a/hermes_shm/test/unit/data_structures/containers/manual_ptr.cc
+++ b/hermes_shm/test/unit/data_structures/containers/manual_ptr.cc
@@ -1,0 +1,47 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "hermes_shm/data_structures/smart_ptr/manual_ptr.h"
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+#include "smart_ptr.h"
+
+using hermes_shm::ipc::string;
+using hermes_shm::ipc::mptr;
+using hermes_shm::ipc::mptr;
+using hermes_shm::ipc::make_mptr;
+using hermes_shm::ipc::TypedPointer;
+
+template<typename T>
+void ManualPtrTest() {
+  Allocator *alloc = alloc_g;
+  hipc::SmartPtrTestSuite<T, mptr<T>> test;
+  CREATE_SET_VAR_TO_INT_OR_STRING(T, num, 25);
+  test.ptr_ = make_mptr<T>(num);
+  test.DereferenceTest(num);
+  test.MoveConstructorTest(num);
+  test.MoveAssignmentTest(num);
+  test.CopyConstructorTest(num);
+  test.CopyAssignmentTest(num);
+  test.SerializeationConstructorTest(num);
+  test.SerializeationOperatorTest(num);
+  test.ptr_.shm_destroy();
+}
+
+TEST_CASE("ManualPtrOfString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  ManualPtrTest<hipc::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/pair.cc
+++ b/hermes_shm/test/unit/data_structures/containers/pair.cc
@@ -1,0 +1,64 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/pair.h"
+#include "hermes_shm/data_structures/string.h"
+
+template<typename FirstT, typename SecondT>
+void PairTest() {
+  Allocator *alloc = alloc_g;
+
+  // Construct test
+  {
+    CREATE_SET_VAR_TO_INT_OR_STRING(FirstT, first, 124);
+    CREATE_SET_VAR_TO_INT_OR_STRING(SecondT, second, 130);
+    hipc::pair<FirstT, SecondT> data(alloc, first, second);
+    REQUIRE(*data.first_ == first);
+    REQUIRE(*data.second_ == second);
+  }
+
+  // Copy test
+  {
+    CREATE_SET_VAR_TO_INT_OR_STRING(FirstT, first, 124);
+    CREATE_SET_VAR_TO_INT_OR_STRING(SecondT, second, 130);
+    hipc::pair<FirstT, SecondT> data(alloc, first, second);
+    hipc::pair<FirstT, SecondT> cpy(data);
+    REQUIRE(*cpy.first_ == first);
+    REQUIRE(*cpy.second_ == second);
+  }
+
+  // Move test
+  {
+    CREATE_SET_VAR_TO_INT_OR_STRING(FirstT, first, 124);
+    CREATE_SET_VAR_TO_INT_OR_STRING(SecondT, second, 130);
+    hipc::pair<FirstT, SecondT> data(alloc, first, second);
+    hipc::pair<FirstT, SecondT> cpy(std::move(data));
+    REQUIRE(*cpy.first_ == first);
+    REQUIRE(*cpy.second_ == second);
+  }
+}
+
+TEST_CASE("PairOfIntInt") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  PairTest<int, int>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("PairOfIntString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  PairTest<int, hipc::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/smart_ptr.h
+++ b/hermes_shm/test/unit/data_structures/containers/smart_ptr.h
@@ -1,0 +1,84 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_ptr__STRUCTURES_CONTAINERS_SMART_PTR_H_
+#define HERMES_SHM_TEST_UNIT_ptr__STRUCTURES_CONTAINERS_SMART_PTR_H_
+
+#include "basic_test.h"
+#include "test_init.h"
+
+namespace hermes_shm::ipc {
+
+template<typename T, typename PointerT>
+class SmartPtrTestSuite {
+ public:
+  PointerT ptr_;
+
+ public:
+  // Test dereference
+  void DereferenceTest(T &num) {
+    REQUIRE(ptr_.get_ref() == num);
+    REQUIRE(ptr_.get_ref_const() == num);
+    REQUIRE(*ptr_ == num);
+  }
+
+  // Test move constructor
+  void MoveConstructorTest(T &num) {
+    PointerT ptr2(std::move(ptr_));
+    REQUIRE(ptr_.IsNull());
+    REQUIRE(std::hash<PointerT>{}(ptr2) == std::hash<T>{}(num));
+    ptr_ = std::move(ptr2);
+  }
+
+  // Test move assignment operator
+  void MoveAssignmentTest(T &num) {
+    PointerT ptr2 = std::move(ptr_);
+    REQUIRE(ptr_.IsNull());
+    REQUIRE(std::hash<PointerT>{}(ptr2) == std::hash<T>{}(num));
+    ptr_ = std::move(ptr2);
+  }
+
+  // Test copy constructor
+  void CopyConstructorTest(T &num) {
+    PointerT ptr2(ptr_);
+    REQUIRE(*ptr_ == num);
+    REQUIRE(*ptr2 == num);
+  }
+
+  // Test copy assignment
+  void CopyAssignmentTest(T &num) {
+    PointerT ptr2 = ptr_;
+    REQUIRE(*ptr_ == num);
+    REQUIRE(*ptr2 == num);
+  }
+
+  // Test serialization + deserialization (constructor)
+  void SerializeationConstructorTest(T &num) {
+    TypedPointer<T> ar;
+    ptr_ >> ar;
+    PointerT from_ar(ar);
+    REQUIRE(*from_ar == num);
+  }
+
+  // Test serialization + deserialization (operator)
+  void SerializeationOperatorTest(T &num) {
+    TypedPointer<T> ar;
+    ptr_ >> ar;
+    PointerT from_ar;
+    from_ar << ar;
+    REQUIRE(*from_ar == num);
+  }
+};
+
+}  // namespace hermes_shm::ipc
+
+#endif //HERMES_SHM_TEST_UNIT_ptr__STRUCTURES_CONTAINERS_SMART_PTR_H_

--- a/hermes_shm/test/unit/data_structures/containers/string.cc
+++ b/hermes_shm/test/unit/data_structures/containers/string.cc
@@ -1,0 +1,51 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+using hermes_shm::ipc::string;
+
+void TestString() {
+  Allocator *alloc = alloc_g;
+
+  auto text1 = string("hello1");
+  REQUIRE(text1 == "hello1");
+  REQUIRE(text1 != "h");
+  REQUIRE(text1 != "asdfklaf");
+
+  auto text2 = string("hello2");
+  REQUIRE(text2 == "hello2");
+
+  string text3 = text1 + text2;
+  REQUIRE(text3 == "hello1hello2");
+
+  string text4(6);
+  memcpy(text4.data_mutable(), "hello4", strlen("hello4"));
+
+  string text5 = text4;
+  REQUIRE(text5 == "hello4");
+  REQUIRE(text5.header_ != text4.header_);
+
+  string text6 = std::move(text5);
+  REQUIRE(text6 == "hello4");
+}
+
+TEST_CASE("String") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(IS_SHM_ARCHIVEABLE(string));
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  TestString();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/test_init.cc
+++ b/hermes_shm/test/unit/data_structures/containers/test_init.cc
@@ -1,0 +1,34 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include <mpi.h>
+
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+Allocator *alloc_g = nullptr;
+
+void Posttest() {
+  std::string shm_url = "test_allocators";
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->DestroyBackend(shm_url);
+  alloc_g = nullptr;
+}
+
+void MainPretest() {
+  Pretest<hipc::StackAllocator>();
+}
+
+void MainPosttest() {
+  Posttest();
+}

--- a/hermes_shm/test/unit/data_structures/containers/test_init.h
+++ b/hermes_shm/test/unit/data_structures/containers/test_init.h
@@ -1,0 +1,49 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_
+#define HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_
+
+#include "hermes_shm/data_structures/data_structure.h"
+
+using hermes_shm::ipc::PosixShmMmap;
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::Pointer;
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::MemoryManager;
+using hermes_shm::ipc::Pointer;
+
+extern Allocator *alloc_g;
+
+template<typename AllocT>
+void Pretest() {
+  std::string shm_url = "test_allocators";
+  allocator_id_t alloc_id(0, 1);
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->CreateBackend<PosixShmMmap>(
+    MemoryManager::kDefaultBackendSize, shm_url);
+  mem_mngr->CreateAllocator<AllocT>(shm_url, alloc_id, 0);
+  alloc_g = mem_mngr->GetAllocator(alloc_id);
+}
+
+void Posttest();
+
+#endif  // HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_

--- a/hermes_shm/test/unit/data_structures/containers/unordered_map.cc
+++ b/hermes_shm/test/unit/data_structures/containers/unordered_map.cc
@@ -1,0 +1,226 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/thread_unsafe/unordered_map.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::MemoryManager;
+using hermes_shm::ipc::Pointer;
+using hermes_shm::ipc::unordered_map;
+using hermes_shm::ipc::string;
+
+#define GET_INT_FROM_KEY(VAR) CREATE_GET_INT_FROM_VAR(Key, key_ret, VAR)
+#define GET_INT_FROM_VAL(VAR) CREATE_GET_INT_FROM_VAR(Val, val_ret, VAR)
+
+#define CREATE_KV_PAIR(KEY_NAME, KEY, VAL_NAME, VAL)\
+  CREATE_SET_VAR_TO_INT_OR_STRING(Key, KEY_NAME, KEY); \
+  CREATE_SET_VAR_TO_INT_OR_STRING(Val, VAL_NAME, VAL);
+
+template<typename Key, typename Val>
+void UnorderedMapOpTest() {
+  Allocator *alloc = alloc_g;
+  unordered_map<Key, Val> map(alloc);
+
+  // Insert 20 entries into the map (no growth trigger)
+  {
+    for (int i = 0; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      map.emplace(key, val);
+    }
+  }
+
+  // Check if the 20 entries are indexable
+  {
+    for (int i = 0; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      REQUIRE(*(map[key]) == val);
+    }
+  }
+
+  // Check if 20 entries are findable
+  {
+    for (int i = 0; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      auto iter = map.find(key);
+      REQUIRE((*iter)->GetVal() == val);
+    }
+  }
+
+  // Iterate over the map
+  {
+    // auto prep = map.iter_prep();
+    // prep.Lock();
+    int i = 0;
+    for (auto entry : map) {
+      GET_INT_FROM_KEY(entry->GetKey());
+      GET_INT_FROM_VAL(entry->GetVal());
+      REQUIRE((0 <= key_ret && key_ret < 20));
+      REQUIRE((0 <= val_ret && val_ret < 20));
+      ++i;
+    }
+    REQUIRE(i == 20);
+  }
+
+  // Re-emplace elements
+  {
+    for (int i = 0; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, i + 100);
+      map.emplace(key, val);
+      REQUIRE(*(map[key]) == val);
+    }
+  }
+
+  // Modify the fourth map entry (move assignment)
+  {
+    CREATE_KV_PAIR(key, 4, val, 25);
+    auto iter = map.find(key);
+    (*iter)->GetVal() = std::move(val);
+    REQUIRE((*iter)->GetVal() == val);
+  }
+
+  // Verify the modification took place
+  {
+    CREATE_KV_PAIR(key, 4, val, 25);
+    REQUIRE(*(map[key]) == val);
+  }
+
+  // Modify the fourth map entry (copy assignment)
+  {
+    CREATE_KV_PAIR(key, 4, val, 50);
+    auto iter = map.find(key);
+    (*iter)->GetVal() = val;
+    REQUIRE((*iter)->GetVal() == val);
+  }
+
+  // Verify the modification took place
+  {
+    CREATE_KV_PAIR(key, 4, val, 50);
+    REQUIRE(*(map[key]) == val);
+  }
+
+  // Modify the fourth map entry (copy assignment)
+  {
+    CREATE_KV_PAIR(key, 4, val, 100);
+    auto x = map[key];
+    (*x) = val;
+  }
+
+  // Verify the modification took place
+  {
+    CREATE_KV_PAIR(key, 4, val, 100);
+    REQUIRE(*map[key] == val);
+  }
+
+  // Remove 15 entries from the map
+  {
+    for (int i = 0; i < 15; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      map.erase(key);
+    }
+    REQUIRE(map.size() == 5);
+    for (int i = 0; i < 15; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      REQUIRE(map.find(key) == map.end());
+    }
+  }
+
+  // Attempt to replace an existing key
+  {
+    for (int i = 15; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, 100);
+      REQUIRE(map.try_emplace(key, val) == false);
+    }
+    for (int i = 15; i < 20; ++i) {
+      CREATE_KV_PAIR(key, i, val, 100);
+      REQUIRE(*map[key] != val);
+    }
+  }
+
+  // Erase the entire map
+  {
+    map.clear();
+    REQUIRE(map.size() == 0);
+  }
+
+  // Add 100 entries to the map (should force a growth)
+  {
+    for (int i = 0; i < 100; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      map.emplace(key, val);
+      REQUIRE(map.find(key) != map.end());
+    }
+    for (int i = 0; i < 100; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      REQUIRE(map.find(key) != map.end());
+    }
+  }
+
+  // Copy the unordered_map
+  {
+    unordered_map<Key, Val> cpy(map);
+    for (int i = 0; i < 100; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      REQUIRE(map.find(key) != map.end());
+      REQUIRE(cpy.find(key) != cpy.end());
+    }
+  }
+
+  // Move the unordered_map
+  {
+    unordered_map<Key, Val> cpy = std::move(map);
+    for (int i = 0; i < 100; ++i) {
+      CREATE_KV_PAIR(key, i, val, i);
+      REQUIRE(cpy.find(key) != cpy.end());
+    }
+    map = std::move(cpy);
+  }
+
+  // Emplace a move entry into the map
+
+}
+
+TEST_CASE("UnorderedMapOfIntInt") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  UnorderedMapOpTest<int, int>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("UnorderedMapOfIntString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  UnorderedMapOpTest<int, string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+
+TEST_CASE("UnorderedMapOfStringInt") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  UnorderedMapOpTest<string, int>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("UnorderedMapOfStringString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  UnorderedMapOpTest<string, string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/unordered_map_thread.cc
+++ b/hermes_shm/test/unit/data_structures/containers/unordered_map_thread.cc
@@ -1,0 +1,85 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "omp.h"
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/thread_safe/unordered_map.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+#include "hermes_shm/util/errors.h"
+#include <sstream>
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::MemoryManager;
+using hermes_shm::ipc::Pointer;
+using hermes_shm::ipc::unordered_map;
+using hermes_shm::ipc::string;
+
+void UnorderedMapParallelInsert() {
+  Allocator *alloc = alloc_g;
+  unordered_map<string, string> map(alloc);
+
+  int entries_per_thread = 50;
+  int nthreads = 4;
+  int total_entries = nthreads * entries_per_thread;
+  HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+
+  omp_set_dynamic(0);
+#pragma omp parallel shared(alloc, map) num_threads(nthreads)
+  {
+    int rank = omp_get_thread_num();
+    int off = rank*entries_per_thread;
+#pragma omp barrier
+    // Insert entries into the map (no growth trigger)
+    {
+      for (int i = 0; i < entries_per_thread; ++i) {
+        int key = off + i;
+        int val = 2 * key;
+        auto t1 = string(std::to_string(key));
+        auto t2 = string(std::to_string(val));
+
+        {
+          std::stringstream ss;
+          ss << "Emplace start: " << t1.str() << std::endl;
+          std::cout << ss.str();
+        }
+        map.emplace(t1, t2);
+        {
+          std::stringstream ss;
+          ss << "Emplace end: " << t1.str() << std::endl;
+          std::cout << ss.str();
+        }
+      }
+    }
+#pragma omp barrier
+  }
+  REQUIRE(map.size() == total_entries);
+
+  // Verify the map has all entries
+  for (int i = 0; i < total_entries; ++i) {
+    auto key = string(std::to_string(i));
+    auto val = string(std::to_string(2*i));
+    REQUIRE(*(map[key]) == val);
+  }
+}
+
+TEST_CASE("UnorderedMapParallelInsert") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  UnorderedMapParallelInsert();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/vector.cc
+++ b/hermes_shm/test/unit/data_structures/containers/vector.cc
@@ -1,0 +1,81 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/thread_unsafe/vector.h"
+#include "hermes_shm/data_structures/thread_unsafe/list.h"
+#include "hermes_shm/data_structures/string.h"
+#include "vector.h"
+
+using hermes_shm::ipc::vector;
+using hermes_shm::ipc::list;
+using hermes_shm::ipc::string;
+
+template<typename T>
+void VectorTest() {
+  Allocator *alloc = alloc_g;
+  vector<T> vec(alloc);
+  VectorTestSuite<T, vector<T>> test(vec, alloc);
+
+  test.EmplaceTest(15);
+  test.IndexTest();
+  test.ForwardIteratorTest();
+  test.ConstForwardIteratorTest();
+  test.CopyConstructorTest();
+  test.CopyAssignmentTest();
+  test.MoveConstructorTest();
+  test.MoveAssignmentTest();
+  test.EmplaceFrontTest();
+  test.ModifyEntryCopyIntoTest();
+  test.ModifyEntryMoveIntoTest();
+  test.EraseTest();
+}
+
+void VectorOfListOfStringTest() {
+  Allocator *alloc = alloc_g;
+  vector<list<string>> vec(alloc);
+
+  vec.resize(10);
+  for (auto bkt : vec) {
+    (*bkt).emplace_back("hello");
+  }
+  vec.clear();
+}
+
+TEST_CASE("VectorOfInt") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  VectorTest<int>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("VectorOfString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  VectorTest<hipc::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("VectorOfStdString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  VectorTest<std::string>();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}
+
+TEST_CASE("VectorOfListOfString") {
+  Allocator *alloc = alloc_g;
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+  VectorOfListOfStringTest();
+  REQUIRE(alloc->GetCurrentlyAllocatedSize() == 0);
+}

--- a/hermes_shm/test/unit/data_structures/containers/vector.h
+++ b/hermes_shm/test/unit/data_structures/containers/vector.h
@@ -1,0 +1,37 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_VECTOR_H_
+#define HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_VECTOR_H_
+
+#include "list.h"
+
+template<typename T, typename Container>
+class VectorTestSuite : public ListTestSuite<T, Container> {
+ public:
+  using ListTestSuite<T, Container>::obj_;
+
+ public:
+  /// Constructor
+  VectorTestSuite(Container &obj, Allocator *alloc)
+  : ListTestSuite<T, Container>(obj, alloc) {}
+
+  /// Test vector index operator
+  void IndexTest() {
+    for (int i = 0; i < obj_.size(); ++i) {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, var, i);
+      REQUIRE(*obj_[i] == var);
+    }
+  }
+};
+
+#endif //HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_CONTAINERS_VECTOR_H_

--- a/hermes_shm/test/unit/data_structures/containers_mpi/CMakeLists.txt
+++ b/hermes_shm/test/unit/data_structures/containers_mpi/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_data_structure_mpi_exec
+        ${TEST_MAIN}/main_mpi.cc
+        test_init.cc
+        list_vec_mpi.cc
+)
+
+add_dependencies(test_data_structure_mpi_exec hermes_shm_data_structures)
+target_link_libraries(test_data_structure_mpi_exec
+        hermes_shm_data_structures Catch2::Catch2 MPI::MPI_CXX OpenMP::OpenMP_CXX)
+
+# VECTOR TESTS
+add_test(NAME test_vector_of_int_mpi COMMAND
+        mpirun -n 4 ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_mpi_exec "VectorOfIntMpi")
+add_test(NAME test_vector_of_string_mpi COMMAND
+        mpirun -n 1  ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_mpi_exec "VectorOfStringMpi")
+
+# LIST TESTS
+add_test(NAME test_list_of_int_mpi COMMAND
+        mpirun -n 4 ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_mpi_exec "ListOfIntMpi")
+add_test(NAME test_list_of_string_mpi COMMAND
+        mpirun -n 2 ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_mpi_exec "ListOfStringMpi")
+
+message("mpirun -n 1 ${CMAKE_CURRENT_BINARY_DIR}/test_data_structure_mpi_exec ListOfStringMpi")

--- a/hermes_shm/test/unit/data_structures/containers_mpi/list_vec_mpi.cc
+++ b/hermes_shm/test/unit/data_structures/containers_mpi/list_vec_mpi.cc
@@ -1,0 +1,110 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+#include "hermes_shm/data_structures/string.h"
+#include "hermes_shm/data_structures/thread_unsafe/list.h"
+#include "hermes_shm/data_structures/thread_unsafe/vector.h"
+#include "hermes_shm/util/error.h"
+
+template<typename T, typename ContainerT>
+void ListVecTest(size_t count) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  Allocator *alloc = alloc_g;
+  Pointer *header = alloc->GetCustomHeader<Pointer>();
+  ContainerT obj;
+
+  try {
+    if (rank == 0) {
+      obj.shm_init(alloc);
+      obj >> (*header);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    obj.shm_deserialize(*header);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Write 100 objects from rank 0
+    {
+      if (rank == 0) {
+        for (int i = 0; i < count; ++i) {
+          CREATE_SET_VAR_TO_INT_OR_STRING(T, var, i);
+          obj.emplace_back(var);
+        }
+      }
+      MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Read 100 objects from every rank
+    {
+      REQUIRE(obj.size() == count);
+      int i = 0;
+      for (hipc::ShmRef<T> var : obj) {
+        CREATE_SET_VAR_TO_INT_OR_STRING(T, orig, i);
+        REQUIRE(*var == orig);
+        ++i;
+      }
+      MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Modify an object in rank 0
+    {
+      if (rank == 0) {
+        CREATE_SET_VAR_TO_INT_OR_STRING(T, update, count);
+        hipc::ShmRef<T> first = *obj.begin();
+        (*first) = update;
+      }
+      MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Check if modification received
+    {
+      CREATE_SET_VAR_TO_INT_OR_STRING(T, update, count);
+      hipc::ShmRef<T> first = *obj.begin();
+      REQUIRE((*first) == update);
+      MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+  } catch(HERMES_SHM_ERROR_TYPE &HERMES_SHM_ERROR_PTR) {
+    std::cout << "HERE0" << std::endl;
+    err->print();
+  } catch(hermes_shm::Error &err) {
+    std::cout << "HERE1" << std::endl;
+    err.print();
+  } catch(int err) {
+    std::cout << "HERE2" << std::endl;
+  } catch(std::runtime_error &err) {
+    std::cout << "HERE3" << std::endl;
+  } catch(std::logic_error &err) {
+    std::cout << "HERE4" << std::endl;
+  } catch(...) {
+    std::cout << "HERE5" << std::endl;
+  }
+}
+
+TEST_CASE("ListOfIntMpi") {
+  ListVecTest<int, hipc::list<int>>(100);
+}
+
+TEST_CASE("ListOfStringMpi") {
+  ListVecTest<hipc::string, hipc::list<hipc::string>>(100);
+}
+
+TEST_CASE("VectorOfIntMpi") {
+  ListVecTest<int, hipc::vector<int>>(100);
+}
+
+TEST_CASE("VectorOfStringMpi") {
+  ListVecTest<hipc::string, hipc::vector<hipc::string>>(100);
+}

--- a/hermes_shm/test/unit/data_structures/containers_mpi/test_init.cc
+++ b/hermes_shm/test/unit/data_structures/containers_mpi/test_init.cc
@@ -1,0 +1,52 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "test_init.h"
+
+#include "hermes_shm/memory/allocator/stack_allocator.h"
+
+Allocator *alloc_g = nullptr;
+
+template<typename AllocT>
+void PretestRank0() {
+  std::string shm_url = "test_allocators";
+  allocator_id_t alloc_id(0, 1);
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->CreateBackend<PosixShmMmap>(
+    MemoryManager::kDefaultBackendSize, shm_url);
+  mem_mngr->CreateAllocator<AllocT>(shm_url, alloc_id, sizeof(Pointer));
+  alloc_g = mem_mngr->GetAllocator(alloc_id);
+}
+
+void PretestRankN() {
+  std::string shm_url = "test_allocators";
+  allocator_id_t alloc_id(0, 1);
+  auto mem_mngr = HERMES_SHM_MEMORY_MANAGER;
+  mem_mngr->AttachBackend(MemoryBackendType::kPosixShmMmap, shm_url);
+  alloc_g = mem_mngr->GetAllocator(alloc_id);
+}
+
+void MainPretest() {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    PretestRank0<hipc::StackAllocator>();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (rank != 0) {
+    PretestRankN();
+  }
+}
+
+void MainPosttest() {
+}

--- a/hermes_shm/test/unit/data_structures/containers_mpi/test_init.h
+++ b/hermes_shm/test/unit/data_structures/containers_mpi/test_init.h
@@ -1,0 +1,39 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_
+#define HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_
+
+#include "hermes_shm/data_structures/data_structure.h"
+#include <mpi.h>
+
+using hermes_shm::ipc::PosixShmMmap;
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::Pointer;
+
+using hermes_shm::ipc::MemoryBackendType;
+using hermes_shm::ipc::MemoryBackend;
+using hermes_shm::ipc::allocator_id_t;
+using hermes_shm::ipc::AllocatorType;
+using hermes_shm::ipc::Allocator;
+using hermes_shm::ipc::MemoryManager;
+using hermes_shm::ipc::Pointer;
+
+extern Allocator *alloc_g;
+
+void Posttest();
+
+#endif  // HERMES_SHM_TEST_UNIT_DATA_STRUCTURES_TEST_INIT_H_

--- a/hermes_shm/test/unit/data_structures/lock/CMakeLists.txt
+++ b/hermes_shm/test/unit/data_structures/lock/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_lock_exec
+        ${TEST_MAIN}/main.cc
+        test_init.cc
+        lock.cc)
+add_dependencies(test_lock_exec hermes_shm_data_structures)
+target_link_libraries(test_lock_exec
+        hermes_shm_data_structures Catch2::Catch2 MPI::MPI_CXX OpenMP::OpenMP_CXX)
+
+add_test(NAME test_mutex COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_lock_exec "Mutex")
+
+add_test(NAME test_rw_lock COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/test_lock_exec "RwLock")
+

--- a/hermes_shm/test/unit/data_structures/lock/lock.cc
+++ b/hermes_shm/test/unit/data_structures/lock/lock.cc
@@ -1,0 +1,111 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include "omp.h"
+#include "hermes_shm/thread/lock.h"
+
+using hermes_shm::Mutex;
+using hermes_shm::RwLock;
+
+void MutexTest() {
+  int nthreads = 8;
+  int loop_count = 10000;
+  int count = 0;
+  Mutex lock;
+
+  HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+
+  omp_set_dynamic(0);
+#pragma omp parallel shared(lock) num_threads(nthreads)
+  {
+    // Support parallel write
+#pragma omp barrier
+    for (int i = 0; i < loop_count; ++i) {
+      lock.Lock();
+      count += 1;
+      lock.Unlock();
+    }
+#pragma omp barrier
+    REQUIRE(count == loop_count * nthreads);
+#pragma omp barrier
+  }
+}
+
+void barrier_for_reads(std::vector<int> &tid_start, int left) {
+  int count;
+  do {
+    count = 0;
+    for (int i = 0; i < left; ++i) {
+      count += tid_start[i];
+    }
+  } while (count < left);
+}
+
+void RwLockTest() {
+  int nthreads = 8;
+  int left = nthreads / 2;
+  std::vector<int> tid_start(left, 0);
+  int loop_count = 100000;
+  int count = 0;
+  RwLock lock;
+
+  HERMES_SHM_THREAD_MANAGER->GetThreadStatic();
+
+  omp_set_dynamic(0);
+#pragma omp parallel \
+  shared(lock, nthreads, left, loop_count, count, tid_start) \
+  num_threads(nthreads)
+  {
+    int tid = omp_get_thread_num();
+
+    // Support parallel write
+#pragma omp barrier
+    for (int i = 0; i < loop_count; ++i) {
+      lock.WriteLock();
+      count += 1;
+      lock.WriteUnlock();
+    }
+#pragma omp barrier
+    REQUIRE(count == loop_count * nthreads);
+#pragma omp barrier
+
+    // Support for parallel read and write
+#pragma omp barrier
+
+    int cur_count = count;
+    if (tid < left) {
+      lock.ReadLock();
+      tid_start[tid] = 1;
+      barrier_for_reads(tid_start, left);
+      for (int i = 0; i < loop_count; ++i) {
+        REQUIRE(count == cur_count);
+      }
+      lock.ReadUnlock();
+    } else {
+      barrier_for_reads(tid_start, left);
+      lock.WriteLock();
+      for (int i = 0; i < loop_count; ++i) {
+        count += 1;
+      }
+      lock.WriteUnlock();
+    }
+  }
+}
+
+TEST_CASE("Mutex") {
+  MutexTest();
+}
+
+TEST_CASE("RwLock") {
+  RwLockTest();
+}

--- a/hermes_shm/test/unit/data_structures/lock/test_init.cc
+++ b/hermes_shm/test/unit/data_structures/lock/test_init.cc
@@ -1,0 +1,17 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+void MainPretest() {}
+
+void MainPosttest() {}

--- a/hermes_shm/test/unit/main.cc
+++ b/hermes_shm/test/unit/main.cc
@@ -1,0 +1,28 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include <mpi.h>
+
+int main(int argc, char **argv) {
+  int rc;
+  Catch::Session session;
+  auto cli = session.cli();
+  session.cli(cli);
+  rc = session.applyCommandLine(argc, argv);
+  if (rc != 0) return rc;
+  MainPretest();
+  rc = session.run();
+  MainPosttest();
+  if (rc != 0) return rc;
+  return rc;
+}

--- a/hermes_shm/test/unit/main_mpi.cc
+++ b/hermes_shm/test/unit/main_mpi.cc
@@ -1,0 +1,30 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include <mpi.h>
+
+int main(int argc, char **argv) {
+  int rc;
+  MPI_Init(&argc, &argv);
+  Catch::Session session;
+  auto cli = session.cli();
+  session.cli(cli);
+  rc = session.applyCommandLine(argc, argv);
+  if (rc != 0) return rc;
+  MainPretest();
+  rc = session.run();
+  MainPosttest();
+  if (rc != 0) return rc;
+  MPI_Finalize();
+  return rc;
+}

--- a/hermes_shm/test/unit/types/CMakeLists.txt
+++ b/hermes_shm/test/unit/types/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(hermes_shm)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(test_types
+        ${TEST_MAIN}/main.cc
+        test_init.cc
+        test_argpack.cc)
+target_link_libraries(test_types
+        Catch2::Catch2 MPI::MPI_CXX OpenMP::OpenMP_CXX)

--- a/hermes_shm/test/unit/types/test_argpack.cc
+++ b/hermes_shm/test/unit/types/test_argpack.cc
@@ -1,0 +1,180 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+#include <hermes_shm/types/tuple_base.h>
+#include <utility>
+
+void test_argpack0_pass() {
+  std::cout << "HERE0" << std::endl;
+}
+
+void test_argpack0() {
+  hermes_shm::PassArgPack::Call(hermes_shm::ArgPack<>(), test_argpack0_pass);
+}
+
+template<typename T1, typename T2, typename T3>
+void test_argpack3_pass(T1 x, T2 y, T3 z) {
+  REQUIRE(x == 0);
+  REQUIRE(y == 1);
+  REQUIRE(z == 0);
+  std::cout << "HERE3" << std::endl;
+}
+
+void test_product1(int b, int c) {
+  REQUIRE(b == 1);
+  REQUIRE(c == 2);
+}
+
+void test_product2(double d, double e) {
+  REQUIRE(d == 3);
+  REQUIRE(e == 4);
+}
+
+template<typename Pack1, typename Pack2>
+void test_product(int a, Pack1 &&pack1, int a2, Pack2 &&pack2) {
+  REQUIRE(a == 0);
+  REQUIRE(a2 == 0);
+  hermes_shm::PassArgPack::Call(
+    std::forward<Pack1>(pack1),
+    test_product1);
+  hermes_shm::PassArgPack::Call(
+    std::forward<Pack2>(pack2),
+    test_product2);
+}
+
+template<typename T1, typename T2, typename T3>
+void verify_tuple3(hermes_shm::tuple<T1, T2, T3> &x) {
+  REQUIRE(x.Size() == 3);
+  REQUIRE(x.template Get<0>() == 0);
+  REQUIRE(x.template Get<1>() == 1);
+  REQUIRE(x.template Get<2>() == 0);
+#ifdef TEST_COMPILER_ERROR
+  std::cout << x.Get<3>() << std::endl;
+#endif
+}
+
+template<typename T1, typename T2, typename T3>
+void test_argpack3() {
+  // Pass an argpack to a function
+  {
+    hermes_shm::PassArgPack::Call(
+      hermes_shm::make_argpack(T1(0), T2(1), T3(0)),
+      test_argpack3_pass<T1, T2, T3>);
+  }
+
+  // Pass an argpack containing references to a function
+  {
+    T2 y = 1;
+    hermes_shm::PassArgPack::Call(
+      hermes_shm::make_argpack(0, y, 0),
+      test_argpack3_pass<T1, T2, T3>);
+  }
+
+  // Create a 3-tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> x(0, 1, 0);
+    verify_tuple3(x);
+  }
+
+  // Copy a tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> y(0, 1, 0);
+    hermes_shm::tuple<T1, T2, T3> x(y);
+    verify_tuple3(x);
+  }
+
+  // Copy assign tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> y(0, 1, 0);
+    hermes_shm::tuple<T1, T2, T3> x;
+    x = y;
+    verify_tuple3(x);
+  }
+
+  // Move tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> y(0, 1, 0);
+    hermes_shm::tuple<T1, T2, T3> x(std::move(y));
+    verify_tuple3(x);
+  }
+
+  // Move assign tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> y(0, 1, 0);
+    hermes_shm::tuple<T1, T2, T3> x;
+    x = std::move(y);
+    verify_tuple3(x);
+  }
+
+  // Iterate over a tuple
+  {
+    hermes_shm::tuple<T1, T2, T3> x(0, 1, 0);
+    hermes_shm::ForwardIterateTuple::Apply(
+      x,
+      [](auto i, auto &arg) constexpr {
+        std::cout << "lambda: " << i.Get() << std::endl;
+      });
+  }
+
+  // Merge two argpacks into a single pack
+  {
+   size_t y = hermes_shm::MergeArgPacks::Merge(
+     hermes_shm::make_argpack(T1(0)),
+     hermes_shm::make_argpack(T2(1), T2(0))).Size();
+   REQUIRE(y == 3);
+ }
+
+  // Pass a merged argpack to a function
+  {
+    hermes_shm::PassArgPack::Call(
+      hermes_shm::MergeArgPacks::Merge(
+        hermes_shm::make_argpack(0),
+        hermes_shm::make_argpack(1, 0)),
+      test_argpack3_pass<T1, T2, T3>);
+  }
+
+  // Construct tuple from argpack
+  {
+    hermes_shm::tuple<int, int, int> x(
+      hermes_shm::make_argpack(10, 11, 12));
+    REQUIRE(x.Get<0>() == 10);
+    REQUIRE(x.Get<1>() == 11);
+    REQUIRE(x.Get<2>() == 12);
+  }
+
+  // Product an argpack
+  {
+   auto&& pack = hermes_shm::ProductArgPacks::Product(
+     0,
+     hermes_shm::make_argpack(1, 2),
+     hermes_shm::make_argpack<double, double>(3, 4));
+   REQUIRE(pack.Size() == 4);
+ }
+
+  // Product an argpack
+  {
+    hermes_shm::PassArgPack::Call(
+      hermes_shm::ProductArgPacks::Product(
+        0,
+        hermes_shm::make_argpack(1, 2),
+        hermes_shm::make_argpack(3.0, 4.0)),
+      test_product<
+        hermes_shm::ArgPack<int&&, int&&>,
+        hermes_shm::ArgPack<double&&, double&&>>);
+  }
+}
+
+TEST_CASE("TestArgpack") {
+  test_argpack0();
+  test_argpack3<int, double, float>();
+}

--- a/hermes_shm/test/unit/types/test_init.cc
+++ b/hermes_shm/test/unit/types/test_init.cc
@@ -1,0 +1,17 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Hermes. The full Hermes copyright notice, including  *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory. If you do not  *
+ * have access to the file, you may request a copy from help@hdfgroup.org.   *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "basic_test.h"
+
+void MainPretest() {}
+
+void MainPosttest() {}

--- a/src/api/vbucket.h
+++ b/src/api/vbucket.h
@@ -163,9 +163,10 @@ class VBucket {
   size_t Get(const std::string &name, Bucket *bkt, void *user_blob,
              size_t blob_size, const Context &ctx);
 
-  /** retrieves the subset of blob links satisfying pred */
-  /** could return iterator */
+  /** retrieves all blob links */
   std::vector<std::string> GetLinks();
+
+  /** retrieves all blob links subject to a predicte in \a ctx */
   std::vector<std::string> GetLinks(Context &ctx);
 
   /** \brief Attach a Trait to this VBucket.


### PR DESCRIPTION
This commit contains the updated Hermes SHM data structures library, which is being used to reduce the static nature of the Hermes configuration file.