### PR TITLE
ci: add missing dependency and fix path to build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build and Test
 #        if: steps.hermes-cache.outputs.cache-hit != 'true'
-        run: docker exec /hermes_deps_c bash hermes/ci/build_hermes.sh
+        run: docker exec /hermes_deps_c bash /hermes/ci/build_hermes.sh
 
 #      - name: Test
 #        run: bash ci/test_hermes.sh

--- a/docker/deps.Dockerfile
+++ b/docker/deps.Dockerfile
@@ -28,7 +28,7 @@ RUN apt install -y \
     build-essential ca-certificates \
     coreutils curl environment-modules \
     gfortran git gpg lsb-release \
-    unzip zip \
+    unzip zip libelf-dev \
     bash jq gdbserver gdb
 
 # Setup basic environment


### PR DESCRIPTION
This PR fixes the CI build error:

```
-- Checking for module 'libelf'
CMake Error at /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:603 (message):
--   No package 'libelf' found
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:825 (_pkg_check_modules_internal)
  /root/spack/opt/spack/linux-ubuntu22.04-zen2/gcc-11.4.0/hermes_shm-master-zg6jrwsu4v3wjksngaatxaeu6e7xuzgb/cmake/HermesShmConfig.cmake:73 (pkg_check_modules)
  CMakeLists.txt:108 (find_package)
```