### PR TITLE
fix: gcc 12.1.0 compilation error (#497)

### DIFF
--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -416,7 +416,11 @@ std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
     LOG(FATAL) << "Big endian machines not supported yet." << std::endl;
   }
 
-  LOG(INFO) << "Initializing hermes config with " << config_file << std::endl;
+  if (config_file != NULL) {
+    LOG(INFO) << "Initializing hermes with " << config_file << std::endl;
+  } else {
+    LOG(INFO) << "Initializing hermes without conf file" << std::endl;
+  }
 
   hermes::Config config = {};
   hermes::InitConfig(&config, config_file);

--- a/src/api/hermes.cc
+++ b/src/api/hermes.cc
@@ -416,7 +416,7 @@ std::shared_ptr<Hermes> InitHermes(const char *config_file, bool is_daemon,
     LOG(FATAL) << "Big endian machines not supported yet." << std::endl;
   }
 
-  LOG(INFO) << "Initializing hermes config" << std::endl;
+  LOG(INFO) << "Initializing hermes config with " << config_file << std::endl;
 
   hermes::Config config = {};
   hermes::InitConfig(&config, config_file);

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -87,19 +87,25 @@ void PrintExpectedAndFail(const std::string &expected, u32 line_number = 0) {
   LOG(FATAL) << msg.str();
 }
 
-/** log an error message when the number of devices is 0 in \a config */
+/** log an error message when the number of devices is < 1 in \a config */
 void RequireNumDevices(Config *config) {
-  if (config->num_devices == 0) {
-    LOG(FATAL) << "The configuration variable 'num_devices' must be defined "
-               << "first" << std::endl;
+  if (config->num_devices < 1 || config->num_devices > kMaxDevices) {
+    LOG(FATAL) << "The configuration variable 'num_devices' is out of range: "
+               << config->num_devices << std::endl;
   }
 }
 
-/** log an error message when the number of slabs is 0 in \a config  */
+/** log an error message when the number of any slab is < 1 in \a config  */
 void RequireNumSlabs(Config *config) {
-  if (config->num_slabs == 0) {
-    LOG(FATAL) << "The configuration variable 'num_slabs' must be defined first"
-               << std::endl;
+  for (int device = 0; device < config->num_devices; ++device) {
+    if (config->num_slabs[device] < 1) {
+      LOG(FATAL)
+        << "The configuration variable 'num_slabs' for device "
+        << device
+        << " is invalid: "
+        << config->num_slabs[device]
+        << std::endl;
+    }
   }
 }
 


### PR DESCRIPTION
* Check valid inputs more carefully.
* Log what configuration file is being used.