### PR TITLE
ci: update docker hub pull location

### DIFF
--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 # Pull the Hermes dependencies image
-docker pull lukemartinlogan/hermes_deps:latest
+docker pull hdfgroup/hermes-deps:latest
 docker run -d \
 --mount src=${PWD},target=/hermes,type=bind \
 --name hermes_deps_c \
@@ -14,5 +14,5 @@ docker run -d \
 --shm-size=8G \
 -p 4000:4000 \
 -p 4001:4001 \
-lukemartinlogan/hermes_deps \
+hdfgroup/hermes-deps \
 tail -f /dev/null


### PR DESCRIPTION
GH secrets for DockerHub are working again.
