### PR TITLE
test: remove size

### DIFF
--- a/test/unit/pipelines/mpiio/test_hermes_mpiio_basic_async.yaml
+++ b/test/unit/pipelines/mpiio/test_hermes_mpiio_basic_async.yaml
@@ -8,4 +8,4 @@ pkgs:
     pkg_name: hermes_mpiio_tests
     test_file: mpiio_basic
     hermes: true
-    size: large
+


### PR DESCRIPTION
This PR fixes Jarvis error: `In the menu , size is not a valid key-word argument`

fix #693 