### PR TITLE
ci: update setup-python action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: Run cpplint
         run: pip install cpplint==1.5.4 && bash ci/lint.sh `pwd`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup python
         uses: actions/setup-python@v2
@@ -38,7 +38,7 @@ jobs:
         run: pip install cpplint==1.5.4 && bash ci/lint.sh `pwd`
 
       - name: Cache Spack packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: spack-cache
         with:
           path: ~/${{ env.LOCAL }}


### PR DESCRIPTION
This patch is for testing locally with `act`.
See https://github.com/actions/setup-python/issues/162 .